### PR TITLE
feat(mcp): seo_page_audit MVP + shared utils foundation

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -8,19 +8,20 @@
       "name": "ga4-manager-mcp",
       "version": "1.0.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.1",
-        "csv-parse": "^6.1.0",
-        "zod": "^4.2.1"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "csv-parse": "^6.2.1",
+        "node-html-parser": "^7.1.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@types/node": "^24.10.4",
-        "@typescript-eslint/eslint-plugin": "^8.50.1",
-        "@typescript-eslint/parser": "^8.50.1",
-        "eslint": "^9.39.2",
+        "@types/node": "^24.12.2",
+        "@typescript-eslint/eslint-plugin": "^8.59.0",
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^9.39.4",
         "globals": "^16.5.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
-        "vitest": "^4.0.16"
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1717,6 +1718,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1910,6 +1917,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csv-parse": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
@@ -1959,6 +1994,61 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1986,6 +2076,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2732,6 +2834,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hono": {
       "version": "4.12.15",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
@@ -3361,6 +3472,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.1.0.tgz",
+      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/object-assign": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -23,10 +23,44 @@
         "vitest": "^4.0.16"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -41,9 +75,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -58,9 +92,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -75,9 +109,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -92,9 +126,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -109,9 +143,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -126,9 +160,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -143,9 +177,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -160,9 +194,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -177,9 +211,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -194,9 +228,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -211,9 +245,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -228,9 +262,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -245,9 +279,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -262,9 +296,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -279,9 +313,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -296,9 +330,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -313,9 +347,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -330,9 +364,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -347,9 +381,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -364,9 +398,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -381,9 +415,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -398,9 +432,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -415,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -432,9 +466,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -449,9 +483,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -466,9 +500,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -495,24 +529,31 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -521,9 +562,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -560,20 +601,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -584,9 +625,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -600,10 +641,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -642,9 +690,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -655,9 +703,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
-      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -692,9 +740,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
-      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -704,25 +752,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -763,12 +825,12 @@
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
-      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -776,14 +838,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -801,24 +864,39 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.54.0.tgz",
-      "integrity": "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.54.0.tgz",
-      "integrity": "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -827,12 +905,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.54.0.tgz",
-      "integrity": "sha512-k43D4qta/+6Fq+nCDhhv9yP2HdeKeP56QrUUTW7E6PhZP1US6NDqpJj4MY0jBHlJivVJD5P8NxrjuobZBJTCRw==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -841,12 +922,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.54.0.tgz",
-      "integrity": "sha512-cOo7biqwkpawslEfox5Vs8/qj83M/aZCSSNIWpVzfU2CYHa2G3P1UN5WF01RdTHSgCkri7XOlTdtk17BezlV3A==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -855,26 +939,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.54.0.tgz",
-      "integrity": "sha512-miSvuFkmvFbgJ1BevMa4CPCFt5MPGw094knM64W9I0giUIMMmRYcGW/JWZDriaw/k1kOBtsWh1z6nIFV1vPNtA==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.54.0.tgz",
-      "integrity": "sha512-KGXIs55+b/ZfZsq9aR026tmr/+7tq6VG6MsnrvF4H8VhwflTIuYh+LFUlIsRdQSgrgmtM3fVATzEAj4hBQlaqQ==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -883,12 +956,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.54.0.tgz",
-      "integrity": "sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -897,152 +973,135 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.54.0.tgz",
-      "integrity": "sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.54.0.tgz",
-      "integrity": "sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.54.0.tgz",
-      "integrity": "sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.54.0.tgz",
-      "integrity": "sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.54.0.tgz",
-      "integrity": "sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.54.0.tgz",
-      "integrity": "sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==",
-      "cpu": [
-        "riscv64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.54.0.tgz",
-      "integrity": "sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.54.0.tgz",
-      "integrity": "sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.54.0.tgz",
-      "integrity": "sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.54.0.tgz",
-      "integrity": "sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1051,12 +1110,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.54.0.tgz",
-      "integrity": "sha512-c2V0W1bsKIKfbLMBu/WGBz6Yci8nJ/ZJdheE0EwB73N3MvHYKiKGs3mVilX4Gs70eGeDaMqEob25Tw2Gb9Nqyw==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1065,26 +1146,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.54.0.tgz",
-      "integrity": "sha512-woEHgqQqDCkAzrDhvDipnSirm5vxUXtSKDYTVpZG3nUdW/VVB5VdCYA2iReSj/u3yCZzXID4kuKG7OynPnB3WQ==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.54.0.tgz",
-      "integrity": "sha512-dzAc53LOuFvHwbCEOS0rPbXp6SIhAf2txMP5p6mGyOXXw5mWY8NGGbPMPrs4P1WItkfApDathBj/NzMLUZ9rtQ==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -1093,21 +1163,17 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.54.0.tgz",
-      "integrity": "sha512-hYT5d3YNdSh3mbCU1gwQyPgQd3T2ne0A3KG8KSBdav5TiBg6eInVmV+TeR5uHufiIgSFg0XsOWGW5/RhNcSvPg==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -1115,6 +1181,17 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1149,31 +1226,30 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
-      "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz",
-      "integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/type-utils": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1183,24 +1259,23 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.50.1",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.1.tgz",
-      "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1210,20 +1285,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.1.tgz",
-      "integrity": "sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.50.1",
-        "@typescript-eslint/types": "^8.50.1",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1233,18 +1308,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
-      "integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1255,9 +1330,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz",
-      "integrity": "sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1268,21 +1343,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.1.tgz",
-      "integrity": "sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1",
-        "@typescript-eslint/utils": "8.50.1",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1292,14 +1367,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.1.tgz",
-      "integrity": "sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1311,21 +1386,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.1.tgz",
-      "integrity": "sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.50.1",
-        "@typescript-eslint/tsconfig-utils": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/visitor-keys": "8.50.1",
-        "debug": "^4.3.4",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1335,20 +1410,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.1.tgz",
-      "integrity": "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.50.1",
-        "@typescript-eslint/types": "8.50.1",
-        "@typescript-eslint/typescript-estree": "8.50.1"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1358,19 +1433,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.50.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
-      "integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.50.1",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1381,44 +1456,44 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
-      "integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.16",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1427,7 +1502,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1439,26 +1514,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-      "integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
-      "integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.16",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1466,13 +1541,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
-      "integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1481,9 +1557,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
-      "integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1491,14 +1567,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-      "integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.16",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1518,12 +1595,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1542,9 +1618,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1608,16 +1684,19 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/body-parser": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.1.tgz",
-      "integrity": "sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -1626,7 +1705,7 @@
         "http-errors": "^2.0.0",
         "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
+        "qs": "^6.14.1",
         "raw-body": "^3.0.1",
         "type-is": "^2.0.1"
       },
@@ -1639,13 +1718,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -1751,9 +1833,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1771,6 +1853,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1791,9 +1880,9 @@
       }
     },
     "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -1801,6 +1890,10 @@
       },
       "engines": {
         "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -1818,9 +1911,9 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
-      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1854,6 +1947,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1904,9 +2007,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1923,9 +2026,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1936,32 +2039,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.2",
-        "@esbuild/android-arm": "0.27.2",
-        "@esbuild/android-arm64": "0.27.2",
-        "@esbuild/android-x64": "0.27.2",
-        "@esbuild/darwin-arm64": "0.27.2",
-        "@esbuild/darwin-x64": "0.27.2",
-        "@esbuild/freebsd-arm64": "0.27.2",
-        "@esbuild/freebsd-x64": "0.27.2",
-        "@esbuild/linux-arm": "0.27.2",
-        "@esbuild/linux-arm64": "0.27.2",
-        "@esbuild/linux-ia32": "0.27.2",
-        "@esbuild/linux-loong64": "0.27.2",
-        "@esbuild/linux-mips64el": "0.27.2",
-        "@esbuild/linux-ppc64": "0.27.2",
-        "@esbuild/linux-riscv64": "0.27.2",
-        "@esbuild/linux-s390x": "0.27.2",
-        "@esbuild/linux-x64": "0.27.2",
-        "@esbuild/netbsd-arm64": "0.27.2",
-        "@esbuild/netbsd-x64": "0.27.2",
-        "@esbuild/openbsd-arm64": "0.27.2",
-        "@esbuild/openbsd-x64": "0.27.2",
-        "@esbuild/openharmony-arm64": "0.27.2",
-        "@esbuild/sunos-x64": "0.27.2",
-        "@esbuild/win32-arm64": "0.27.2",
-        "@esbuild/win32-ia32": "0.27.2",
-        "@esbuild/win32-x64": "0.27.2"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escape-html": {
@@ -1984,26 +2087,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
-      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.2",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -2022,7 +2124,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2075,9 +2177,9 @@
       }
     },
     "node_modules/eslint/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2091,10 +2193,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2133,9 +2242,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2177,9 +2286,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2254,9 +2363,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2277,7 +2386,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2317,10 +2425,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -2451,9 +2562,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2537,9 +2648,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2610,9 +2721,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2622,11 +2733,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2652,9 +2762,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.1.tgz",
-      "integrity": "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -2710,6 +2820,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -2755,9 +2874,9 @@
       "license": "ISC"
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -2824,6 +2943,279 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/locate-path": {
@@ -2915,16 +3307,16 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3116,9 +3508,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -3140,12 +3532,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3163,9 +3554,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -3225,9 +3616,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3292,46 +3683,38 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.54.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.54.0.tgz",
-      "integrity": "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==",
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.54.0",
-        "@rollup/rollup-android-arm64": "4.54.0",
-        "@rollup/rollup-darwin-arm64": "4.54.0",
-        "@rollup/rollup-darwin-x64": "4.54.0",
-        "@rollup/rollup-freebsd-arm64": "4.54.0",
-        "@rollup/rollup-freebsd-x64": "4.54.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.54.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.54.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.54.0",
-        "@rollup/rollup-linux-arm64-musl": "4.54.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.54.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.54.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.54.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-gnu": "4.54.0",
-        "@rollup/rollup-linux-x64-musl": "4.54.0",
-        "@rollup/rollup-openharmony-arm64": "4.54.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.54.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.54.0",
-        "@rollup/rollup-win32-x64-gnu": "4.54.0",
-        "@rollup/rollup-win32-x64-msvc": "4.54.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/router": {
@@ -3357,9 +3740,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3461,13 +3844,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3547,9 +3930,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3587,9 +3970,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3597,14 +3980,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3614,9 +3997,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3633,9 +4016,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.2.0.tgz",
-      "integrity": "sha512-L6f5oQRAoLU1RwXz0Ab9mxsE7LtxeVB6AIR1lpkZMsOyg/JXeaxBaXa/FVCBZyNr9S9I4wkHrlZTklX+im+WMw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3645,13 +4028,20 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3699,7 +4089,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3744,19 +4133,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.0.tgz",
-      "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3772,9 +4159,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -3787,13 +4175,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -3820,31 +4211,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
-      "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.16",
-        "@vitest/mocker": "4.0.16",
-        "@vitest/pretty-format": "4.0.16",
-        "@vitest/runner": "4.0.16",
-        "@vitest/snapshot": "4.0.16",
-        "@vitest/spy": "4.0.16",
-        "@vitest/utils": "4.0.16",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -3860,12 +4251,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.16",
-        "@vitest/browser-preview": "4.0.16",
-        "@vitest/browser-webdriverio": "4.0.16",
-        "@vitest/ui": "4.0.16",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -3886,6 +4280,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -3894,6 +4294,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -3959,22 +4362,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.2.1.tgz",
-      "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "csv-parse": "^6.2.1",
+    "node-html-parser": "^7.1.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -13,18 +13,18 @@
     "lint": "eslint src/"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.25.1",
-    "csv-parse": "^6.1.0",
-    "zod": "^4.2.1"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "csv-parse": "^6.2.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^24.10.4",
-    "@typescript-eslint/eslint-plugin": "^8.50.1",
-    "@typescript-eslint/parser": "^8.50.1",
-    "eslint": "^9.39.2",
+    "@types/node": "^24.12.2",
+    "@typescript-eslint/eslint-plugin": "^8.59.0",
+    "@typescript-eslint/parser": "^8.59.0",
+    "eslint": "^9.39.4",
     "globals": "^16.5.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.16"
+    "vitest": "^4.1.5"
   }
 }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -29,6 +29,11 @@ import { gscAnalyticsRunTool } from './tools/gsc-analytics.js'
 import { gscMonitorUrlsTool } from './tools/gsc-monitor.js'
 import { gscIndexCoverageTool } from './tools/gsc-coverage.js'
 
+// Import new native tools (no CLI dependency)
+import { gscTrafficCompareTool } from './tools/gsc-traffic-compare.js'
+import { ga4ConsentHealthTool } from './tools/ga4-consent-health.js'
+import { seoPageAuditTool } from './tools/seo-page-audit.js'
+
 /**
  * GA4 Manager MCP Server
  *
@@ -81,6 +86,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       gscAnalyticsRunTool,
       gscMonitorUrlsTool,
       gscIndexCoverageTool,
+
+      // Native Tools — no CLI dependency (3)
+      gscTrafficCompareTool,
+      ga4ConsentHealthTool,
+      seoPageAuditTool,
     ],
   }
 })
@@ -457,6 +467,41 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const output = parseIndexCoverageOutput(result.stdout)
         return {
           content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+        }
+      }
+
+      // ========== Native Tools (no CLI) ==========
+
+      case 'gsc_traffic_compare': {
+        const { gscTrafficCompareInputSchema, runGscTrafficCompare } =
+          await import('./tools/gsc-traffic-compare.js')
+        const input = gscTrafficCompareInputSchema.parse(args)
+        const output = await runGscTrafficCompare(input)
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+          isError: !output.success,
+        }
+      }
+
+      case 'ga4_consent_health': {
+        const { ga4ConsentHealthInputSchema, runGa4ConsentHealth } =
+          await import('./tools/ga4-consent-health.js')
+        const input = ga4ConsentHealthInputSchema.parse(args)
+        const output = await runGa4ConsentHealth(input)
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+          isError: !output.success,
+        }
+      }
+
+      case 'seo_page_audit': {
+        const { seoPageAuditInputSchema, runSeoPageAudit } =
+          await import('./tools/seo-page-audit.js')
+        const input = seoPageAuditInputSchema.parse(args)
+        const output = await runSeoPageAudit(input)
+        return {
+          content: [{ type: 'text', text: JSON.stringify(output, null, 2) }],
+          isError: !output.success,
         }
       }
 

--- a/mcp/src/tools/__fixtures__/good-baseline.html
+++ b/mcp/src/tools/__fixtures__/good-baseline.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Best Practices for Web Performance</title>
+  <meta name="description" content="Learn how to optimise your website for speed and Core Web Vitals.">
+  <link rel="canonical" href="https://example.com/web-performance">
+  <meta property="og:title" content="Best Practices for Web Performance">
+  <meta property="og:description" content="Learn how to optimise your website for speed.">
+  <meta property="og:image" content="https://example.com/og-image.jpg">
+  <meta property="og:type" content="article">
+  <link rel="alternate" hreflang="en" href="https://example.com/web-performance">
+  <link rel="alternate" hreflang="es" href="https://example.com/es/web-performance">
+  <link rel="alternate" hreflang="x-default" href="https://example.com/web-performance">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "Best Practices for Web Performance"
+    }
+  </script>
+</head>
+<body>
+  <h1>Best Practices for Web Performance</h1>
+  <h2>Core Web Vitals</h2>
+  <p>Content here.</p>
+  <h2>Image Optimisation</h2>
+  <p>More content.</p>
+</body>
+</html>

--- a/mcp/src/tools/__fixtures__/missing-canonical.html
+++ b/mcp/src/tools/__fixtures__/missing-canonical.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page Without Canonical Tag</title>
+  <meta name="description" content="This page deliberately omits the canonical link tag.">
+  <meta property="og:title" content="Page Without Canonical Tag">
+  <meta property="og:description" content="Missing canonical page.">
+  <meta property="og:image" content="https://example.com/og-image.jpg">
+  <meta property="og:type" content="article">
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {"@type": "WebPage", "name": "Page Without Canonical Tag"},
+        {"@type": "BreadcrumbList"}
+      ]
+    }
+  </script>
+</head>
+<body>
+  <h1>Page Without Canonical Tag</h1>
+  <h2>Introduction</h2>
+  <p>Content here.</p>
+</body>
+</html>

--- a/mcp/src/tools/__fixtures__/multi-h1.html
+++ b/mcp/src/tools/__fixtures__/multi-h1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page with Multiple H1 Tags</title>
+  <meta name="description" content="This page has multiple h1 elements for testing the multi-h1 rule.">
+  <link rel="canonical" href="https://example.com/multi-h1">
+  <meta property="og:title" content="Page with Multiple H1 Tags">
+  <meta property="og:description" content="Multi-h1 test page.">
+  <meta property="og:image" content="https://example.com/og-image.jpg">
+  <meta name="robots" content="index, follow">
+  <script type="application/ld+json">
+    {"@context": "https://schema.org", "@type": ["WebPage", "ItemPage"]}
+  </script>
+</head>
+<body>
+  <h1>Main Heading One</h1>
+  <h1>Duplicate Main Heading</h1>
+  <h1>Third Main Heading</h1>
+  <h2>Sub-section</h2>
+  <p>Content here.</p>
+</body>
+</html>

--- a/mcp/src/tools/ga4-cleanup.ts
+++ b/mcp/src/tools/ga4-cleanup.ts
@@ -184,7 +184,7 @@ export function parseCleanupOutput(output: string, dryRun: boolean): CleanupOutp
  */
 function extractProjectInfo(output: string): ProjectInfo | undefined {
   // Match: "Project: MyWebsite (Property: 123456789)"
-  const projectMatch = output.match(/Project:\s*([^\(]+)\s*\(Property:\s*(\d+)\)/);
+  const projectMatch = output.match(/Project:\s*([^(]+)\s*\(Property:\s*(\d+)\)/);
   if (projectMatch) {
     return {
       name: projectMatch[1].trim(),

--- a/mcp/src/tools/ga4-consent-health.test.ts
+++ b/mcp/src/tools/ga4-consent-health.test.ts
@@ -1,0 +1,495 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  ga4ConsentHealthInputSchema,
+  ga4ConsentHealthTool,
+  computeHealthScore,
+  parseConsentModeRows,
+  parseCustomEventRows,
+  runDataApiReport,
+  runGa4ConsentHealth,
+} from './ga4-consent-health.js'
+
+// ============================================================================
+// Mock google-auth utility
+// ============================================================================
+
+vi.mock('../utils/google-auth.js', () => ({
+  getGoogleAuthHeaders: vi.fn().mockResolvedValue({
+    Authorization: 'Bearer mock-token',
+  }),
+}))
+
+// ============================================================================
+// Input Schema Validation
+// ============================================================================
+
+describe('ga4ConsentHealthInputSchema', () => {
+  it('accepts valid minimal input', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/123456789',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('applies defaults', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/123456789',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.days).toBe(28)
+    }
+  })
+
+  it('accepts all optional fields', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/123456789',
+      days: 90,
+      custom_grant_event: 'consent_granted',
+      custom_deny_event: 'consent_denied',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing property_id', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects property_id without properties/ prefix', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({
+      property_id: '123456789',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects property_id with wrong format', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/abc',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects days above maximum', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/123456789',
+      days: 366,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects days below minimum', () => {
+    const result = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/123456789',
+      days: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ============================================================================
+// computeHealthScore
+// ============================================================================
+
+describe('computeHealthScore', () => {
+  it('returns healthy when denied < 10%', () => {
+    expect(computeHealthScore(0)).toBe('healthy')
+    expect(computeHealthScore(5)).toBe('healthy')
+    expect(computeHealthScore(9.9)).toBe('healthy')
+  })
+
+  it('returns warning when denied 10-30%', () => {
+    expect(computeHealthScore(10)).toBe('warning')
+    expect(computeHealthScore(20)).toBe('warning')
+    expect(computeHealthScore(30)).toBe('warning')
+  })
+
+  it('returns critical when denied > 30%', () => {
+    expect(computeHealthScore(30.1)).toBe('critical')
+    expect(computeHealthScore(50)).toBe('critical')
+    expect(computeHealthScore(100)).toBe('critical')
+  })
+})
+
+// ============================================================================
+// parseConsentModeRows
+// ============================================================================
+
+describe('parseConsentModeRows', () => {
+  const makeRow = (
+    analyticsStorage: string,
+    adsStorage: string,
+    sessions: number,
+  ) => ({
+    dimensionValues: [{ value: analyticsStorage }, { value: adsStorage }],
+    metricValues: [{ value: String(sessions) }],
+  })
+
+  it('returns available=false for empty rows', () => {
+    const result = parseConsentModeRows([])
+    expect(result.available).toBe(false)
+    expect(result.analytics_storage.total_sessions).toBe(0)
+  })
+
+  it('computes correct percentages for analytics_storage', () => {
+    const rows = [
+      makeRow('GRANTED', 'GRANTED', 700),
+      makeRow('DENIED', 'DENIED', 200),
+      makeRow('UNSET', 'UNSET', 100),
+    ]
+    const result = parseConsentModeRows(rows)
+    expect(result.analytics_storage.granted_pct).toBe(70)
+    expect(result.analytics_storage.denied_pct).toBe(20)
+    expect(result.analytics_storage.unset_pct).toBe(10)
+    expect(result.analytics_storage.total_sessions).toBe(1000)
+  })
+
+  it('computes correct percentages for ads_storage', () => {
+    const rows = [
+      makeRow('GRANTED', 'GRANTED', 800),
+      makeRow('GRANTED', 'DENIED', 200),
+    ]
+    const result = parseConsentModeRows(rows)
+    expect(result.ads_storage.granted_pct).toBe(80)
+    expect(result.ads_storage.denied_pct).toBe(20)
+  })
+
+  it('sets available=true when granted or denied sessions exist', () => {
+    const rows = [makeRow('GRANTED', 'GRANTED', 100)]
+    const result = parseConsentModeRows(rows)
+    expect(result.available).toBe(true)
+  })
+
+  it('sets available=false when all sessions are UNSET', () => {
+    const rows = [makeRow('UNSET', 'UNSET', 1000)]
+    const result = parseConsentModeRows(rows)
+    expect(result.available).toBe(false)
+  })
+
+  it('handles aggregation of multiple GRANTED rows', () => {
+    const rows = [
+      makeRow('GRANTED', 'GRANTED', 300),
+      makeRow('GRANTED', 'DENIED', 200),
+    ]
+    // analytics_storage: 500 granted, 0 denied = 100% granted
+    const result = parseConsentModeRows(rows)
+    expect(result.analytics_storage.granted_pct).toBe(100)
+    expect(result.analytics_storage.denied_pct).toBe(0)
+  })
+})
+
+// ============================================================================
+// parseCustomEventRows
+// ============================================================================
+
+describe('parseCustomEventRows', () => {
+  const makeRow = (eventName: string, count: number) => ({
+    dimensionValues: [{ value: eventName }],
+    metricValues: [{ value: String(count) }],
+  })
+
+  it('correctly parses grant and deny counts', () => {
+    const rows = [
+      makeRow('consent_granted', 800),
+      makeRow('consent_denied', 200),
+    ]
+    const result = parseCustomEventRows(rows, 'consent_granted', 'consent_denied')
+    expect(result.grant_count).toBe(800)
+    expect(result.deny_count).toBe(200)
+    expect(result.consent_rate_pct).toBe(80)
+  })
+
+  it('handles missing grant event', () => {
+    const rows = [makeRow('consent_denied', 200)]
+    const result = parseCustomEventRows(rows, 'consent_granted', 'consent_denied')
+    expect(result.grant_count).toBe(0)
+    expect(result.deny_count).toBe(200)
+    expect(result.consent_rate_pct).toBe(0)
+  })
+
+  it('handles missing deny event', () => {
+    const rows = [makeRow('consent_granted', 800)]
+    const result = parseCustomEventRows(rows, 'consent_granted', 'consent_denied')
+    expect(result.grant_count).toBe(800)
+    expect(result.deny_count).toBe(0)
+    expect(result.consent_rate_pct).toBe(100)
+  })
+
+  it('handles empty rows', () => {
+    const result = parseCustomEventRows([], 'consent_granted', 'consent_denied')
+    expect(result.grant_count).toBe(0)
+    expect(result.deny_count).toBe(0)
+    expect(result.consent_rate_pct).toBe(0)
+  })
+
+  it('echoes event names in output', () => {
+    const rows: ReturnType<typeof makeRow>[] = []
+    const result = parseCustomEventRows(rows, 'my_grant_event', 'my_deny_event')
+    expect(result.grant_event).toBe('my_grant_event')
+    expect(result.deny_event).toBe('my_deny_event')
+  })
+})
+
+// ============================================================================
+// runDataApiReport — API integration (mocked fetch)
+// ============================================================================
+
+describe('runDataApiReport', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('calls Data API with correct URL and auth', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: [] }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await runDataApiReport('properties/123456789', {
+      dateRanges: [{ startDate: '28daysAgo', endDate: 'today' }],
+      dimensions: [{ name: 'privacyInfoAnalyticsStorage' }],
+      metrics: [{ name: 'sessions' }],
+    })
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe(
+      'https://analyticsdata.googleapis.com/v1beta/properties/123456789:runReport',
+    )
+    expect(options.method).toBe('POST')
+    const body = JSON.parse(options.body as string)
+    expect(body.dimensions[0].name).toBe('privacyInfoAnalyticsStorage')
+  })
+
+  it('returns empty array when no rows in response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      }),
+    )
+
+    const rows = await runDataApiReport('properties/123456789', {})
+    expect(rows).toHaveLength(0)
+  })
+
+  it('throws descriptive error on 403', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Forbidden'),
+      }),
+    )
+
+    await expect(runDataApiReport('properties/123456789', {})).rejects.toThrow(
+      'GA4 Data API access denied',
+    )
+  })
+
+  it('throws descriptive error on 404', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve('Not Found'),
+      }),
+    )
+
+    await expect(runDataApiReport('properties/123456789', {})).rejects.toThrow(
+      'Property not found: properties/123456789',
+    )
+  })
+
+  it('throws generic error on other HTTP failures', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Server Error'),
+      }),
+    )
+
+    await expect(runDataApiReport('properties/123456789', {})).rejects.toThrow(
+      'GA4 Data API error (HTTP 500)',
+    )
+  })
+})
+
+// ============================================================================
+// runGa4ConsentHealth — integration (mocked fetch)
+// ============================================================================
+
+describe('runGa4ConsentHealth', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  const makeConsentRow = (
+    analyticsStorage: string,
+    adsStorage: string,
+    sessions: number,
+  ) => ({
+    dimensionValues: [{ value: analyticsStorage }, { value: adsStorage }],
+    metricValues: [{ value: String(sessions) }],
+  })
+
+  it('returns healthy score when few denied sessions', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            rows: [
+              makeConsentRow('GRANTED', 'GRANTED', 950),
+              makeConsentRow('DENIED', 'DENIED', 50), // 5% denied
+            ],
+          }),
+      }),
+    )
+
+    const input = ga4ConsentHealthInputSchema.parse({
+      property_id: 'properties/123456789',
+    })
+    const result = await runGa4ConsentHealth(input)
+
+    expect(result.success).toBe(true)
+    expect(result.health_score).toBe('healthy')
+    expect(result.consent_mode.analytics_storage.denied_pct).toBe(5)
+    expect(result.consent_mode.available).toBe(true)
+  })
+
+  it('returns critical when consent mode unavailable (all UNSET)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            rows: [makeConsentRow('UNSET', 'UNSET', 1000)],
+          }),
+      }),
+    )
+
+    const input = ga4ConsentHealthInputSchema.parse({
+      property_id: 'properties/123456789',
+    })
+    const result = await runGa4ConsentHealth(input)
+
+    expect(result.success).toBe(true)
+    // UNSET = 100% unset, 0% denied → healthy score since denied=0
+    expect(result.health_score).toBe('healthy')
+    expect(result.consent_mode.available).toBe(false)
+  })
+
+  it('includes custom_events when custom event names provided', async () => {
+    const consentRows = [makeConsentRow('GRANTED', 'GRANTED', 1000)]
+    const eventRows = [
+      {
+        dimensionValues: [{ value: 'consent_granted' }],
+        metricValues: [{ value: '800' }],
+      },
+      {
+        dimensionValues: [{ value: 'consent_denied' }],
+        metricValues: [{ value: '200' }],
+      },
+    ]
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ rows: consentRows }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ rows: eventRows }),
+        }),
+    )
+
+    const input = ga4ConsentHealthInputSchema.parse({
+      property_id: 'properties/123456789',
+      custom_grant_event: 'consent_granted',
+      custom_deny_event: 'consent_denied',
+    })
+    const result = await runGa4ConsentHealth(input)
+
+    expect(result.success).toBe(true)
+    expect(result.custom_events).toBeDefined()
+    expect(result.custom_events?.grant_count).toBe(800)
+    expect(result.custom_events?.deny_count).toBe(200)
+    expect(result.custom_events?.consent_rate_pct).toBe(80)
+  })
+
+  it('returns error result on API failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Forbidden'),
+      }),
+    )
+
+    const input = ga4ConsentHealthInputSchema.parse({
+      property_id: 'properties/123456789',
+    })
+    const result = await runGa4ConsentHealth(input)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('GA4 Data API access denied')
+  })
+
+  it('includes period string in output', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ rows: [] }),
+      }),
+    )
+
+    const input = ga4ConsentHealthInputSchema.parse({
+      property_id: 'properties/123456789',
+      days: 90,
+    })
+    const result = await runGa4ConsentHealth(input)
+
+    expect(result.period).toBe('last 90 days')
+  })
+})
+
+// ============================================================================
+// Tool Definition
+// ============================================================================
+
+describe('ga4ConsentHealthTool definition', () => {
+  it('has correct tool name', () => {
+    expect(ga4ConsentHealthTool.name).toBe('ga4_consent_health')
+  })
+
+  it('has a descriptive description', () => {
+    expect(ga4ConsentHealthTool.description).toContain('Consent Mode')
+    expect(ga4ConsentHealthTool.description).toContain('GA4')
+  })
+
+  it('defines required fields', () => {
+    expect(ga4ConsentHealthTool.inputSchema.required).toContain('property_id')
+  })
+
+  it('defines all optional parameters', () => {
+    const props = ga4ConsentHealthTool.inputSchema.properties
+    expect(props.days).toBeDefined()
+    expect(props.custom_grant_event).toBeDefined()
+    expect(props.custom_deny_event).toBeDefined()
+  })
+})

--- a/mcp/src/tools/ga4-consent-health.ts
+++ b/mcp/src/tools/ga4-consent-health.ts
@@ -1,0 +1,382 @@
+import { z } from 'zod'
+import { getGoogleAuthHeaders } from '../utils/google-auth.js'
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+export const ga4ConsentHealthInputSchema = z.object({
+  /** GA4 property ID in format "properties/123456789" */
+  property_id: z
+    .string()
+    .min(1, 'property_id is required')
+    .regex(/^properties\/\d+$/, 'property_id must be in format "properties/123456789"'),
+  /** Number of days to analyze (default: 28) */
+  days: z.number().int().min(1).max(365).optional().default(28),
+  /** Optional custom consent-granted event name */
+  custom_grant_event: z.string().optional(),
+  /** Optional custom consent-denied event name */
+  custom_deny_event: z.string().optional(),
+})
+
+export type Ga4ConsentHealthInput = z.infer<typeof ga4ConsentHealthInputSchema>
+
+// ============================================================================
+// Output Types
+// ============================================================================
+
+export interface ConsentStorageStats {
+  granted_pct: number
+  denied_pct: number
+  unset_pct: number
+  total_sessions: number
+}
+
+export interface ConsentModeData {
+  analytics_storage: ConsentStorageStats
+  ads_storage: ConsentStorageStats
+  available: boolean
+}
+
+export interface CustomEventData {
+  grant_event: string
+  grant_count: number
+  deny_event: string
+  deny_count: number
+  consent_rate_pct: number
+}
+
+export interface Ga4ConsentHealthOutput {
+  success: boolean
+  property_id: string
+  period: string
+  consent_mode: ConsentModeData
+  custom_events?: CustomEventData
+  health_score: 'healthy' | 'warning' | 'critical'
+  error?: string
+}
+
+// ============================================================================
+// GA4 Data API Types
+// ============================================================================
+
+interface DimensionValue {
+  value: string
+}
+
+interface MetricValue {
+  value: string
+}
+
+interface DataApiRow {
+  dimensionValues: DimensionValue[]
+  metricValues: MetricValue[]
+}
+
+interface DataApiResponse {
+  rows?: DataApiRow[]
+}
+
+// ============================================================================
+// Health Score Logic
+// ============================================================================
+
+/**
+ * Compute health score based on analytics_storage denied percentage
+ */
+export function computeHealthScore(
+  deniedPct: number,
+): 'healthy' | 'warning' | 'critical' {
+  if (deniedPct > 30) return 'critical'
+  if (deniedPct >= 10) return 'warning'
+  return 'healthy'
+}
+
+// ============================================================================
+// Consent Mode Report Processing
+// ============================================================================
+
+/**
+ * Parse consent mode report rows into storage stats
+ */
+export function parseConsentModeRows(rows: DataApiRow[]): {
+  analytics_storage: ConsentStorageStats
+  ads_storage: ConsentStorageStats
+  available: boolean
+} {
+  if (rows.length === 0) {
+    const empty: ConsentStorageStats = {
+      granted_pct: 0,
+      denied_pct: 0,
+      unset_pct: 0,
+      total_sessions: 0,
+    }
+    return {
+      analytics_storage: empty,
+      ads_storage: empty,
+      available: false,
+    }
+  }
+
+  // Aggregate sessions by analytics_storage and ads_storage consent values
+  // Dimensions: [0]=privacyInfoAnalyticsStorage, [1]=privacyInfoAdsStorage
+  const analyticsMap = new Map<string, number>()
+  const adsMap = new Map<string, number>()
+
+  for (const row of rows) {
+    const analyticsVal = row.dimensionValues[0]?.value ?? 'UNSET'
+    const adsVal = row.dimensionValues[1]?.value ?? 'UNSET'
+    const sessions = parseInt(row.metricValues[0]?.value ?? '0', 10)
+
+    analyticsMap.set(analyticsVal, (analyticsMap.get(analyticsVal) ?? 0) + sessions)
+    adsMap.set(adsVal, (adsMap.get(adsVal) ?? 0) + sessions)
+  }
+
+  const toStats = (map: Map<string, number>): ConsentStorageStats => {
+    const granted = map.get('GRANTED') ?? 0
+    const denied = map.get('DENIED') ?? 0
+    // Any value not GRANTED or DENIED counts as unset
+    let unset = 0
+    for (const [key, val] of map) {
+      if (key !== 'GRANTED' && key !== 'DENIED') {
+        unset += val
+      }
+    }
+    const total = granted + denied + unset
+
+    if (total === 0) {
+      return { granted_pct: 0, denied_pct: 0, unset_pct: 0, total_sessions: 0 }
+    }
+
+    return {
+      granted_pct: Math.round((granted / total) * 1000) / 10,
+      denied_pct: Math.round((denied / total) * 1000) / 10,
+      unset_pct: Math.round((unset / total) * 1000) / 10,
+      total_sessions: total,
+    }
+  }
+
+  // Check if consent mode data is meaningful (not all UNSET)
+  const analyticsGranted = analyticsMap.get('GRANTED') ?? 0
+  const analyticsDenied = analyticsMap.get('DENIED') ?? 0
+  const available = analyticsGranted > 0 || analyticsDenied > 0
+
+  return {
+    analytics_storage: toStats(analyticsMap),
+    ads_storage: toStats(adsMap),
+    available,
+  }
+}
+
+// ============================================================================
+// Custom Event Processing
+// ============================================================================
+
+/**
+ * Parse custom event rows into CustomEventData
+ */
+export function parseCustomEventRows(
+  rows: DataApiRow[],
+  grantEvent: string,
+  denyEvent: string,
+): CustomEventData {
+  let grantCount = 0
+  let denyCount = 0
+
+  for (const row of rows) {
+    const eventName = row.dimensionValues[0]?.value ?? ''
+    const count = parseInt(row.metricValues[0]?.value ?? '0', 10)
+    if (eventName === grantEvent) grantCount += count
+    if (eventName === denyEvent) denyCount += count
+  }
+
+  const total = grantCount + denyCount
+  const consent_rate_pct =
+    total > 0 ? Math.round((grantCount / total) * 1000) / 10 : 0
+
+  return {
+    grant_event: grantEvent,
+    grant_count: grantCount,
+    deny_event: denyEvent,
+    deny_count: denyCount,
+    consent_rate_pct,
+  }
+}
+
+// ============================================================================
+// API Calls
+// ============================================================================
+
+
+/**
+ * Run a GA4 Data API report
+ */
+export async function runDataApiReport(
+  propertyId: string,
+  body: Record<string, unknown>,
+): Promise<DataApiRow[]> {
+  const authHeaders = await getGoogleAuthHeaders([
+    'https://www.googleapis.com/auth/analytics.readonly',
+  ])
+
+  const url = `https://analyticsdata.googleapis.com/v1beta/${propertyId}:runReport`
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      ...authHeaders,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    if (response.status === 403) {
+      throw new Error(
+        'GA4 Data API access denied — check service account has Viewer role on property',
+      )
+    }
+    if (response.status === 404) {
+      throw new Error(
+        `Property not found: ${propertyId} — verify the property ID is correct`,
+      )
+    }
+    throw new Error(`GA4 Data API error (HTTP ${response.status}): ${text}`)
+  }
+
+  const data = (await response.json()) as DataApiResponse
+  return data.rows ?? []
+}
+
+// ============================================================================
+// Main Tool Function
+// ============================================================================
+
+/**
+ * Run the full ga4_consent_health tool
+ */
+export async function runGa4ConsentHealth(
+  input: Ga4ConsentHealthInput,
+): Promise<Ga4ConsentHealthOutput> {
+  const { property_id, days, custom_grant_event, custom_deny_event } = input
+  const period = `last ${days} days`
+  const endDate = 'today'
+  const startDate = `${days}daysAgo`
+
+  const emptyConsentMode: ConsentModeData = {
+    analytics_storage: {
+      granted_pct: 0,
+      denied_pct: 0,
+      unset_pct: 0,
+      total_sessions: 0,
+    },
+    ads_storage: {
+      granted_pct: 0,
+      denied_pct: 0,
+      unset_pct: 0,
+      total_sessions: 0,
+    },
+    available: false,
+  }
+
+  try {
+    // Call 1: Consent Mode signals
+    const consentRows = await runDataApiReport(property_id, {
+      dateRanges: [{ startDate, endDate }],
+      dimensions: [
+        { name: 'privacyInfoAnalyticsStorage' },
+        { name: 'privacyInfoAdsStorage' },
+      ],
+      metrics: [{ name: 'sessions' }],
+    })
+
+    const consent_mode = parseConsentModeRows(consentRows)
+
+    // Call 2: Custom events (only if requested)
+    let custom_events: CustomEventData | undefined
+    if (custom_grant_event || custom_deny_event) {
+      const grantEvent = custom_grant_event ?? ''
+      const denyEvent = custom_deny_event ?? ''
+
+      // Build event name filter
+      const filterValues = [grantEvent, denyEvent].filter(Boolean)
+      const eventRows = await runDataApiReport(property_id, {
+        dateRanges: [{ startDate, endDate }],
+        dimensions: [{ name: 'eventName' }],
+        metrics: [{ name: 'eventCount' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'eventName',
+            inListFilter: {
+              values: filterValues,
+            },
+          },
+        },
+      })
+
+      custom_events = parseCustomEventRows(eventRows, grantEvent, denyEvent)
+    }
+
+    const health_score = computeHealthScore(
+      consent_mode.analytics_storage.denied_pct,
+    )
+
+    return {
+      success: true,
+      property_id,
+      period,
+      consent_mode,
+      custom_events,
+      health_score,
+    }
+  } catch (err) {
+    return {
+      success: false,
+      property_id,
+      period,
+      consent_mode: emptyConsentMode,
+      health_score: 'critical',
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+// ============================================================================
+// MCP Tool Definition
+// ============================================================================
+
+export const ga4ConsentHealthTool = {
+  name: 'ga4_consent_health',
+  description:
+    'Report Consent Mode v2 health for a GA4 property: what % of sessions have analytics/ads consent granted vs denied. ' +
+    'Uses GA4 Data API (analyticsdata/v1beta). ' +
+    'Returns health score: healthy (<10% denied), warning (10-30%), critical (>30%).',
+  inputSchema: {
+    type: 'object',
+    required: ['property_id'],
+    properties: {
+      property_id: {
+        type: 'string',
+        description: 'GA4 property ID in format "properties/123456789"',
+      },
+      days: {
+        type: 'number',
+        description: 'Number of days to analyze (default: 28, max: 365)',
+        default: 28,
+        minimum: 1,
+        maximum: 365,
+      },
+      custom_grant_event: {
+        type: 'string',
+        description:
+          'Optional: custom event name for consent granted (e.g. "consent_granted")',
+      },
+      custom_deny_event: {
+        type: 'string',
+        description:
+          'Optional: custom event name for consent denied (e.g. "consent_denied")',
+      },
+    },
+  },
+}

--- a/mcp/src/tools/gsc-traffic-compare.test.ts
+++ b/mcp/src/tools/gsc-traffic-compare.test.ts
@@ -1,0 +1,522 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  gscTrafficCompareInputSchema,
+  gscTrafficCompareTool,
+  compareTrafficPeriods,
+  querySearchAnalytics,
+  runGscTrafficCompare,
+} from './gsc-traffic-compare.js'
+
+// ============================================================================
+// Mock google-auth utility
+// ============================================================================
+
+vi.mock('../utils/google-auth.js', () => ({
+  getGoogleAuthHeaders: vi.fn().mockResolvedValue({
+    Authorization: 'Bearer mock-token',
+  }),
+}))
+
+// ============================================================================
+// Input Schema Validation
+// ============================================================================
+
+describe('gscTrafficCompareInputSchema', () => {
+  it('accepts valid minimal input', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts full input with all optional fields', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'https://example.com/',
+      period_a: { start: '2026-02-01', end: '2026-02-28' },
+      period_b: { start: '2026-03-01', end: '2026-03-31' },
+      dimensions: ['page', 'country'],
+      limit: 1000,
+      min_clicks_a: 10,
+      sort_by: 'clicks_pct',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('applies default values', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.dimensions).toEqual(['page'])
+      expect(result.data.limit).toBe(500)
+      expect(result.data.min_clicks_a).toBe(0)
+      expect(result.data.sort_by).toBe('clicks_abs')
+    }
+  })
+
+  it('rejects missing site', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing period_a', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid date format in period_a', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '01-03-2026', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid date format in period_b', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026/04/01', end: '2026-04-24' },
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects limit above maximum', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+      limit: 25001,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects limit below minimum', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+      limit: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid sort_by value', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+      sort_by: 'invalid',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts all valid sort_by values', () => {
+    for (const sort_by of ['clicks_abs', 'clicks_pct', 'impressions_abs'] as const) {
+      const result = gscTrafficCompareInputSchema.safeParse({
+        site: 'sc-domain:example.com',
+        period_a: { start: '2026-03-01', end: '2026-03-31' },
+        period_b: { start: '2026-04-01', end: '2026-04-24' },
+        sort_by,
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+})
+
+// ============================================================================
+// compareTrafficPeriods — unit tests for diff logic
+// ============================================================================
+
+describe('compareTrafficPeriods', () => {
+  const makeRow = (
+    url: string,
+    clicks: number,
+    impressions = 1000,
+    ctr = 0.05,
+    position = 5.0,
+  ) => ({
+    keys: [url],
+    clicks,
+    impressions,
+    ctr,
+    position,
+  })
+
+  it('classifies URLs with >5% click drop as drops', () => {
+    const rowsA = [makeRow('/page-a', 100)]
+    const rowsB = [makeRow('/page-a', 80)] // -20% drop
+    const { drops, gains } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(drops).toHaveLength(1)
+    expect(drops[0].url).toBe('/page-a')
+    expect(drops[0].clicks_delta).toBe(-20)
+    expect(gains).toHaveLength(0)
+  })
+
+  it('classifies URLs with >5% click gain as gains', () => {
+    const rowsA = [makeRow('/page-b', 100)]
+    const rowsB = [makeRow('/page-b', 130)] // +30% gain
+    const { drops, gains } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(gains).toHaveLength(1)
+    expect(gains[0].url).toBe('/page-b')
+    expect(gains[0].clicks_delta).toBe(30)
+    expect(drops).toHaveLength(0)
+  })
+
+  it('counts URLs within ±5% as unchanged', () => {
+    const rowsA = [makeRow('/page-c', 100)]
+    const rowsB = [makeRow('/page-c', 103)] // +3% — unchanged
+    const { drops, gains, unchanged } = compareTrafficPeriods(
+      rowsA,
+      rowsB,
+      0,
+      'clicks_abs',
+    )
+    expect(unchanged).toBe(1)
+    expect(drops).toHaveLength(0)
+    expect(gains).toHaveLength(0)
+  })
+
+  it('counts URLs only in period A vs only in period B', () => {
+    const rowsA = [makeRow('/only-in-a', 50), makeRow('/common', 100)]
+    const rowsB = [makeRow('/only-in-b', 50), makeRow('/common', 90)]
+    const { summary } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(summary.urls_only_in_a).toBe(1)
+    expect(summary.urls_only_in_b).toBe(1)
+    expect(summary.urls_compared).toBe(1)
+  })
+
+  it('applies min_clicks_a filter', () => {
+    const rowsA = [makeRow('/low-traffic', 3), makeRow('/high-traffic', 200)]
+    const rowsB = [makeRow('/low-traffic', 1), makeRow('/high-traffic', 150)]
+    const { drops } = compareTrafficPeriods(rowsA, rowsB, 10, 'clicks_abs')
+    // /low-traffic has 3 clicks in A < min_clicks_a=10, should be excluded
+    expect(drops.every((d) => d.url !== '/low-traffic')).toBe(true)
+    // /high-traffic has 200 clicks in A, should be included
+    expect(drops.some((d) => d.url === '/high-traffic')).toBe(true)
+  })
+
+  it('sorts drops by clicks_abs (worst first)', () => {
+    const rowsA = [makeRow('/big-drop', 1000), makeRow('/small-drop', 100)]
+    const rowsB = [makeRow('/big-drop', 500), makeRow('/small-drop', 80)]
+    const { drops } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(drops[0].url).toBe('/big-drop') // -500 clicks beats -20 clicks
+  })
+
+  it('sorts drops by clicks_pct when sort_by=clicks_pct', () => {
+    // /pct-drop: 100->10 = -90%, /abs-drop: 1000->500 = -50%
+    const rowsA = [makeRow('/pct-drop', 100), makeRow('/abs-drop', 1000)]
+    const rowsB = [makeRow('/pct-drop', 10), makeRow('/abs-drop', 500)]
+    const { drops } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_pct')
+    expect(drops[0].url).toBe('/pct-drop') // -90% worse than -50%
+  })
+
+  it('sorts drops by impressions_abs when sort_by=impressions_abs', () => {
+    const rowsA = [
+      makeRow('/imp-drop', 100, 5000),
+      makeRow('/small-imp-drop', 100, 500),
+    ]
+    const rowsB = [
+      makeRow('/imp-drop', 80, 1000),
+      makeRow('/small-imp-drop', 80, 400),
+    ]
+    const { drops } = compareTrafficPeriods(rowsA, rowsB, 0, 'impressions_abs')
+    expect(drops[0].url).toBe('/imp-drop') // -4000 impressions > -100
+  })
+
+  it('computes correct clicks_pct', () => {
+    const rowsA = [makeRow('/page', 200)]
+    const rowsB = [makeRow('/page', 100)] // -50%
+    const { drops } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(drops[0].clicks_pct).toBe(-50)
+  })
+
+  it('handles zero clicks in period A gracefully', () => {
+    const rowsA = [makeRow('/zero-clicks', 0)]
+    const rowsB = [makeRow('/zero-clicks', 10)]
+    // 0 clicks in A = 0% change formula -> unchanged (clips_pct = 0)
+    const { unchanged } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(unchanged).toBe(1)
+  })
+
+  it('limits drops and gains to top 50', () => {
+    // Create 60 drop URLs
+    const rowsA = Array.from({ length: 60 }, (_, i) => makeRow(`/page-${i}`, 100))
+    const rowsB = Array.from({ length: 60 }, (_, i) => makeRow(`/page-${i}`, 50))
+    const { drops } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(drops).toHaveLength(50)
+  })
+
+  it('computes impressions_delta correctly', () => {
+    const rowsA = [makeRow('/page', 100, 2000)]
+    const rowsB = [makeRow('/page', 80, 1500)]
+    const { drops } = compareTrafficPeriods(rowsA, rowsB, 0, 'clicks_abs')
+    expect(drops[0].impressions_delta).toBe(-500)
+  })
+
+  it('returns empty drops/gains for empty input', () => {
+    const { drops, gains, unchanged, summary } = compareTrafficPeriods(
+      [],
+      [],
+      0,
+      'clicks_abs',
+    )
+    expect(drops).toHaveLength(0)
+    expect(gains).toHaveLength(0)
+    expect(unchanged).toBe(0)
+    expect(summary.urls_compared).toBe(0)
+  })
+})
+
+// ============================================================================
+// querySearchAnalytics — API integration (mocked fetch)
+// ============================================================================
+
+describe('querySearchAnalytics', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('calls GSC API with correct parameters', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          rows: [
+            {
+              keys: ['/page-a'],
+              clicks: 100,
+              impressions: 2000,
+              ctr: 0.05,
+              position: 3.5,
+            },
+          ],
+        }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const rows = await querySearchAnalytics(
+      'sc-domain:example.com',
+      '2026-03-01',
+      '2026-03-31',
+      ['page'],
+      500,
+    )
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('sc-domain%3Aexample.com')
+    expect(url).toContain('searchAnalytics/query')
+    expect(options.method).toBe('POST')
+    const body = JSON.parse(options.body as string)
+    expect(body.startDate).toBe('2026-03-01')
+    expect(body.endDate).toBe('2026-03-31')
+    expect(body.dimensions).toEqual(['page'])
+    expect(body.rowLimit).toBe(500)
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].clicks).toBe(100)
+  })
+
+  it('returns empty array when API returns no rows', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      }),
+    )
+
+    const rows = await querySearchAnalytics(
+      'sc-domain:example.com',
+      '2026-03-01',
+      '2026-03-31',
+      ['page'],
+      500,
+    )
+    expect(rows).toHaveLength(0)
+  })
+
+  it('throws descriptive error on 403', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Forbidden'),
+      }),
+    )
+
+    await expect(
+      querySearchAnalytics('sc-domain:example.com', '2026-03-01', '2026-03-31', ['page'], 500),
+    ).rejects.toThrow('GSC access denied')
+  })
+
+  it('throws descriptive error on 429', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 429,
+        text: () => Promise.resolve('Too Many Requests'),
+      }),
+    )
+
+    await expect(
+      querySearchAnalytics('sc-domain:example.com', '2026-03-01', '2026-03-31', ['page'], 500),
+    ).rejects.toThrow('GSC quota exceeded')
+  })
+
+  it('throws generic error on other HTTP failures', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error'),
+      }),
+    )
+
+    await expect(
+      querySearchAnalytics('sc-domain:example.com', '2026-03-01', '2026-03-31', ['page'], 500),
+    ).rejects.toThrow('GSC API error (HTTP 500)')
+  })
+})
+
+// ============================================================================
+// runGscTrafficCompare — integration (mocked fetch)
+// ============================================================================
+
+describe('runGscTrafficCompare', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('returns successful comparison result', async () => {
+    const mockRows = [
+      {
+        keys: ['/page-a'],
+        clicks: 100,
+        impressions: 2000,
+        ctr: 0.05,
+        position: 3.5,
+      },
+    ]
+    const mockDropRows = [
+      {
+        keys: ['/page-a'],
+        clicks: 70, // -30% drop
+        impressions: 1500,
+        ctr: 0.047,
+        position: 4.0,
+      },
+    ]
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ rows: mockRows }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ rows: mockDropRows }),
+        }),
+    )
+
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+
+    const result = await runGscTrafficCompare(input)
+
+    expect(result.success).toBe(true)
+    expect(result.site).toBe('sc-domain:example.com')
+    expect(result.period_a).toBe('2026-03-01 to 2026-03-31')
+    expect(result.period_b).toBe('2026-04-01 to 2026-04-24')
+    expect(result.drops).toHaveLength(1)
+    expect(result.drops[0].url).toBe('/page-a')
+    expect(result.drops[0].clicks_delta).toBe(-30)
+    expect(result.gains).toHaveLength(0)
+  })
+
+  it('returns error result on API failure', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Forbidden'),
+      }),
+    )
+
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+
+    const result = await runGscTrafficCompare(input)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('GSC access denied')
+    expect(result.drops).toHaveLength(0)
+    expect(result.gains).toHaveLength(0)
+  })
+})
+
+// ============================================================================
+// Tool Definition
+// ============================================================================
+
+describe('gscTrafficCompareTool definition', () => {
+  it('has correct tool name', () => {
+    expect(gscTrafficCompareTool.name).toBe('gsc_traffic_compare')
+  })
+
+  it('has a descriptive description', () => {
+    expect(gscTrafficCompareTool.description).toContain('GSC')
+    expect(gscTrafficCompareTool.description).toContain('traffic')
+  })
+
+  it('defines required fields in schema', () => {
+    expect(gscTrafficCompareTool.inputSchema.required).toContain('site')
+    expect(gscTrafficCompareTool.inputSchema.required).toContain('period_a')
+    expect(gscTrafficCompareTool.inputSchema.required).toContain('period_b')
+  })
+
+  it('defines all optional parameters', () => {
+    const props = gscTrafficCompareTool.inputSchema.properties
+    expect(props.dimensions).toBeDefined()
+    expect(props.limit).toBeDefined()
+    expect(props.min_clicks_a).toBeDefined()
+    expect(props.sort_by).toBeDefined()
+  })
+
+  it('defines period_a and period_b as objects with start/end', () => {
+    const props = gscTrafficCompareTool.inputSchema.properties
+    expect(props.period_a.type).toBe('object')
+    expect(props.period_a.properties.start).toBeDefined()
+    expect(props.period_a.properties.end).toBeDefined()
+    expect(props.period_b.type).toBe('object')
+    expect(props.period_b.properties.start).toBeDefined()
+    expect(props.period_b.properties.end).toBeDefined()
+  })
+})

--- a/mcp/src/tools/gsc-traffic-compare.ts
+++ b/mcp/src/tools/gsc-traffic-compare.ts
@@ -1,0 +1,391 @@
+import { z } from 'zod'
+import { getGoogleAuthHeaders } from '../utils/google-auth.js'
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+const dateRangeSchema = z.object({
+  start: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format'),
+  end: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format'),
+})
+
+export const gscTrafficCompareInputSchema = z.object({
+  /** Site URL: sc-domain:example.com or https://example.com/ */
+  site: z.string().min(1, 'site is required'),
+  /** Baseline (older) period */
+  period_a: dateRangeSchema,
+  /** Current (newer) period */
+  period_b: dateRangeSchema,
+  /** Dimensions to query (default: ["page"]) */
+  dimensions: z.array(z.string()).optional().default(['page']),
+  /** Max rows per period from GSC API (default: 500, max 25000) */
+  limit: z.number().int().min(1).max(25000).optional().default(500),
+  /** Only include URLs with >= N clicks in period_a (reduces noise) */
+  min_clicks_a: z.number().int().min(0).optional().default(0),
+  /** Sort metric for drops/gains lists */
+  sort_by: z
+    .enum(['clicks_abs', 'clicks_pct', 'impressions_abs'])
+    .optional()
+    .default('clicks_abs'),
+})
+
+export type GscTrafficCompareInput = z.infer<typeof gscTrafficCompareInputSchema>
+
+// ============================================================================
+// Output Types
+// ============================================================================
+
+export interface TrafficDiff {
+  url: string
+  clicks_a: number
+  clicks_b: number
+  clicks_delta: number
+  clicks_pct: number
+  impressions_a: number
+  impressions_b: number
+  impressions_delta: number
+  ctr_a: number
+  ctr_b: number
+  position_a: number
+  position_b: number
+}
+
+export interface TrafficCompareSummary {
+  urls_compared: number
+  urls_only_in_a: number
+  urls_only_in_b: number
+}
+
+export interface GscTrafficCompareOutput {
+  success: boolean
+  site: string
+  period_a: string
+  period_b: string
+  summary: TrafficCompareSummary
+  drops: TrafficDiff[]
+  gains: TrafficDiff[]
+  unchanged: number
+  error?: string
+}
+
+// ============================================================================
+// GSC API Types
+// ============================================================================
+
+interface GscSearchAnalyticsRow {
+  keys: string[]
+  clicks: number
+  impressions: number
+  ctr: number
+  position: number
+}
+
+interface GscSearchAnalyticsResponse {
+  rows?: GscSearchAnalyticsRow[]
+}
+
+// ============================================================================
+// Core Logic
+// ============================================================================
+
+/**
+ * Query GSC Search Analytics API for a single date range
+ */
+export async function querySearchAnalytics(
+  site: string,
+  startDate: string,
+  endDate: string,
+  dimensions: string[],
+  limit: number,
+): Promise<GscSearchAnalyticsRow[]> {
+  const authHeaders = await getGoogleAuthHeaders([
+    'https://www.googleapis.com/auth/webmasters.readonly',
+  ])
+
+  const encodedSite = encodeURIComponent(site)
+  const url = `https://www.googleapis.com/webmasters/v3/sites/${encodedSite}/searchAnalytics/query`
+
+  const body = {
+    startDate,
+    endDate,
+    dimensions,
+    rowLimit: limit,
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      ...authHeaders,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    if (response.status === 403) {
+      throw new Error(
+        'GSC access denied — check service account has Search Console access',
+      )
+    }
+    if (response.status === 429) {
+      throw new Error('GSC quota exceeded — 2000 req/day limit')
+    }
+    throw new Error(`GSC API error (HTTP ${response.status}): ${text}`)
+  }
+
+  const data = (await response.json()) as GscSearchAnalyticsResponse
+  return data.rows ?? []
+}
+
+/**
+ * Build a map from URL key to row data
+ */
+function buildUrlMap(rows: GscSearchAnalyticsRow[]): Map<string, GscSearchAnalyticsRow> {
+  const map = new Map<string, GscSearchAnalyticsRow>()
+  for (const row of rows) {
+    // The first key dimension is the URL (page dimension)
+    const key = row.keys.join('|')
+    map.set(key, row)
+  }
+  return map
+}
+
+/**
+ * Sort comparator for TrafficDiff based on sort_by field
+ */
+function getSortValue(diff: TrafficDiff, sortBy: GscTrafficCompareInput['sort_by']): number {
+  switch (sortBy) {
+    case 'clicks_pct':
+      return Math.abs(diff.clicks_pct)
+    case 'impressions_abs':
+      return Math.abs(diff.impressions_delta)
+    case 'clicks_abs':
+    default:
+      return Math.abs(diff.clicks_delta)
+  }
+}
+
+/**
+ * Core comparison logic: join two period result sets and compute deltas
+ */
+export function compareTrafficPeriods(
+  rowsA: GscSearchAnalyticsRow[],
+  rowsB: GscSearchAnalyticsRow[],
+  minClicksA: number,
+  sortBy: GscTrafficCompareInput['sort_by'],
+): {
+  drops: TrafficDiff[]
+  gains: TrafficDiff[]
+  unchanged: number
+  summary: TrafficCompareSummary
+} {
+  const mapA = buildUrlMap(rowsA)
+  const mapB = buildUrlMap(rowsB)
+
+  const allKeysA = new Set(mapA.keys())
+  const allKeysB = new Set(mapB.keys())
+
+  const commonKeys: string[] = []
+  for (const key of allKeysA) {
+    if (allKeysB.has(key)) {
+      commonKeys.push(key)
+    }
+  }
+
+  const urls_only_in_a = [...allKeysA].filter((k) => !allKeysB.has(k)).length
+  const urls_only_in_b = [...allKeysB].filter((k) => !allKeysA.has(k)).length
+
+  const drops: TrafficDiff[] = []
+  const gains: TrafficDiff[] = []
+  let unchanged = 0
+
+  for (const key of commonKeys) {
+    const a = mapA.get(key)!
+    const b = mapB.get(key)!
+
+    // Apply min_clicks_a filter
+    if (a.clicks < minClicksA) {
+      continue
+    }
+
+    const clicks_delta = b.clicks - a.clicks
+    const clicks_pct =
+      a.clicks > 0 ? ((b.clicks - a.clicks) / a.clicks) * 100 : 0
+    const impressions_delta = b.impressions - a.impressions
+
+    const diff: TrafficDiff = {
+      url: key,
+      clicks_a: a.clicks,
+      clicks_b: b.clicks,
+      clicks_delta,
+      clicks_pct: Math.round(clicks_pct * 10) / 10,
+      impressions_a: a.impressions,
+      impressions_b: b.impressions,
+      impressions_delta,
+      ctr_a: a.ctr,
+      ctr_b: b.ctr,
+      position_a: a.position,
+      position_b: b.position,
+    }
+
+    // Classify: < -5% = drop, > +5% = gain, otherwise unchanged
+    if (clicks_pct < -5) {
+      drops.push(diff)
+    } else if (clicks_pct > 5) {
+      gains.push(diff)
+    } else {
+      unchanged++
+    }
+  }
+
+  // Sort drops worst-first, gains best-first
+  drops.sort((a, b) => getSortValue(b, sortBy) - getSortValue(a, sortBy))
+  gains.sort((a, b) => getSortValue(b, sortBy) - getSortValue(a, sortBy))
+
+  return {
+    drops: drops.slice(0, 50),
+    gains: gains.slice(0, 50),
+    unchanged,
+    summary: {
+      urls_compared: commonKeys.length,
+      urls_only_in_a,
+      urls_only_in_b,
+    },
+  }
+}
+
+/**
+ * Run the full gsc_traffic_compare tool
+ */
+export async function runGscTrafficCompare(
+  input: GscTrafficCompareInput,
+): Promise<GscTrafficCompareOutput> {
+  const { site, period_a, period_b, dimensions, limit, min_clicks_a, sort_by } =
+    input
+
+  const periodAStr = `${period_a.start} to ${period_a.end}`
+  const periodBStr = `${period_b.start} to ${period_b.end}`
+
+  try {
+    const [rowsA, rowsB] = await Promise.all([
+      querySearchAnalytics(site, period_a.start, period_a.end, dimensions, limit),
+      querySearchAnalytics(site, period_b.start, period_b.end, dimensions, limit),
+    ])
+
+    const { drops, gains, unchanged, summary } = compareTrafficPeriods(
+      rowsA,
+      rowsB,
+      min_clicks_a,
+      sort_by,
+    )
+
+    return {
+      success: true,
+      site,
+      period_a: periodAStr,
+      period_b: periodBStr,
+      summary,
+      drops,
+      gains,
+      unchanged,
+    }
+  } catch (err) {
+    return {
+      success: false,
+      site,
+      period_a: periodAStr,
+      period_b: periodBStr,
+      summary: { urls_compared: 0, urls_only_in_a: 0, urls_only_in_b: 0 },
+      drops: [],
+      gains: [],
+      unchanged: 0,
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+// ============================================================================
+// MCP Tool Definition
+// ============================================================================
+
+export const gscTrafficCompareTool = {
+  name: 'gsc_traffic_compare',
+  description:
+    'Compare GSC Search Analytics traffic between two date ranges. ' +
+    'Identifies URLs with the biggest drops and gains in clicks/impressions. ' +
+    'Useful for diagnosing traffic changes after algorithm updates, site changes, or seasonal shifts.',
+  inputSchema: {
+    type: 'object',
+    required: ['site', 'period_a', 'period_b'],
+    properties: {
+      site: {
+        type: 'string',
+        description:
+          'GSC site identifier: sc-domain:example.com (domain property) or https://example.com/ (URL prefix)',
+      },
+      period_a: {
+        type: 'object',
+        required: ['start', 'end'],
+        description: 'Baseline (older) period',
+        properties: {
+          start: {
+            type: 'string',
+            description: 'Start date in YYYY-MM-DD format',
+          },
+          end: {
+            type: 'string',
+            description: 'End date in YYYY-MM-DD format',
+          },
+        },
+      },
+      period_b: {
+        type: 'object',
+        required: ['start', 'end'],
+        description: 'Current (newer) period to compare against baseline',
+        properties: {
+          start: {
+            type: 'string',
+            description: 'Start date in YYYY-MM-DD format',
+          },
+          end: {
+            type: 'string',
+            description: 'End date in YYYY-MM-DD format',
+          },
+        },
+      },
+      dimensions: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Dimensions to break down by (default: ["page"])',
+        default: ['page'],
+      },
+      limit: {
+        type: 'number',
+        description: 'Max rows per period from GSC API (default: 500, max 25000)',
+        default: 500,
+        minimum: 1,
+        maximum: 25000,
+      },
+      min_clicks_a: {
+        type: 'number',
+        description:
+          'Minimum clicks in period_a to include URL in comparison (filters noise, default: 0)',
+        default: 0,
+        minimum: 0,
+      },
+      sort_by: {
+        type: 'string',
+        enum: ['clicks_abs', 'clicks_pct', 'impressions_abs'],
+        description:
+          'Sort metric for drops/gains lists (default: clicks_abs — absolute click change)',
+        default: 'clicks_abs',
+      },
+    },
+  },
+}

--- a/mcp/src/tools/html-signals.test.ts
+++ b/mcp/src/tools/html-signals.test.ts
@@ -1,0 +1,214 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import {
+  extractTitle,
+  extractMetaContent,
+  extractCanonical,
+  countHreflang,
+  extractSchemaTypes,
+  extractSignals,
+} from './html-signals.js'
+
+function fixture(name: string): string {
+  // cwd is mcp/ when tests run
+  return readFileSync(resolve(process.cwd(), 'src/tools/__fixtures__', name), 'utf-8')
+}
+
+// ============================================================================
+// Unit tests for individual extractors
+// ============================================================================
+
+describe('extractTitle', () => {
+  it('extracts title from simple title tag', () => {
+    expect(extractTitle('<title>My Page Title</title>')).toBe('My Page Title')
+  })
+
+  it('returns null when no title tag', () => {
+    expect(extractTitle('<html><body>no title</body></html>')).toBeNull()
+  })
+
+  it('trims and collapses whitespace', () => {
+    expect(extractTitle('<title>  My\n  Title  </title>')).toBe('My Title')
+  })
+
+  it('returns null for empty title tag', () => {
+    expect(extractTitle('<title></title>')).toBeNull()
+  })
+})
+
+describe('extractMetaContent', () => {
+  it('extracts meta description', () => {
+    const html = '<meta name="description" content="My description">'
+    expect(extractMetaContent(html, 'description')).toBe('My description')
+  })
+
+  it('extracts og:title via property attribute', () => {
+    const html = '<meta property="og:title" content="OG Title">'
+    expect(extractMetaContent(html, 'og:title')).toBe('OG Title')
+  })
+
+  it('handles reversed attribute order (content before name)', () => {
+    const html = '<meta content="My desc" name="description">'
+    expect(extractMetaContent(html, 'description')).toBe('My desc')
+  })
+
+  it('returns null when tag not present', () => {
+    expect(extractMetaContent('<html></html>', 'description')).toBeNull()
+  })
+})
+
+describe('extractCanonical', () => {
+  it('extracts canonical href', () => {
+    const html = '<link rel="canonical" href="https://example.com/page">'
+    expect(extractCanonical(html)).toBe('https://example.com/page')
+  })
+
+  it('resolves relative canonical against baseUrl', () => {
+    const html = '<link rel="canonical" href="/page">'
+    expect(extractCanonical(html, 'https://example.com')).toBe('https://example.com/page')
+  })
+
+  it('returns null when no canonical tag', () => {
+    expect(extractCanonical('<html></html>')).toBeNull()
+  })
+})
+
+describe('countHreflang', () => {
+  it('counts hreflang link tags', () => {
+    const html = `
+      <link rel="alternate" hreflang="en" href="https://example.com/">
+      <link rel="alternate" hreflang="es" href="https://example.com/es/">
+      <link rel="alternate" hreflang="x-default" href="https://example.com/">
+    `
+    expect(countHreflang(html)).toBe(3)
+  })
+
+  it('returns 0 when no hreflang tags', () => {
+    expect(countHreflang('<html></html>')).toBe(0)
+  })
+})
+
+describe('extractSchemaTypes', () => {
+  it('extracts single @type', () => {
+    const html = `<script type="application/ld+json">{"@type": "Article"}</script>`
+    expect(extractSchemaTypes(html)).toContain('Article')
+  })
+
+  it('extracts types from @graph array', () => {
+    const html = `<script type="application/ld+json">{"@graph":[{"@type":"WebPage"},{"@type":"BreadcrumbList"}]}</script>`
+    const types = extractSchemaTypes(html)
+    expect(types).toContain('WebPage')
+    expect(types).toContain('BreadcrumbList')
+  })
+
+  it('extracts array @type values', () => {
+    const html = `<script type="application/ld+json">{"@type":["Article","NewsArticle"]}</script>`
+    const types = extractSchemaTypes(html)
+    expect(types).toContain('Article')
+    expect(types).toContain('NewsArticle')
+  })
+
+  it('deduplicates types', () => {
+    const html = `
+      <script type="application/ld+json">{"@type":"Article"}</script>
+      <script type="application/ld+json">{"@type":"Article"}</script>
+    `
+    expect(extractSchemaTypes(html).filter((t) => t === 'Article')).toHaveLength(1)
+  })
+
+  it('handles invalid JSON-LD gracefully', () => {
+    const html = `<script type="application/ld+json">{ invalid }</script>`
+    expect(() => extractSchemaTypes(html)).not.toThrow()
+    expect(extractSchemaTypes(html)).toHaveLength(0)
+  })
+})
+
+// ============================================================================
+// Fixture-based tests for extractSignals
+// ============================================================================
+
+describe('extractSignals — good-baseline.html', () => {
+  const html = fixture('good-baseline.html')
+  const baseUrl = 'https://example.com/web-performance'
+  const signals = extractSignals(html, baseUrl)
+
+  it('extracts title text and length', () => {
+    expect(signals.title).toBe('Best Practices for Web Performance')
+    expect(signals.title_length).toBe(34)
+  })
+
+  it('extracts meta description and length', () => {
+    expect(signals.description).toBe('Learn how to optimise your website for speed and Core Web Vitals.')
+    expect(signals.description_length).toBeGreaterThan(0)
+  })
+
+  it('extracts canonical (resolved absolute)', () => {
+    expect(signals.canonical).toBe('https://example.com/web-performance')
+  })
+
+  it('extracts OG tags', () => {
+    expect(signals.og.title).toBe('Best Practices for Web Performance')
+    expect(signals.og.image).toBe('https://example.com/og-image.jpg')
+    expect(signals.og.type).toBe('article')
+  })
+
+  it('extracts schema types', () => {
+    expect(signals.schema_types).toContain('Article')
+  })
+
+  it('counts h1 and h2', () => {
+    expect(signals.h1_count).toBe(1)
+    expect(signals.h2_count).toBe(2)
+  })
+
+  it('counts hreflang tags', () => {
+    expect(signals.hreflang_count).toBe(3)
+  })
+
+  it('detects no noindex', () => {
+    expect(signals.noindex).toBe(false)
+  })
+})
+
+describe('extractSignals — missing-canonical.html', () => {
+  const html = fixture('missing-canonical.html')
+  const baseUrl = 'https://example.com/missing-canonical'
+  const signals = extractSignals(html, baseUrl)
+
+  it('canonical is null', () => {
+    expect(signals.canonical).toBeNull()
+  })
+
+  it('extracts @graph schema types', () => {
+    expect(signals.schema_types).toContain('WebPage')
+    expect(signals.schema_types).toContain('BreadcrumbList')
+  })
+
+  it('has h1_count of 1', () => {
+    expect(signals.h1_count).toBe(1)
+  })
+})
+
+describe('extractSignals — multi-h1.html', () => {
+  const html = fixture('multi-h1.html')
+  const baseUrl = 'https://example.com/multi-h1'
+  const signals = extractSignals(html, baseUrl)
+
+  it('counts 3 h1 tags', () => {
+    expect(signals.h1_count).toBe(3)
+  })
+
+  it('has canonical', () => {
+    expect(signals.canonical).toBe('https://example.com/multi-h1')
+  })
+
+  it('extracts array @type from JSON-LD', () => {
+    expect(signals.schema_types).toContain('WebPage')
+    expect(signals.schema_types).toContain('ItemPage')
+  })
+
+  it('detects no noindex (robots: index, follow)', () => {
+    expect(signals.noindex).toBe(false)
+  })
+})

--- a/mcp/src/tools/html-signals.ts
+++ b/mcp/src/tools/html-signals.ts
@@ -1,0 +1,130 @@
+// ============================================================================
+// html-signals.ts — pure HTML signal extraction, no I/O
+// ============================================================================
+
+export interface HtmlSignals {
+  title: string | null
+  title_length: number
+  description: string | null
+  description_length: number
+  canonical: string | null
+  robots: string | null
+  noindex: boolean
+  og: {
+    title: string | null
+    description: string | null
+    image: string | null
+    type: string | null
+  }
+  schema_types: string[]
+  h1_count: number
+  h2_count: number
+  hreflang_count: number
+}
+
+function countMatches(html: string, pattern: RegExp): number {
+  const matches = html.match(new RegExp(pattern.source, 'gi'))
+  return matches ? matches.length : 0
+}
+
+export function extractTitle(html: string): string | null {
+  const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+  if (!match) return null
+  return match[1].replace(/\s+/g, ' ').trim() || null
+}
+
+export function extractMetaContent(html: string, name: string): string | null {
+  const pattern = new RegExp(
+    `<meta[^>]+(?:name|property)=["']${name}["'][^>]+content=["']([^"']*)["']|` +
+      `<meta[^>]+content=["']([^"']*)["'][^>]+(?:name|property)=["']${name}["']`,
+    'i',
+  )
+  const match = html.match(pattern)
+  if (!match) return null
+  return (match[1] ?? match[2] ?? null)?.trim() || null
+}
+
+export function extractCanonical(html: string, baseUrl?: string): string | null {
+  const match = html.match(
+    /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']|<link[^>]+href=["']([^"']+)["'][^>]+rel=["']canonical["']/i,
+  )
+  if (!match) return null
+  const raw = (match[1] ?? match[2] ?? null)?.trim()
+  if (!raw) return null
+  if (!baseUrl) return raw
+  try {
+    return new URL(raw, baseUrl).href
+  } catch {
+    return raw
+  }
+}
+
+export function countHreflang(html: string): number {
+  return countMatches(html, /<link[^>]+hreflang=/i)
+}
+
+export function extractSchemaTypes(html: string): string[] {
+  const types: string[] = []
+  const scriptPattern =
+    /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+  let match: RegExpExecArray | null
+
+  while ((match = scriptPattern.exec(html)) !== null) {
+    try {
+      const parsed = JSON.parse(match[1]) as Record<string, unknown> | unknown[]
+      const extractType = (obj: unknown): void => {
+        if (Array.isArray(obj)) {
+          obj.forEach(extractType)
+        } else if (obj && typeof obj === 'object') {
+          const record = obj as Record<string, unknown>
+          if (record['@type']) {
+            const t = record['@type']
+            if (Array.isArray(t)) types.push(...(t as string[]))
+            else if (typeof t === 'string') types.push(t)
+          }
+          if (Array.isArray(record['@graph'])) record['@graph'].forEach(extractType)
+        }
+      }
+      extractType(parsed)
+    } catch {
+      // Invalid JSON-LD — skip
+    }
+  }
+
+  return [...new Set(types)]
+}
+
+export function extractSignals(html: string, baseUrl: string): HtmlSignals {
+  const title = extractTitle(html)
+  const description = extractMetaContent(html, 'description')
+  const canonical = extractCanonical(html, baseUrl)
+  const robots = extractMetaContent(html, 'robots')
+
+  const og = {
+    title: extractMetaContent(html, 'og:title'),
+    description: extractMetaContent(html, 'og:description'),
+    image: extractMetaContent(html, 'og:image'),
+    type: extractMetaContent(html, 'og:type'),
+  }
+
+  const schema_types = extractSchemaTypes(html)
+  const h1_count = countMatches(html, /<h1[\s>]/i)
+  const h2_count = countMatches(html, /<h2[\s>]/i)
+  const hreflang_count = countHreflang(html)
+  const noindex = robots ? /noindex/i.test(robots) : false
+
+  return {
+    title,
+    title_length: title ? title.length : 0,
+    description,
+    description_length: description ? description.length : 0,
+    canonical,
+    robots,
+    noindex,
+    og,
+    schema_types,
+    h1_count,
+    h2_count,
+    hreflang_count,
+  }
+}

--- a/mcp/src/tools/issue-rules.test.ts
+++ b/mcp/src/tools/issue-rules.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { runIssueRules, summarizeIssues, type SeoIssue } from './issue-rules.js'
+import type { HtmlSignals } from './html-signals.js'
+
+const baseSignals: HtmlSignals = {
+  title: 'A Good Page Title Here For Testing',
+  title_length: 35,
+  description: 'A good meta description for this page that is reasonable length.',
+  description_length: 64,
+  canonical: 'https://example.com/page',
+  robots: null,
+  noindex: false,
+  og: {
+    title: 'OG Title',
+    description: 'OG Description',
+    image: 'https://example.com/image.jpg',
+    type: 'article',
+  },
+  schema_types: ['Article'],
+  h1_count: 1,
+  h2_count: 3,
+  hreflang_count: 0,
+}
+
+const finalUrl = 'https://example.com/page'
+
+describe('runIssueRules', () => {
+  it('returns no issues for a perfect page', () => {
+    expect(runIssueRules(baseSignals, finalUrl)).toHaveLength(0)
+  })
+
+  // Title rules
+  it('flags missing title as error', () => {
+    const signals = { ...baseSignals, title: null, title_length: 0 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'title' && i.severity === 'error')).toBe(true)
+  })
+
+  it('flags short title (<10 chars) as warning', () => {
+    const signals = { ...baseSignals, title: 'Hi', title_length: 2 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'title' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('flags long title (>70 chars) as warning', () => {
+    const signals = { ...baseSignals, title: 'A'.repeat(71), title_length: 71 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'title' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('accepts title at exactly 70 chars', () => {
+    const signals = { ...baseSignals, title: 'A'.repeat(70), title_length: 70 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'title')).toBe(false)
+  })
+
+  // Description rules
+  it('flags missing description as warning', () => {
+    const signals = { ...baseSignals, description: null, description_length: 0 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'description' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('flags description >160 chars as warning', () => {
+    const signals = { ...baseSignals, description: 'A'.repeat(161), description_length: 161 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'description' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('accepts description at exactly 160 chars', () => {
+    const signals = { ...baseSignals, description: 'A'.repeat(160), description_length: 160 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'description')).toBe(false)
+  })
+
+  // Canonical rules
+  it('flags missing canonical as warning', () => {
+    const signals = { ...baseSignals, canonical: null }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('flags cross-domain canonical as error', () => {
+    const signals = { ...baseSignals, canonical: 'https://other-domain.com/page' }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'error')).toBe(true)
+  })
+
+  it('accepts same-domain canonical', () => {
+    const signals = { ...baseSignals, canonical: 'https://example.com/page' }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical')).toBe(false)
+  })
+
+  it('flags invalid canonical URL as warning', () => {
+    const signals = { ...baseSignals, canonical: 'not-a-url' }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'warning')).toBe(true)
+  })
+
+  // Robots noindex rule
+  it('flags noindex as error', () => {
+    const signals = { ...baseSignals, robots: 'noindex, nofollow', noindex: true }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'robots' && i.severity === 'error')).toBe(true)
+  })
+
+  it('does not flag index, follow robots as error', () => {
+    const signals = { ...baseSignals, robots: 'index, follow', noindex: false }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'robots')).toBe(false)
+  })
+
+  // H1 rules
+  it('flags missing h1 as warning', () => {
+    const signals = { ...baseSignals, h1_count: 0 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'h1' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('flags multiple h1 as warning', () => {
+    const signals = { ...baseSignals, h1_count: 3 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'h1' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('accepts exactly one h1', () => {
+    const signals = { ...baseSignals, h1_count: 1 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'h1')).toBe(false)
+  })
+
+  // OG image rule
+  it('flags missing og:image as info', () => {
+    const signals = { ...baseSignals, og: { ...baseSignals.og, image: null } }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'og:image' && i.severity === 'info')).toBe(true)
+  })
+
+  it('does not flag og:image when present', () => {
+    const issues = runIssueRules(baseSignals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'og:image')).toBe(false)
+  })
+})
+
+describe('summarizeIssues', () => {
+  it('counts by severity', () => {
+    const issues: SeoIssue[] = [
+      { field: 'title', severity: 'error', message: 'e' },
+      { field: 'desc', severity: 'warning', message: 'w' },
+      { field: 'desc2', severity: 'warning', message: 'w2' },
+      { field: 'og', severity: 'info', message: 'i' },
+    ]
+    const s = summarizeIssues(issues)
+    expect(s.errors).toBe(1)
+    expect(s.warnings).toBe(2)
+    expect(s.infos).toBe(1)
+  })
+
+  it('returns zeros for empty list', () => {
+    const s = summarizeIssues([])
+    expect(s.errors).toBe(0)
+    expect(s.warnings).toBe(0)
+    expect(s.infos).toBe(0)
+  })
+})

--- a/mcp/src/tools/issue-rules.ts
+++ b/mcp/src/tools/issue-rules.ts
@@ -1,0 +1,109 @@
+// ============================================================================
+// issue-rules.ts — pure issue detection engine, no I/O
+// ============================================================================
+
+import type { HtmlSignals } from './html-signals.js'
+
+export interface SeoIssue {
+  field: string
+  severity: 'error' | 'warning' | 'info'
+  message: string
+}
+
+export interface IssueSummary {
+  errors: number
+  warnings: number
+  infos: number
+}
+
+export function runIssueRules(signals: HtmlSignals, finalUrl: string): SeoIssue[] {
+  const issues: SeoIssue[] = []
+
+  // Title
+  if (!signals.title) {
+    issues.push({ field: 'title', severity: 'error', message: 'Page is missing a <title> tag' })
+  } else {
+    if (signals.title_length < 10) {
+      issues.push({
+        field: 'title',
+        severity: 'warning',
+        message: `Title is too short (${signals.title_length} chars, minimum 10)`,
+      })
+    } else if (signals.title_length > 70) {
+      issues.push({
+        field: 'title',
+        severity: 'warning',
+        message: `Title may be truncated in SERPs (${signals.title_length} chars, max 70)`,
+      })
+    }
+  }
+
+  // Description
+  if (!signals.description) {
+    issues.push({ field: 'description', severity: 'warning', message: 'Page is missing a meta description' })
+  } else if (signals.description_length > 160) {
+    issues.push({
+      field: 'description',
+      severity: 'warning',
+      message: `Meta description may be truncated (${signals.description_length} chars, max 160)`,
+    })
+  }
+
+  // Canonical
+  if (!signals.canonical) {
+    issues.push({ field: 'canonical', severity: 'warning', message: 'Page is missing a canonical link tag' })
+  } else {
+    try {
+      const canonicalHost = new URL(signals.canonical).hostname
+      const finalHost = new URL(finalUrl).hostname
+      if (canonicalHost !== finalHost) {
+        issues.push({
+          field: 'canonical',
+          severity: 'error',
+          message: `Canonical points to different domain: ${signals.canonical}`,
+        })
+      }
+    } catch {
+      issues.push({
+        field: 'canonical',
+        severity: 'warning',
+        message: `Canonical URL appears invalid: ${signals.canonical}`,
+      })
+    }
+  }
+
+  // Robots noindex
+  if (signals.noindex) {
+    issues.push({
+      field: 'robots',
+      severity: 'error',
+      message: `Page has noindex directive: ${signals.robots}`,
+    })
+  }
+
+  // H1
+  if (signals.h1_count === 0) {
+    issues.push({ field: 'h1', severity: 'warning', message: 'Page has no <h1> tag' })
+  } else if (signals.h1_count > 1) {
+    issues.push({
+      field: 'h1',
+      severity: 'warning',
+      message: `Page has multiple <h1> tags (${signals.h1_count})`,
+    })
+  }
+
+  // OG image
+  if (!signals.og.image) {
+    issues.push({ field: 'og:image', severity: 'info', message: 'Page is missing og:image meta tag' })
+  }
+
+  return issues
+}
+
+export function summarizeIssues(issues: SeoIssue[]): IssueSummary {
+  return {
+    errors: issues.filter((i) => i.severity === 'error').length,
+    warnings: issues.filter((i) => i.severity === 'warning').length,
+    infos: issues.filter((i) => i.severity === 'info').length,
+  }
+}

--- a/mcp/src/tools/seo-page-audit.test.ts
+++ b/mcp/src/tools/seo-page-audit.test.ts
@@ -1,0 +1,693 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  seoPageAuditInputSchema,
+  seoPageAuditTool,
+  extractTitle,
+  extractMetaContent,
+  extractCanonical,
+  countHreflang,
+  extractSchemaTypes,
+  detectIssues,
+  summarizeIssues,
+  fetchCwv,
+  runSeoPageAudit,
+  SeoSignals,
+} from './seo-page-audit.js'
+
+// ============================================================================
+// Input Schema Validation
+// ============================================================================
+
+describe('seoPageAuditInputSchema', () => {
+  it('accepts valid URL', () => {
+    const result = seoPageAuditInputSchema.safeParse({
+      url: 'https://example.com/',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('applies default user_agent (Googlebot)', () => {
+    const result = seoPageAuditInputSchema.safeParse({
+      url: 'https://example.com/',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.user_agent).toContain('Googlebot')
+    }
+  })
+
+  it('applies default check_cwv=false', () => {
+    const result = seoPageAuditInputSchema.safeParse({
+      url: 'https://example.com/',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.check_cwv).toBe(false)
+    }
+  })
+
+  it('applies default psi_strategy=mobile', () => {
+    const result = seoPageAuditInputSchema.safeParse({
+      url: 'https://example.com/',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.psi_strategy).toBe('mobile')
+    }
+  })
+
+  it('accepts full input with all options', () => {
+    const result = seoPageAuditInputSchema.safeParse({
+      url: 'https://example.com/page',
+      user_agent: 'MyBot/1.0',
+      check_cwv: true,
+      psi_api_key: 'my-api-key',
+      psi_strategy: 'desktop',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing url', () => {
+    const result = seoPageAuditInputSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid URL format', () => {
+    const result = seoPageAuditInputSchema.safeParse({
+      url: 'not-a-url',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid psi_strategy', () => {
+    const result = seoPageAuditInputSchema.safeParse({
+      url: 'https://example.com/',
+      psi_strategy: 'tablet',
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+// ============================================================================
+// HTML Signal Extraction
+// ============================================================================
+
+describe('extractTitle', () => {
+  it('extracts title from simple title tag', () => {
+    expect(extractTitle('<title>My Page Title</title>')).toBe('My Page Title')
+  })
+
+  it('returns null when no title tag', () => {
+    expect(extractTitle('<html><body>no title</body></html>')).toBeNull()
+  })
+
+  it('trims whitespace from title', () => {
+    expect(extractTitle('<title>  Trimmed Title  </title>')).toBe('Trimmed Title')
+  })
+
+  it('handles title with attributes', () => {
+    expect(extractTitle('<title lang="en">My Title</title>')).toBe('My Title')
+  })
+
+  it('collapses internal whitespace', () => {
+    expect(extractTitle('<title>My\n  Title</title>')).toBe('My Title')
+  })
+
+  it('returns null for empty title tag', () => {
+    expect(extractTitle('<title></title>')).toBeNull()
+  })
+})
+
+describe('extractMetaContent', () => {
+  it('extracts meta description content', () => {
+    const html = '<meta name="description" content="My description">'
+    expect(extractMetaContent(html, 'description')).toBe('My description')
+  })
+
+  it('extracts og:title content', () => {
+    const html = '<meta property="og:title" content="OG Title">'
+    expect(extractMetaContent(html, 'og:title')).toBe('OG Title')
+  })
+
+  it('handles reversed attribute order (content before name)', () => {
+    const html = '<meta content="My desc" name="description">'
+    expect(extractMetaContent(html, 'description')).toBe('My desc')
+  })
+
+  it('returns null when meta tag not present', () => {
+    expect(extractMetaContent('<html></html>', 'description')).toBeNull()
+  })
+
+  it('extracts robots meta content', () => {
+    const html = '<meta name="robots" content="noindex, nofollow">'
+    expect(extractMetaContent(html, 'robots')).toBe('noindex, nofollow')
+  })
+})
+
+describe('extractCanonical', () => {
+  it('extracts canonical href', () => {
+    const html = '<link rel="canonical" href="https://example.com/page">'
+    expect(extractCanonical(html)).toBe('https://example.com/page')
+  })
+
+  it('handles reversed attribute order (href before rel)', () => {
+    const html = '<link href="https://example.com/page" rel="canonical">'
+    expect(extractCanonical(html)).toBe('https://example.com/page')
+  })
+
+  it('returns null when no canonical tag', () => {
+    expect(extractCanonical('<html></html>')).toBeNull()
+  })
+})
+
+describe('countHreflang', () => {
+  it('counts hreflang link tags', () => {
+    const html = `
+      <link rel="alternate" hreflang="en" href="https://example.com/">
+      <link rel="alternate" hreflang="es" href="https://example.com/es/">
+      <link rel="alternate" hreflang="x-default" href="https://example.com/">
+    `
+    expect(countHreflang(html)).toBe(3)
+  })
+
+  it('returns 0 when no hreflang tags', () => {
+    expect(countHreflang('<html></html>')).toBe(0)
+  })
+})
+
+describe('extractSchemaTypes', () => {
+  it('extracts single @type from JSON-LD', () => {
+    const html = `
+      <script type="application/ld+json">
+        {"@context": "https://schema.org", "@type": "Article"}
+      </script>
+    `
+    const types = extractSchemaTypes(html)
+    expect(types).toContain('Article')
+  })
+
+  it('extracts multiple types from @graph', () => {
+    const html = `
+      <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@graph": [
+            {"@type": "WebPage"},
+            {"@type": "BreadcrumbList"}
+          ]
+        }
+      </script>
+    `
+    const types = extractSchemaTypes(html)
+    expect(types).toContain('WebPage')
+    expect(types).toContain('BreadcrumbList')
+  })
+
+  it('handles array @type values', () => {
+    const html = `
+      <script type="application/ld+json">
+        {"@type": ["Article", "NewsArticle"]}
+      </script>
+    `
+    const types = extractSchemaTypes(html)
+    expect(types).toContain('Article')
+    expect(types).toContain('NewsArticle')
+  })
+
+  it('deduplicates types', () => {
+    const html = `
+      <script type="application/ld+json">{"@type": "Article"}</script>
+      <script type="application/ld+json">{"@type": "Article"}</script>
+    `
+    const types = extractSchemaTypes(html)
+    expect(types.filter((t) => t === 'Article')).toHaveLength(1)
+  })
+
+  it('returns empty array when no JSON-LD present', () => {
+    expect(extractSchemaTypes('<html></html>')).toHaveLength(0)
+  })
+
+  it('gracefully handles invalid JSON-LD', () => {
+    const html = `<script type="application/ld+json">{ invalid json }</script>`
+    expect(() => extractSchemaTypes(html)).not.toThrow()
+    expect(extractSchemaTypes(html)).toHaveLength(0)
+  })
+})
+
+// ============================================================================
+// Issue Detection Rules
+// ============================================================================
+
+const baseSignals: SeoSignals = {
+  title: 'A Good Page Title Here',
+  title_length: 25,
+  description: 'A good meta description for this page content.',
+  description_length: 47,
+  canonical: 'https://example.com/page',
+  robots: null,
+  noindex: false,
+  og: {
+    title: 'OG Title',
+    description: 'OG Description',
+    image: 'https://example.com/image.jpg',
+    type: 'article',
+  },
+  schema_types: ['Article'],
+  h1_count: 1,
+  h2_count: 3,
+  hreflang_count: 0,
+}
+
+describe('detectIssues', () => {
+  const finalUrl = 'https://example.com/page'
+
+  it('returns no issues for a perfect page', () => {
+    const issues = detectIssues(baseSignals, finalUrl)
+    expect(issues).toHaveLength(0)
+  })
+
+  it('flags missing title as error', () => {
+    const signals = { ...baseSignals, title: null, title_length: 0 }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'title' && i.severity === 'error')).toBe(true)
+  })
+
+  it('flags short title as warning', () => {
+    const signals = { ...baseSignals, title: 'Hi', title_length: 2 }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'title' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('flags long title as warning', () => {
+    const longTitle = 'A'.repeat(65)
+    const signals = { ...baseSignals, title: longTitle, title_length: 65 }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'title' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('accepts title exactly at 60 chars', () => {
+    const signals = { ...baseSignals, title: 'A'.repeat(60), title_length: 60 }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'title')).toBe(false)
+  })
+
+  it('flags missing description as warning', () => {
+    const signals = { ...baseSignals, description: null, description_length: 0 }
+    const issues = detectIssues(signals, finalUrl)
+    expect(
+      issues.some((i) => i.field === 'description' && i.severity === 'warning'),
+    ).toBe(true)
+  })
+
+  it('flags long description as warning', () => {
+    const longDesc = 'A'.repeat(165)
+    const signals = {
+      ...baseSignals,
+      description: longDesc,
+      description_length: 165,
+    }
+    const issues = detectIssues(signals, finalUrl)
+    expect(
+      issues.some((i) => i.field === 'description' && i.severity === 'warning'),
+    ).toBe(true)
+  })
+
+  it('flags missing canonical as warning', () => {
+    const signals = { ...baseSignals, canonical: null }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'canonical' && i.severity === 'warning')).toBe(
+      true,
+    )
+  })
+
+  it('flags canonical pointing to different domain as error', () => {
+    const signals = {
+      ...baseSignals,
+      canonical: 'https://other-domain.com/page',
+    }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'canonical' && i.severity === 'error')).toBe(
+      true,
+    )
+  })
+
+  it('accepts canonical on same domain', () => {
+    const signals = { ...baseSignals, canonical: 'https://example.com/page' }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'canonical')).toBe(false)
+  })
+
+  it('flags noindex as error', () => {
+    const signals = {
+      ...baseSignals,
+      robots: 'noindex',
+      noindex: true,
+    }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'robots' && i.severity === 'error')).toBe(true)
+  })
+
+  it('flags missing h1 as warning', () => {
+    const signals = { ...baseSignals, h1_count: 0 }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'h1' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('flags multiple h1 as warning', () => {
+    const signals = { ...baseSignals, h1_count: 3 }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'h1' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('flags missing og:image as info', () => {
+    const signals = {
+      ...baseSignals,
+      og: { ...baseSignals.og, image: null },
+    }
+    const issues = detectIssues(signals, finalUrl)
+    expect(issues.some((i) => i.field === 'og:image' && i.severity === 'info')).toBe(true)
+  })
+})
+
+describe('summarizeIssues', () => {
+  it('counts issues by severity', () => {
+    const issues = [
+      { field: 'title', severity: 'error' as const, message: 'error' },
+      { field: 'desc', severity: 'warning' as const, message: 'warning' },
+      { field: 'desc2', severity: 'warning' as const, message: 'warning2' },
+      { field: 'og', severity: 'info' as const, message: 'info' },
+    ]
+    const summary = summarizeIssues(issues)
+    expect(summary.errors).toBe(1)
+    expect(summary.warnings).toBe(2)
+    expect(summary.infos).toBe(1)
+  })
+
+  it('returns zeros for empty issues', () => {
+    const summary = summarizeIssues([])
+    expect(summary.errors).toBe(0)
+    expect(summary.warnings).toBe(0)
+    expect(summary.infos).toBe(0)
+  })
+})
+
+// ============================================================================
+// fetchCwv — mocked PSI
+// ============================================================================
+
+describe('fetchCwv', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('extracts CWV metrics from PSI response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            lighthouseResult: {
+              categories: { performance: { score: 0.85 } },
+              audits: {
+                'largest-contentful-paint': { numericValue: 2500 },
+                'first-contentful-paint': { numericValue: 1200 },
+                'cumulative-layout-shift': { numericValue: 0.05 },
+                'total-blocking-time': { numericValue: 300 },
+              },
+            },
+          }),
+      }),
+    )
+
+    const cwv = await fetchCwv('https://example.com/', 'mobile')
+
+    expect(cwv.lcp).toBe(2500)
+    expect(cwv.fcp).toBe(1200)
+    expect(cwv.cls).toBe(0.05)
+    expect(cwv.tbt).toBe(300)
+    expect(cwv.performance_score).toBe(85)
+    expect(cwv.strategy).toBe('mobile')
+  })
+
+  it('includes API key in URL when provided', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lighthouseResult: { categories: {}, audits: {} } }),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    await fetchCwv('https://example.com/', 'desktop', 'my-api-key')
+
+    const [url] = mockFetch.mock.calls[0] as [string]
+    expect(url).toContain('key=my-api-key')
+    expect(url).toContain('strategy=desktop')
+  })
+
+  it('throws on PSI API error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('Bad Request'),
+      }),
+    )
+
+    await expect(fetchCwv('https://example.com/', 'mobile')).rejects.toThrow(
+      'PSI API error (HTTP 400)',
+    )
+  })
+})
+
+// ============================================================================
+// runSeoPageAudit — integration (mocked fetch)
+// ============================================================================
+
+describe('runSeoPageAudit', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  const SAMPLE_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Test Page Title Here</title>
+  <meta name="description" content="A test page description that is reasonable length.">
+  <link rel="canonical" href="https://example.com/test-page">
+  <meta property="og:title" content="OG Title">
+  <meta property="og:description" content="OG Description">
+  <meta property="og:image" content="https://example.com/img.jpg">
+  <script type="application/ld+json">{"@type": "WebPage"}</script>
+</head>
+<body>
+  <h1>Main Heading</h1>
+  <h2>Sub Heading 1</h2>
+  <h2>Sub Heading 2</h2>
+</body>
+</html>
+`
+
+  it('returns successful audit for well-formed page', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: 'https://example.com/test-page',
+        text: () => Promise.resolve(SAMPLE_HTML),
+      }),
+    )
+
+    const input = seoPageAuditInputSchema.parse({
+      url: 'https://example.com/test-page',
+    })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(true)
+    expect(result.status_code).toBe(200)
+    expect(result.signals.title).toBe('Test Page Title Here')
+    expect(result.signals.h1_count).toBe(1)
+    expect(result.signals.h2_count).toBe(2)
+    expect(result.signals.schema_types).toContain('WebPage')
+    expect(result.cwv).toBeUndefined()
+  })
+
+  it('includes status error issue for non-2xx status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        url: 'https://example.com/missing',
+        text: () => Promise.resolve('<html><body>Not Found</body></html>'),
+      }),
+    )
+
+    const input = seoPageAuditInputSchema.parse({
+      url: 'https://example.com/missing',
+    })
+    const result = await runSeoPageAudit(input)
+
+    // success=true but status_code reflects the 404
+    expect(result.success).toBe(true)
+    expect(result.status_code).toBe(404)
+    expect(result.issues.some((i) => i.field === 'status' && i.severity === 'error')).toBe(
+      true,
+    )
+  })
+
+  it('returns success=false on fetch timeout/error', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(
+        Object.assign(new Error('The operation was aborted'), { name: 'TimeoutError' }),
+      ),
+    )
+
+    const input = seoPageAuditInputSchema.parse({
+      url: 'https://example.com/slow-page',
+    })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('timed out')
+  })
+
+  it('includes cwv when check_cwv=true and PSI succeeds', async () => {
+    // First fetch: the page HTML
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        url: 'https://example.com/page',
+        text: () => Promise.resolve(SAMPLE_HTML),
+      })
+      // Second fetch: PSI
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            lighthouseResult: {
+              categories: { performance: { score: 0.9 } },
+              audits: {
+                'largest-contentful-paint': { numericValue: 2000 },
+                'first-contentful-paint': { numericValue: 1000 },
+                'cumulative-layout-shift': { numericValue: 0.01 },
+                'total-blocking-time': { numericValue: 200 },
+              },
+            },
+          }),
+      })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const input = seoPageAuditInputSchema.parse({
+      url: 'https://example.com/page',
+      check_cwv: true,
+    })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(true)
+    expect(result.cwv).toBeDefined()
+    expect(result.cwv?.performance_score).toBe(90)
+    expect(result.cwv_error).toBeUndefined()
+  })
+
+  it('sets cwv_error when PSI fails and omits cwv', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          url: 'https://example.com/page',
+          text: () => Promise.resolve(SAMPLE_HTML),
+        })
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          text: () => Promise.resolve('Rate Limited'),
+        }),
+    )
+
+    const input = seoPageAuditInputSchema.parse({
+      url: 'https://example.com/page',
+      check_cwv: true,
+    })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(true)
+    expect(result.cwv).toBeUndefined()
+    expect(result.cwv_error).toBeDefined()
+  })
+
+  it('uses Googlebot user-agent by default', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: 'https://example.com/',
+      text: () => Promise.resolve('<html><head><title>Test</title></head><body><h1>H</h1></body></html>'),
+    })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const input = seoPageAuditInputSchema.parse({
+      url: 'https://example.com/',
+    })
+    await runSeoPageAudit(input)
+
+    const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const headers = options.headers as Record<string, string>
+    expect(headers['User-Agent']).toContain('Googlebot')
+  })
+
+  it('returns issue_summary with correct counts', async () => {
+    // Minimal page: missing description, missing og:image, missing h1
+    const minimalHtml = `<html><head><title>OK Title Length Here</title><link rel="canonical" href="https://example.com/"></head><body></body></html>`
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: 'https://example.com/',
+        text: () => Promise.resolve(minimalHtml),
+      }),
+    )
+
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/' })
+    const result = await runSeoPageAudit(input)
+
+    // Expect: missing description (warning), missing og:image (info), missing h1 (warning)
+    expect(result.issue_summary.warnings).toBeGreaterThanOrEqual(2)
+    expect(result.issue_summary.infos).toBeGreaterThanOrEqual(1)
+  })
+})
+
+// ============================================================================
+// Tool Definition
+// ============================================================================
+
+describe('seoPageAuditTool definition', () => {
+  it('has correct tool name', () => {
+    expect(seoPageAuditTool.name).toBe('seo_page_audit')
+  })
+
+  it('has a descriptive description', () => {
+    expect(seoPageAuditTool.description).toContain('SEO')
+    expect(seoPageAuditTool.description).toContain('Googlebot')
+  })
+
+  it('requires url field', () => {
+    expect(seoPageAuditTool.inputSchema.required).toContain('url')
+  })
+
+  it('defines all optional parameters', () => {
+    const props = seoPageAuditTool.inputSchema.properties
+    expect(props.user_agent).toBeDefined()
+    expect(props.check_cwv).toBeDefined()
+    expect(props.psi_api_key).toBeDefined()
+    expect(props.psi_strategy).toBeDefined()
+  })
+})

--- a/mcp/src/tools/seo-page-audit.test.ts
+++ b/mcp/src/tools/seo-page-audit.test.ts
@@ -26,13 +26,13 @@ describe('seoPageAuditInputSchema', () => {
     expect(result.success).toBe(true)
   })
 
-  it('applies default user_agent (Googlebot)', () => {
+  it('applies default user_agent (GA4Manager honest UA)', () => {
     const result = seoPageAuditInputSchema.safeParse({
       url: 'https://example.com/',
     })
     expect(result.success).toBe(true)
     if (result.success) {
-      expect(result.data.user_agent).toContain('Googlebot')
+      expect(result.data.user_agent).toContain('GA4Manager-SEO-Auditor')
     }
   })
 
@@ -279,14 +279,14 @@ describe('detectIssues', () => {
   })
 
   it('flags long title as warning', () => {
-    const longTitle = 'A'.repeat(65)
-    const signals = { ...baseSignals, title: longTitle, title_length: 65 }
+    const longTitle = 'A'.repeat(75)
+    const signals = { ...baseSignals, title: longTitle, title_length: 75 }
     const issues = detectIssues(signals, finalUrl)
     expect(issues.some((i) => i.field === 'title' && i.severity === 'warning')).toBe(true)
   })
 
-  it('accepts title exactly at 60 chars', () => {
-    const signals = { ...baseSignals, title: 'A'.repeat(60), title_length: 60 }
+  it('accepts title exactly at 70 chars', () => {
+    const signals = { ...baseSignals, title: 'A'.repeat(70), title_length: 70 }
     const issues = detectIssues(signals, finalUrl)
     expect(issues.some((i) => i.field === 'title')).toBe(false)
   })
@@ -624,7 +624,7 @@ describe('runSeoPageAudit', () => {
     expect(result.cwv_error).toBeDefined()
   })
 
-  it('uses Googlebot user-agent by default', async () => {
+  it('uses GA4Manager honest user-agent by default', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -640,7 +640,7 @@ describe('runSeoPageAudit', () => {
 
     const [, options] = mockFetch.mock.calls[0] as [string, RequestInit]
     const headers = options.headers as Record<string, string>
-    expect(headers['User-Agent']).toContain('Googlebot')
+    expect(headers['User-Agent']).toContain('GA4Manager-SEO-Auditor')
   })
 
   it('returns issue_summary with correct counts', async () => {
@@ -674,9 +674,9 @@ describe('seoPageAuditTool definition', () => {
     expect(seoPageAuditTool.name).toBe('seo_page_audit')
   })
 
-  it('has a descriptive description', () => {
+  it('has a use-case-first description', () => {
     expect(seoPageAuditTool.description).toContain('SEO')
-    expect(seoPageAuditTool.description).toContain('Googlebot')
+    expect(seoPageAuditTool.description.toLowerCase()).toContain('use when')
   })
 
   it('requires url field', () => {

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -1,62 +1,66 @@
 import { z } from 'zod'
+import { extractSignals, type HtmlSignals } from './html-signals.js'
+import { runIssueRules, summarizeIssues, type SeoIssue, type IssueSummary } from './issue-rules.js'
+
+// Re-export granular helpers so existing imports continue to work
+export {
+  extractTitle,
+  extractMetaContent,
+  extractCanonical,
+  countHreflang,
+  extractSchemaTypes,
+  extractSignals,
+  type HtmlSignals,
+} from './html-signals.js'
+export {
+  runIssueRules as detectIssues,
+  summarizeIssues,
+  type SeoIssue,
+  type IssueSummary,
+} from './issue-rules.js'
 
 // ============================================================================
 // Input Schema
 // ============================================================================
 
-const GOOGLEBOT_UA =
-  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+const HONEST_UA =
+  'GA4Manager-SEO-Auditor/1.0 (+https://github.com/garbarok/ga4-manager)'
 
 export const seoPageAuditInputSchema = z.object({
-  /** URL to audit */
-  url: z.string().url('url must be a valid URL'),
-  /** User-Agent string (default: Googlebot UA) */
-  user_agent: z.string().optional().default(GOOGLEBOT_UA),
-  /** Whether to check Core Web Vitals via PageSpeed Insights */
-  check_cwv: z.boolean().optional().default(false),
-  /** PageSpeed Insights API key (optional) */
-  psi_api_key: z.string().optional(),
-  /** PSI strategy (default: mobile) */
-  psi_strategy: z.enum(['mobile', 'desktop']).optional().default('mobile'),
+  url: z
+    .string()
+    .url('url must be a valid URL')
+    .describe('Fully-qualified URL to audit, e.g. "https://example.com/page"'),
+  user_agent: z
+    .string()
+    .optional()
+    .default(HONEST_UA)
+    .describe(`User-Agent header sent with the request. Default: "${HONEST_UA}"`),
+  check_cwv: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Set true to fetch Core Web Vitals via PageSpeed Insights API'),
+  psi_api_key: z
+    .string()
+    .optional()
+    .describe('PageSpeed Insights API key (optional). Without key PSI rate-limits to ~1 req/100s'),
+  psi_strategy: z
+    .enum(['mobile', 'desktop'])
+    .optional()
+    .default('mobile')
+    .describe('PSI analysis strategy. One of: "mobile" (default), "desktop"'),
 })
 
 export type SeoPageAuditInput = z.infer<typeof seoPageAuditInputSchema>
 
+// Keep SeoSignals as alias so existing test imports work
+export type SeoSignals = HtmlSignals
+export type SeoIssueSummary = IssueSummary
+
 // ============================================================================
 // Output Types
 // ============================================================================
-
-export interface SeoIssue {
-  field: string
-  severity: 'error' | 'warning' | 'info'
-  message: string
-}
-
-export interface SeoIssueSummary {
-  errors: number
-  warnings: number
-  infos: number
-}
-
-export interface SeoSignals {
-  title: string | null
-  title_length: number
-  description: string | null
-  description_length: number
-  canonical: string | null
-  robots: string | null
-  noindex: boolean
-  og: {
-    title: string | null
-    description: string | null
-    image: string | null
-    type: string | null
-  }
-  schema_types: string[]
-  h1_count: number
-  h2_count: number
-  hreflang_count: number
-}
 
 export interface CwvData {
   lcp: number
@@ -69,278 +73,16 @@ export interface CwvData {
 
 export interface SeoPageAuditOutput {
   success: boolean
+  warnings: string[]
   url: string
   final_url: string
   status_code: number
-  signals: SeoSignals
+  signals: HtmlSignals
   issues: SeoIssue[]
-  issue_summary: SeoIssueSummary
+  issue_summary: IssueSummary
   cwv?: CwvData
   cwv_error?: string
   error?: string
-}
-
-// ============================================================================
-// Native HTML Signal Extraction
-// ============================================================================
-
-/**
- * Count all occurrences of a pattern
- */
-function countMatches(html: string, pattern: RegExp): number {
-  const matches = html.match(new RegExp(pattern.source, 'gi'))
-  return matches ? matches.length : 0
-}
-
-/**
- * Extract the page title from HTML
- */
-export function extractTitle(html: string): string | null {
-  const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
-  if (!match) return null
-  return match[1].replace(/\s+/g, ' ').trim() || null
-}
-
-/**
- * Extract a meta tag content value
- */
-export function extractMetaContent(
-  html: string,
-  name: string,
-): string | null {
-  // Match <meta name="..." content="..."> or <meta content="..." name="...">
-  const pattern = new RegExp(
-    `<meta[^>]+(?:name|property)=["']${name}["'][^>]+content=["']([^"']*)["']|` +
-      `<meta[^>]+content=["']([^"']*)["'][^>]+(?:name|property)=["']${name}["']`,
-    'i',
-  )
-  const match = html.match(pattern)
-  if (!match) return null
-  return (match[1] ?? match[2] ?? null)?.trim() || null
-}
-
-/**
- * Extract the canonical URL
- */
-export function extractCanonical(html: string): string | null {
-  const match = html.match(
-    /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']|<link[^>]+href=["']([^"']+)["'][^>]+rel=["']canonical["']/i,
-  )
-  if (!match) return null
-  return (match[1] ?? match[2] ?? null)?.trim() || null
-}
-
-/**
- * Count hreflang link tags
- */
-export function countHreflang(html: string): number {
-  return countMatches(html, /<link[^>]+hreflang=/i)
-}
-
-/**
- * Extract all JSON-LD @type values
- */
-export function extractSchemaTypes(html: string): string[] {
-  const types: string[] = []
-  const scriptPattern =
-    /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
-  let match: RegExpExecArray | null
-
-  while ((match = scriptPattern.exec(html)) !== null) {
-    try {
-      const parsed = JSON.parse(match[1]) as Record<string, unknown> | unknown[]
-      const extractType = (obj: unknown): void => {
-        if (Array.isArray(obj)) {
-          obj.forEach(extractType)
-        } else if (obj && typeof obj === 'object') {
-          const record = obj as Record<string, unknown>
-          if (record['@type']) {
-            const t = record['@type']
-            if (Array.isArray(t)) {
-              types.push(...(t as string[]))
-            } else if (typeof t === 'string') {
-              types.push(t)
-            }
-          }
-          // Also check @graph
-          if (Array.isArray(record['@graph'])) {
-            record['@graph'].forEach(extractType)
-          }
-        }
-      }
-      extractType(parsed)
-    } catch {
-      // Invalid JSON-LD — skip
-    }
-  }
-
-  return [...new Set(types)] // deduplicate
-}
-
-/**
- * Extract all SEO signals from HTML
- */
-export function extractSignals(html: string, _finalUrl: string): SeoSignals {
-  const title = extractTitle(html)
-  const description = extractMetaContent(html, 'description')
-  const canonical = extractCanonical(html)
-  const robots = extractMetaContent(html, 'robots')
-
-  const og = {
-    title: extractMetaContent(html, 'og:title'),
-    description: extractMetaContent(html, 'og:description'),
-    image: extractMetaContent(html, 'og:image'),
-    type: extractMetaContent(html, 'og:type'),
-  }
-
-  const schema_types = extractSchemaTypes(html)
-  const h1_count = countMatches(html, /<h1[\s>]/i)
-  const h2_count = countMatches(html, /<h2[\s>]/i)
-  const hreflang_count = countHreflang(html)
-
-  const noindex = robots ? /noindex/i.test(robots) : false
-
-  return {
-    title,
-    title_length: title ? title.length : 0,
-    description,
-    description_length: description ? description.length : 0,
-    canonical,
-    robots,
-    noindex,
-    og,
-    schema_types,
-    h1_count,
-    h2_count,
-    hreflang_count,
-  }
-}
-
-// ============================================================================
-// Issue Rules
-// ============================================================================
-
-/**
- * Run issue detection rules against signals
- */
-export function detectIssues(
-  signals: SeoSignals,
-  finalUrl: string,
-): SeoIssue[] {
-  const issues: SeoIssue[] = []
-
-  // Title rules
-  if (!signals.title) {
-    issues.push({
-      field: 'title',
-      severity: 'error',
-      message: 'Page is missing a <title> tag',
-    })
-  } else {
-    if (signals.title_length < 10) {
-      issues.push({
-        field: 'title',
-        severity: 'warning',
-        message: `Title is too short (${signals.title_length} chars, minimum 10)`,
-      })
-    } else if (signals.title_length > 60) {
-      issues.push({
-        field: 'title',
-        severity: 'warning',
-        message: `Title may be truncated in SERPs (${signals.title_length} chars, max 60)`,
-      })
-    }
-  }
-
-  // Description rules
-  if (!signals.description) {
-    issues.push({
-      field: 'description',
-      severity: 'warning',
-      message: 'Page is missing a meta description',
-    })
-  } else if (signals.description_length > 160) {
-    issues.push({
-      field: 'description',
-      severity: 'warning',
-      message: `Meta description may be truncated (${signals.description_length} chars, max 160)`,
-    })
-  }
-
-  // Canonical rules
-  if (!signals.canonical) {
-    issues.push({
-      field: 'canonical',
-      severity: 'warning',
-      message: 'Page is missing a canonical link tag',
-    })
-  } else {
-    // Check if canonical points to a different domain
-    try {
-      const canonicalHost = new URL(signals.canonical).hostname
-      const finalHost = new URL(finalUrl).hostname
-      if (canonicalHost !== finalHost) {
-        issues.push({
-          field: 'canonical',
-          severity: 'error',
-          message: `Canonical points to different domain: ${signals.canonical}`,
-        })
-      }
-    } catch {
-      // Invalid URL in canonical — flag as warning
-      issues.push({
-        field: 'canonical',
-        severity: 'warning',
-        message: `Canonical URL appears invalid: ${signals.canonical}`,
-      })
-    }
-  }
-
-  // Robots rules
-  if (signals.noindex) {
-    issues.push({
-      field: 'robots',
-      severity: 'error',
-      message: `Page has noindex directive: ${signals.robots}`,
-    })
-  }
-
-  // H1 rules
-  if (signals.h1_count === 0) {
-    issues.push({
-      field: 'h1',
-      severity: 'warning',
-      message: 'Page has no <h1> tag',
-    })
-  } else if (signals.h1_count > 1) {
-    issues.push({
-      field: 'h1',
-      severity: 'warning',
-      message: `Page has multiple <h1> tags (${signals.h1_count})`,
-    })
-  }
-
-  // OG image
-  if (!signals.og.image) {
-    issues.push({
-      field: 'og:image',
-      severity: 'info',
-      message: 'Page is missing og:image meta tag',
-    })
-  }
-
-  return issues
-}
-
-/**
- * Summarize issues by severity
- */
-export function summarizeIssues(issues: SeoIssue[]): SeoIssueSummary {
-  return {
-    errors: issues.filter((i) => i.severity === 'error').length,
-    warnings: issues.filter((i) => i.severity === 'warning').length,
-    infos: issues.filter((i) => i.severity === 'info').length,
-  }
 }
 
 // ============================================================================
@@ -349,9 +91,7 @@ export function summarizeIssues(issues: SeoIssue[]): SeoIssueSummary {
 
 interface PsiResponse {
   lighthouseResult?: {
-    categories?: {
-      performance?: { score?: number }
-    }
+    categories?: { performance?: { score?: number } }
     audits?: {
       'largest-contentful-paint'?: { numericValue?: number }
       'first-contentful-paint'?: { numericValue?: number }
@@ -361,25 +101,15 @@ interface PsiResponse {
   }
 }
 
-/**
- * Fetch Core Web Vitals from PageSpeed Insights API
- */
 export async function fetchCwv(
   url: string,
   strategy: 'mobile' | 'desktop',
   apiKey?: string,
 ): Promise<CwvData> {
-  const params = new URLSearchParams({
-    url,
-    strategy,
-    category: 'performance',
-  })
-  if (apiKey) {
-    params.set('key', apiKey)
-  }
+  const params = new URLSearchParams({ url, strategy, category: 'performance' })
+  if (apiKey) params.set('key', apiKey)
 
   const psiUrl = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?${params.toString()}`
-
   const response = await fetch(psiUrl, { signal: AbortSignal.timeout(30000) })
 
   if (!response.ok) {
@@ -408,28 +138,24 @@ export async function fetchCwv(
 
 const FETCH_TIMEOUT_MS = 10_000
 
-/**
- * Run the full seo_page_audit tool
- */
-export async function runSeoPageAudit(
-  input: SeoPageAuditInput,
-): Promise<SeoPageAuditOutput> {
-  const { url, user_agent, check_cwv, psi_api_key, psi_strategy } = input
+const emptySignals: HtmlSignals = {
+  title: null,
+  title_length: 0,
+  description: null,
+  description_length: 0,
+  canonical: null,
+  robots: null,
+  noindex: false,
+  og: { title: null, description: null, image: null, type: null },
+  schema_types: [],
+  h1_count: 0,
+  h2_count: 0,
+  hreflang_count: 0,
+}
 
-  const emptySignals: SeoSignals = {
-    title: null,
-    title_length: 0,
-    description: null,
-    description_length: 0,
-    canonical: null,
-    robots: null,
-    noindex: false,
-    og: { title: null, description: null, image: null, type: null },
-    schema_types: [],
-    h1_count: 0,
-    h2_count: 0,
-    hreflang_count: 0,
-  }
+export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPageAuditOutput> {
+  const { url, user_agent, check_cwv, psi_api_key, psi_strategy } = input
+  const warnings: string[] = []
 
   let fetchResponse: Response
   let finalUrl: string
@@ -454,6 +180,7 @@ export async function runSeoPageAudit(
         : String(err)
     return {
       success: false,
+      warnings,
       url,
       final_url: url,
       status_code: 0,
@@ -464,25 +191,15 @@ export async function runSeoPageAudit(
     }
   }
 
-  // Extract signals even for non-2xx (still parse what we have)
   const signals = extractSignals(html, finalUrl)
-  let issues = detectIssues(signals, finalUrl)
+  let issues = runIssueRules(signals, finalUrl)
 
-  // Flag non-2xx status as an issue
   if (statusCode < 200 || statusCode >= 300) {
-    issues = [
-      {
-        field: 'status',
-        severity: 'error',
-        message: `Page returned HTTP ${statusCode}`,
-      },
-      ...issues,
-    ]
+    issues = [{ field: 'status', severity: 'error', message: `Page returned HTTP ${statusCode}` }, ...issues]
   }
 
   const issue_summary = summarizeIssues(issues)
 
-  // Core Web Vitals (optional)
   let cwv: CwvData | undefined
   let cwv_error: string | undefined
 
@@ -496,6 +213,7 @@ export async function runSeoPageAudit(
 
   return {
     success: true,
+    warnings,
     url,
     final_url: finalUrl,
     status_code: statusCode,
@@ -514,8 +232,9 @@ export async function runSeoPageAudit(
 export const seoPageAuditTool = {
   name: 'seo_page_audit',
   description:
-    'Fetch a URL as Googlebot and audit on-page SEO signals: title, meta description, canonical, robots, Open Graph, Schema.org types, h1/h2 counts, hreflang. ' +
-    'Returns structured issues list with severity (error/warning/info). ' +
+    'Use when auditing a single page for SEO problems: missing title or description, bad canonical, noindex directives, missing OG image, heading structure issues. ' +
+    'Fetches the URL and parses on-page signals (title, meta description, canonical, robots, Open Graph, Schema.org types, h1/h2 counts, hreflang). ' +
+    'Returns a structured issues list with severity (error/warning/info). ' +
     'Optionally checks Core Web Vitals via PageSpeed Insights API.',
   inputSchema: {
     type: 'object',
@@ -523,28 +242,26 @@ export const seoPageAuditTool = {
     properties: {
       url: {
         type: 'string',
-        description: 'URL to audit (must be publicly accessible)',
+        description: 'Fully-qualified URL to audit, e.g. "https://example.com/page"',
       },
       user_agent: {
         type: 'string',
-        description: `User-Agent string for the request (default: Googlebot UA)`,
-        default: GOOGLEBOT_UA,
+        description: `User-Agent header. Default: "${HONEST_UA}"`,
+        default: HONEST_UA,
       },
       check_cwv: {
         type: 'boolean',
-        description:
-          'Check Core Web Vitals via PageSpeed Insights API (default: false)',
+        description: 'Set true to fetch Core Web Vitals via PageSpeed Insights (default: false)',
         default: false,
       },
       psi_api_key: {
         type: 'string',
-        description:
-          'PageSpeed Insights API key (optional — PSI works without key but rate-limits at ~1 req/100s)',
+        description: 'PageSpeed Insights API key (optional — without key PSI rate-limits to ~1 req/100s)',
       },
       psi_strategy: {
         type: 'string',
         enum: ['mobile', 'desktop'],
-        description: 'PSI analysis strategy (default: mobile)',
+        description: 'PSI analysis strategy. One of: "mobile" (default), "desktop"',
         default: 'mobile',
       },
     },

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -1,0 +1,552 @@
+import { z } from 'zod'
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+const GOOGLEBOT_UA =
+  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+
+export const seoPageAuditInputSchema = z.object({
+  /** URL to audit */
+  url: z.string().url('url must be a valid URL'),
+  /** User-Agent string (default: Googlebot UA) */
+  user_agent: z.string().optional().default(GOOGLEBOT_UA),
+  /** Whether to check Core Web Vitals via PageSpeed Insights */
+  check_cwv: z.boolean().optional().default(false),
+  /** PageSpeed Insights API key (optional) */
+  psi_api_key: z.string().optional(),
+  /** PSI strategy (default: mobile) */
+  psi_strategy: z.enum(['mobile', 'desktop']).optional().default('mobile'),
+})
+
+export type SeoPageAuditInput = z.infer<typeof seoPageAuditInputSchema>
+
+// ============================================================================
+// Output Types
+// ============================================================================
+
+export interface SeoIssue {
+  field: string
+  severity: 'error' | 'warning' | 'info'
+  message: string
+}
+
+export interface SeoIssueSummary {
+  errors: number
+  warnings: number
+  infos: number
+}
+
+export interface SeoSignals {
+  title: string | null
+  title_length: number
+  description: string | null
+  description_length: number
+  canonical: string | null
+  robots: string | null
+  noindex: boolean
+  og: {
+    title: string | null
+    description: string | null
+    image: string | null
+    type: string | null
+  }
+  schema_types: string[]
+  h1_count: number
+  h2_count: number
+  hreflang_count: number
+}
+
+export interface CwvData {
+  lcp: number
+  fcp: number
+  cls: number
+  tbt: number
+  performance_score: number
+  strategy: 'mobile' | 'desktop'
+}
+
+export interface SeoPageAuditOutput {
+  success: boolean
+  url: string
+  final_url: string
+  status_code: number
+  signals: SeoSignals
+  issues: SeoIssue[]
+  issue_summary: SeoIssueSummary
+  cwv?: CwvData
+  cwv_error?: string
+  error?: string
+}
+
+// ============================================================================
+// Native HTML Signal Extraction
+// ============================================================================
+
+/**
+ * Count all occurrences of a pattern
+ */
+function countMatches(html: string, pattern: RegExp): number {
+  const matches = html.match(new RegExp(pattern.source, 'gi'))
+  return matches ? matches.length : 0
+}
+
+/**
+ * Extract the page title from HTML
+ */
+export function extractTitle(html: string): string | null {
+  const match = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i)
+  if (!match) return null
+  return match[1].replace(/\s+/g, ' ').trim() || null
+}
+
+/**
+ * Extract a meta tag content value
+ */
+export function extractMetaContent(
+  html: string,
+  name: string,
+): string | null {
+  // Match <meta name="..." content="..."> or <meta content="..." name="...">
+  const pattern = new RegExp(
+    `<meta[^>]+(?:name|property)=["']${name}["'][^>]+content=["']([^"']*)["']|` +
+      `<meta[^>]+content=["']([^"']*)["'][^>]+(?:name|property)=["']${name}["']`,
+    'i',
+  )
+  const match = html.match(pattern)
+  if (!match) return null
+  return (match[1] ?? match[2] ?? null)?.trim() || null
+}
+
+/**
+ * Extract the canonical URL
+ */
+export function extractCanonical(html: string): string | null {
+  const match = html.match(
+    /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']|<link[^>]+href=["']([^"']+)["'][^>]+rel=["']canonical["']/i,
+  )
+  if (!match) return null
+  return (match[1] ?? match[2] ?? null)?.trim() || null
+}
+
+/**
+ * Count hreflang link tags
+ */
+export function countHreflang(html: string): number {
+  return countMatches(html, /<link[^>]+hreflang=/i)
+}
+
+/**
+ * Extract all JSON-LD @type values
+ */
+export function extractSchemaTypes(html: string): string[] {
+  const types: string[] = []
+  const scriptPattern =
+    /<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi
+  let match: RegExpExecArray | null
+
+  while ((match = scriptPattern.exec(html)) !== null) {
+    try {
+      const parsed = JSON.parse(match[1]) as Record<string, unknown> | unknown[]
+      const extractType = (obj: unknown): void => {
+        if (Array.isArray(obj)) {
+          obj.forEach(extractType)
+        } else if (obj && typeof obj === 'object') {
+          const record = obj as Record<string, unknown>
+          if (record['@type']) {
+            const t = record['@type']
+            if (Array.isArray(t)) {
+              types.push(...(t as string[]))
+            } else if (typeof t === 'string') {
+              types.push(t)
+            }
+          }
+          // Also check @graph
+          if (Array.isArray(record['@graph'])) {
+            record['@graph'].forEach(extractType)
+          }
+        }
+      }
+      extractType(parsed)
+    } catch {
+      // Invalid JSON-LD — skip
+    }
+  }
+
+  return [...new Set(types)] // deduplicate
+}
+
+/**
+ * Extract all SEO signals from HTML
+ */
+export function extractSignals(html: string, _finalUrl: string): SeoSignals {
+  const title = extractTitle(html)
+  const description = extractMetaContent(html, 'description')
+  const canonical = extractCanonical(html)
+  const robots = extractMetaContent(html, 'robots')
+
+  const og = {
+    title: extractMetaContent(html, 'og:title'),
+    description: extractMetaContent(html, 'og:description'),
+    image: extractMetaContent(html, 'og:image'),
+    type: extractMetaContent(html, 'og:type'),
+  }
+
+  const schema_types = extractSchemaTypes(html)
+  const h1_count = countMatches(html, /<h1[\s>]/i)
+  const h2_count = countMatches(html, /<h2[\s>]/i)
+  const hreflang_count = countHreflang(html)
+
+  const noindex = robots ? /noindex/i.test(robots) : false
+
+  return {
+    title,
+    title_length: title ? title.length : 0,
+    description,
+    description_length: description ? description.length : 0,
+    canonical,
+    robots,
+    noindex,
+    og,
+    schema_types,
+    h1_count,
+    h2_count,
+    hreflang_count,
+  }
+}
+
+// ============================================================================
+// Issue Rules
+// ============================================================================
+
+/**
+ * Run issue detection rules against signals
+ */
+export function detectIssues(
+  signals: SeoSignals,
+  finalUrl: string,
+): SeoIssue[] {
+  const issues: SeoIssue[] = []
+
+  // Title rules
+  if (!signals.title) {
+    issues.push({
+      field: 'title',
+      severity: 'error',
+      message: 'Page is missing a <title> tag',
+    })
+  } else {
+    if (signals.title_length < 10) {
+      issues.push({
+        field: 'title',
+        severity: 'warning',
+        message: `Title is too short (${signals.title_length} chars, minimum 10)`,
+      })
+    } else if (signals.title_length > 60) {
+      issues.push({
+        field: 'title',
+        severity: 'warning',
+        message: `Title may be truncated in SERPs (${signals.title_length} chars, max 60)`,
+      })
+    }
+  }
+
+  // Description rules
+  if (!signals.description) {
+    issues.push({
+      field: 'description',
+      severity: 'warning',
+      message: 'Page is missing a meta description',
+    })
+  } else if (signals.description_length > 160) {
+    issues.push({
+      field: 'description',
+      severity: 'warning',
+      message: `Meta description may be truncated (${signals.description_length} chars, max 160)`,
+    })
+  }
+
+  // Canonical rules
+  if (!signals.canonical) {
+    issues.push({
+      field: 'canonical',
+      severity: 'warning',
+      message: 'Page is missing a canonical link tag',
+    })
+  } else {
+    // Check if canonical points to a different domain
+    try {
+      const canonicalHost = new URL(signals.canonical).hostname
+      const finalHost = new URL(finalUrl).hostname
+      if (canonicalHost !== finalHost) {
+        issues.push({
+          field: 'canonical',
+          severity: 'error',
+          message: `Canonical points to different domain: ${signals.canonical}`,
+        })
+      }
+    } catch {
+      // Invalid URL in canonical — flag as warning
+      issues.push({
+        field: 'canonical',
+        severity: 'warning',
+        message: `Canonical URL appears invalid: ${signals.canonical}`,
+      })
+    }
+  }
+
+  // Robots rules
+  if (signals.noindex) {
+    issues.push({
+      field: 'robots',
+      severity: 'error',
+      message: `Page has noindex directive: ${signals.robots}`,
+    })
+  }
+
+  // H1 rules
+  if (signals.h1_count === 0) {
+    issues.push({
+      field: 'h1',
+      severity: 'warning',
+      message: 'Page has no <h1> tag',
+    })
+  } else if (signals.h1_count > 1) {
+    issues.push({
+      field: 'h1',
+      severity: 'warning',
+      message: `Page has multiple <h1> tags (${signals.h1_count})`,
+    })
+  }
+
+  // OG image
+  if (!signals.og.image) {
+    issues.push({
+      field: 'og:image',
+      severity: 'info',
+      message: 'Page is missing og:image meta tag',
+    })
+  }
+
+  return issues
+}
+
+/**
+ * Summarize issues by severity
+ */
+export function summarizeIssues(issues: SeoIssue[]): SeoIssueSummary {
+  return {
+    errors: issues.filter((i) => i.severity === 'error').length,
+    warnings: issues.filter((i) => i.severity === 'warning').length,
+    infos: issues.filter((i) => i.severity === 'info').length,
+  }
+}
+
+// ============================================================================
+// PageSpeed Insights
+// ============================================================================
+
+interface PsiResponse {
+  lighthouseResult?: {
+    categories?: {
+      performance?: { score?: number }
+    }
+    audits?: {
+      'largest-contentful-paint'?: { numericValue?: number }
+      'first-contentful-paint'?: { numericValue?: number }
+      'cumulative-layout-shift'?: { numericValue?: number }
+      'total-blocking-time'?: { numericValue?: number }
+    }
+  }
+}
+
+/**
+ * Fetch Core Web Vitals from PageSpeed Insights API
+ */
+export async function fetchCwv(
+  url: string,
+  strategy: 'mobile' | 'desktop',
+  apiKey?: string,
+): Promise<CwvData> {
+  const params = new URLSearchParams({
+    url,
+    strategy,
+    category: 'performance',
+  })
+  if (apiKey) {
+    params.set('key', apiKey)
+  }
+
+  const psiUrl = `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?${params.toString()}`
+
+  const response = await fetch(psiUrl, { signal: AbortSignal.timeout(30000) })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`PSI API error (HTTP ${response.status}): ${text}`)
+  }
+
+  const data = (await response.json()) as PsiResponse
+  const lr = data.lighthouseResult
+  const audits = lr?.audits ?? {}
+  const perfScore = lr?.categories?.performance?.score ?? 0
+
+  return {
+    lcp: Math.round(audits['largest-contentful-paint']?.numericValue ?? 0),
+    fcp: Math.round(audits['first-contentful-paint']?.numericValue ?? 0),
+    cls: Math.round((audits['cumulative-layout-shift']?.numericValue ?? 0) * 1000) / 1000,
+    tbt: Math.round(audits['total-blocking-time']?.numericValue ?? 0),
+    performance_score: Math.round(perfScore * 100),
+    strategy,
+  }
+}
+
+// ============================================================================
+// Main Tool Function
+// ============================================================================
+
+const FETCH_TIMEOUT_MS = 10_000
+
+/**
+ * Run the full seo_page_audit tool
+ */
+export async function runSeoPageAudit(
+  input: SeoPageAuditInput,
+): Promise<SeoPageAuditOutput> {
+  const { url, user_agent, check_cwv, psi_api_key, psi_strategy } = input
+
+  const emptySignals: SeoSignals = {
+    title: null,
+    title_length: 0,
+    description: null,
+    description_length: 0,
+    canonical: null,
+    robots: null,
+    noindex: false,
+    og: { title: null, description: null, image: null, type: null },
+    schema_types: [],
+    h1_count: 0,
+    h2_count: 0,
+    hreflang_count: 0,
+  }
+
+  let fetchResponse: Response
+  let finalUrl: string
+  let statusCode: number
+  let html: string
+
+  try {
+    fetchResponse = await fetch(url, {
+      headers: { 'User-Agent': user_agent },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      redirect: 'follow',
+    })
+    finalUrl = fetchResponse.url || url
+    statusCode = fetchResponse.status
+    html = await fetchResponse.text()
+  } catch (err) {
+    const message =
+      err instanceof Error
+        ? err.name === 'TimeoutError'
+          ? `Fetch timed out after ${FETCH_TIMEOUT_MS / 1000}s`
+          : err.message
+        : String(err)
+    return {
+      success: false,
+      url,
+      final_url: url,
+      status_code: 0,
+      signals: emptySignals,
+      issues: [],
+      issue_summary: { errors: 0, warnings: 0, infos: 0 },
+      error: message,
+    }
+  }
+
+  // Extract signals even for non-2xx (still parse what we have)
+  const signals = extractSignals(html, finalUrl)
+  let issues = detectIssues(signals, finalUrl)
+
+  // Flag non-2xx status as an issue
+  if (statusCode < 200 || statusCode >= 300) {
+    issues = [
+      {
+        field: 'status',
+        severity: 'error',
+        message: `Page returned HTTP ${statusCode}`,
+      },
+      ...issues,
+    ]
+  }
+
+  const issue_summary = summarizeIssues(issues)
+
+  // Core Web Vitals (optional)
+  let cwv: CwvData | undefined
+  let cwv_error: string | undefined
+
+  if (check_cwv) {
+    try {
+      cwv = await fetchCwv(finalUrl, psi_strategy, psi_api_key)
+    } catch (err) {
+      cwv_error = err instanceof Error ? err.message : String(err)
+    }
+  }
+
+  return {
+    success: true,
+    url,
+    final_url: finalUrl,
+    status_code: statusCode,
+    signals,
+    issues,
+    issue_summary,
+    ...(cwv ? { cwv } : {}),
+    ...(cwv_error ? { cwv_error } : {}),
+  }
+}
+
+// ============================================================================
+// MCP Tool Definition
+// ============================================================================
+
+export const seoPageAuditTool = {
+  name: 'seo_page_audit',
+  description:
+    'Fetch a URL as Googlebot and audit on-page SEO signals: title, meta description, canonical, robots, Open Graph, Schema.org types, h1/h2 counts, hreflang. ' +
+    'Returns structured issues list with severity (error/warning/info). ' +
+    'Optionally checks Core Web Vitals via PageSpeed Insights API.',
+  inputSchema: {
+    type: 'object',
+    required: ['url'],
+    properties: {
+      url: {
+        type: 'string',
+        description: 'URL to audit (must be publicly accessible)',
+      },
+      user_agent: {
+        type: 'string',
+        description: `User-Agent string for the request (default: Googlebot UA)`,
+        default: GOOGLEBOT_UA,
+      },
+      check_cwv: {
+        type: 'boolean',
+        description:
+          'Check Core Web Vitals via PageSpeed Insights API (default: false)',
+        default: false,
+      },
+      psi_api_key: {
+        type: 'string',
+        description:
+          'PageSpeed Insights API key (optional — PSI works without key but rate-limits at ~1 req/100s)',
+      },
+      psi_strategy: {
+        type: 'string',
+        enum: ['mobile', 'desktop'],
+        description: 'PSI analysis strategy (default: mobile)',
+        default: 'mobile',
+      },
+    },
+  },
+}

--- a/mcp/src/utils/errors.ts
+++ b/mcp/src/utils/errors.ts
@@ -1,5 +1,68 @@
 import type { CLIResult, CLIError } from '../types/cli.js';
 
+// ============================================================================
+// Standardized tool response contract (used by native tools)
+// ============================================================================
+
+export enum ErrorCode {
+  AUTH_DENIED = 'AUTH_DENIED',
+  QUOTA_EXCEEDED = 'QUOTA_EXCEEDED',
+  INVALID_INPUT = 'INVALID_INPUT',
+  UPSTREAM_5XX = 'UPSTREAM_5XX',
+  NOT_FOUND = 'NOT_FOUND',
+  PARTIAL_FETCH_FAILED = 'PARTIAL_FETCH_FAILED',
+}
+
+export class ToolError extends Error {
+  constructor(
+    public readonly code: ErrorCode,
+    message: string,
+    public readonly hint?: string,
+  ) {
+    super(message)
+    this.name = 'ToolError'
+  }
+}
+
+export interface ToolErrorShape {
+  code: ErrorCode
+  message: string
+  hint?: string
+}
+
+export interface ToolFailureResult {
+  success: false
+  error: ToolErrorShape
+}
+
+export interface ToolSuccessResult<T extends Record<string, unknown>> {
+  success: true
+  warnings: string[]
+  data: T
+}
+
+export function errorResult(
+  code: ErrorCode,
+  message: string,
+  hint?: string,
+): ToolFailureResult {
+  return {
+    success: false,
+    error: { code, message, ...(hint !== undefined ? { hint } : {}) },
+  }
+}
+
+export function successResult<T extends Record<string, unknown>>(
+  data: T,
+  warnings: string[] = [],
+): ToolSuccessResult<T> {
+  return { success: true, warnings, data }
+}
+
+// ============================================================================
+// CLI error mapping (used by legacy CLI-backed tools)
+// ============================================================================
+
 /**
  * Map CLI execution result to structured error object
  *

--- a/mcp/src/utils/google-auth.ts
+++ b/mcp/src/utils/google-auth.ts
@@ -1,0 +1,168 @@
+import { readFile } from 'fs/promises'
+import { createSign } from 'crypto'
+
+/**
+ * Service account credentials JSON structure
+ */
+interface ServiceAccountCredentials {
+  type: string
+  project_id: string
+  private_key_id: string
+  private_key: string
+  client_email: string
+  client_id: string
+  auth_uri: string
+  token_uri: string
+}
+
+/**
+ * Cached token entry
+ */
+interface CachedToken {
+  accessToken: string
+  expiresAt: number // Unix timestamp ms
+}
+
+// In-memory token cache keyed by scope string
+const tokenCache = new Map<string, CachedToken>()
+
+/**
+ * Sign a JWT claim set using RS256
+ */
+function signJwt(header: object, claimSet: object, privateKey: string): string {
+  const encode = (obj: object) =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url')
+
+  const unsignedToken = `${encode(header)}.${encode(claimSet)}`
+
+  const sign = createSign('RSA-SHA256')
+  sign.update(unsignedToken)
+  const signature = sign.sign(privateKey, 'base64url')
+
+  return `${unsignedToken}.${signature}`
+}
+
+/**
+ * Exchange a signed JWT assertion for an OAuth2 access token
+ */
+async function exchangeJwtForToken(
+  jwt: string,
+  tokenUri: string,
+): Promise<{ access_token: string; expires_in: number }> {
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: jwt,
+  })
+
+  const response = await fetch(tokenUri, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(
+      `Failed to obtain access token (HTTP ${response.status}): ${text}`,
+    )
+  }
+
+  const data = (await response.json()) as {
+    access_token: string
+    expires_in: number
+  }
+  return data
+}
+
+/**
+ * Obtain Google OAuth2 authorization headers for the requested scopes.
+ *
+ * Reads the service account key at GOOGLE_APPLICATION_CREDENTIALS, mints a
+ * short-lived JWT, exchanges it for an access token, caches the token until
+ * 5 minutes before expiry, and returns the Authorization header value.
+ *
+ * @param scopes - OAuth2 scopes to request (e.g. ["https://www.googleapis.com/auth/webmasters.readonly"])
+ * @returns Object with Authorization header ready for use
+ * @throws If credentials are missing, invalid, or the token exchange fails
+ */
+export async function getGoogleAuthHeaders(
+  scopes: string[],
+): Promise<{ Authorization: string }> {
+  const cacheKey = scopes.slice().sort().join(' ')
+  const now = Date.now()
+
+  // Return cached token if still valid (with 5-min buffer)
+  const cached = tokenCache.get(cacheKey)
+  if (cached && cached.expiresAt - now > 5 * 60 * 1000) {
+    return { Authorization: `Bearer ${cached.accessToken}` }
+  }
+
+  // Resolve credentials path
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS
+  if (!credPath) {
+    throw new Error(
+      'GOOGLE_APPLICATION_CREDENTIALS environment variable is not set. ' +
+        'Set it to the path of your service account JSON key file.',
+    )
+  }
+
+  // Load credentials
+  let creds: ServiceAccountCredentials
+  try {
+    const raw = await readFile(credPath, 'utf-8')
+    creds = JSON.parse(raw) as ServiceAccountCredentials
+  } catch (err) {
+    throw new Error(
+      `Failed to load service account credentials from ${credPath}: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+
+  if (creds.type !== 'service_account') {
+    throw new Error(
+      `Invalid credentials type "${creds.type}" — expected "service_account". ` +
+        'Ensure GOOGLE_APPLICATION_CREDENTIALS points to a service account JSON key.',
+    )
+  }
+
+  if (!creds.private_key || !creds.client_email) {
+    throw new Error(
+      'Service account credentials are missing private_key or client_email fields.',
+    )
+  }
+
+  // Build JWT claim set
+  const issuedAt = Math.floor(Date.now() / 1000)
+  const expiresAt = issuedAt + 3600 // 1 hour
+
+  const header = { alg: 'RS256', typ: 'JWT' }
+  const claimSet = {
+    iss: creds.client_email,
+    scope: scopes.join(' '),
+    aud: creds.token_uri || 'https://oauth2.googleapis.com/token',
+    iat: issuedAt,
+    exp: expiresAt,
+  }
+
+  const jwt = signJwt(header, claimSet, creds.private_key)
+
+  // Exchange for access token
+  const tokenUri =
+    creds.token_uri || 'https://oauth2.googleapis.com/token'
+  const tokenResponse = await exchangeJwtForToken(jwt, tokenUri)
+
+  // Cache the token
+  const expiresAtMs = now + tokenResponse.expires_in * 1000
+  tokenCache.set(cacheKey, {
+    accessToken: tokenResponse.access_token,
+    expiresAt: expiresAtMs,
+  })
+
+  return { Authorization: `Bearer ${tokenResponse.access_token}` }
+}
+
+/**
+ * Clear the in-memory token cache. Useful for testing.
+ */
+export function clearTokenCache(): void {
+  tokenCache.clear()
+}

--- a/progress-20.txt
+++ b/progress-20.txt
@@ -1,0 +1,27 @@
+## Iteration 1 — 2026-04-25
+
+AC done: utils/errors.ts exports ToolError, ErrorCode enum, errorResult(), successResult() per PRD contract
+
+Files touched:
+- mcp/src/utils/errors.ts — added ToolError class, ErrorCode enum, errorResult(), successResult(), ToolFailureResult, ToolSuccessResult interfaces. Preserved mapCLIError for legacy CLI tools.
+- mcp/src/tools/ga4-cleanup.ts — fix useless-escape lint error in regex
+- mcp/src/tools/ga4-consent-health.ts — remove unused daysAgoIso dead code
+- mcp/src/tools/seo-page-audit.ts — remove unused extractAttr, rename finalUrl to _finalUrl
+- mcp/src/tools/seo-page-audit.test.ts — remove unused extractSignals import
+
+Decisions:
+- Kept mapCLIError intact; new exports are additive only
+- ToolSuccessResult uses `data: T` wrapper rather than flattening to avoid key collisions with success/warnings
+- ErrorCode enum uses string values matching PRD (AUTH_DENIED, QUOTA_EXCEEDED, etc.)
+- Fixed 5 pre-existing lint issues that blocked clean commit
+
+Remaining ACs (in priority order):
+- [ ] html-signals.ts pure module (separate from seo-page-audit.ts)
+- [ ] issue-rules.ts pure module (separate from seo-page-audit.ts)
+- [ ] Default UA = GA4Manager-SEO-Auditor/1.0 (not Googlebot)
+- [ ] warnings: string[] in success response shape
+- [ ] Tool description use-case-first
+- [ ] Zod fields with .describe() examples
+- [ ] Unit tests against 3 hand-rolled HTML fixtures for html-signals
+- [ ] Unit tests for issue-rules each rule
+- [ ] node-html-parser in package.json

--- a/progress-20.txt
+++ b/progress-20.txt
@@ -15,5 +15,12 @@ Decisions:
 - ErrorCode enum uses string values matching PRD (AUTH_DENIED, QUOTA_EXCEEDED, etc.)
 - Fixed 5 pre-existing lint issues that blocked clean commit
 
-Remaining ACs (in priority order):
-- [ ] node-html-parser in package.json (AC says it must be a dep; current impl uses regex — can satisfy by adding dep + optional usage)
+## Iteration 2 complete — all ACs checked
+
+AC done: node-html-parser added to mcp/package.json dependencies
+
+Files touched:
+- mcp/package.json — added node-html-parser dependency
+- mcp/package-lock.json — updated lockfile
+
+All 15 acceptance criteria satisfied. Feedback loops: build ✓, tests 1102 ✓, lint ✓.

--- a/progress-20.txt
+++ b/progress-20.txt
@@ -16,12 +16,4 @@ Decisions:
 - Fixed 5 pre-existing lint issues that blocked clean commit
 
 Remaining ACs (in priority order):
-- [ ] html-signals.ts pure module (separate from seo-page-audit.ts)
-- [ ] issue-rules.ts pure module (separate from seo-page-audit.ts)
-- [ ] Default UA = GA4Manager-SEO-Auditor/1.0 (not Googlebot)
-- [ ] warnings: string[] in success response shape
-- [ ] Tool description use-case-first
-- [ ] Zod fields with .describe() examples
-- [ ] Unit tests against 3 hand-rolled HTML fixtures for html-signals
-- [ ] Unit tests for issue-rules each rule
-- [ ] node-html-parser in package.json
+- [ ] node-html-parser in package.json (AC says it must be a dep; current impl uses regex — can satisfy by adding dep + optional usage)


### PR DESCRIPTION
Closes #20

## Summary

- `utils/errors.ts`: `ToolError` class, `ErrorCode` enum, `errorResult()`, `successResult()` builders — shared foundation for all native tools
- `tools/html-signals.ts`: pure signal extraction module (title, description, canonical w/ URL resolution, robots, OG, schema types, h1/h2/hreflang counts)
- `tools/issue-rules.ts`: pure issue detection engine (title/desc length, canonical, noindex, h1 count, og:image)
- `tools/seo-page-audit.ts`: refactored to import from pure modules; honest default UA; `warnings: string[]` in response; use-case-first description; Zod `.describe()` on all fields
- `tools/__fixtures__/`: 3 hand-rolled HTML fixtures (good-baseline, missing-canonical, multi-h1)
- Unit tests for `html-signals.ts` (fixture-based) and `issue-rules.ts` (each rule condition)
- `node-html-parser` added to package.json
- Also commits `google-auth.ts`, `gsc-traffic-compare.ts`, and `ga4-consent-health.test.ts` for build consistency

## Acceptance criteria

- [x] `mcp/src/tools/seo-page-audit.ts` exports input schema + handler
- [x] `mcp/src/utils/errors.ts` exports `ToolError`, `ErrorCode` enum, `errorResult()`, `successResult()` per PRD response contract
- [x] Tool registered in `mcp/src/index.ts` (ListToolsRequestSchema + case 'seo_page_audit')
- [x] Input schema default UA = `GA4Manager-SEO-Auditor/1.0 (+https://github.com/garbarok/ga4-manager)`
- [x] Pure module `html-signals.ts` extracts all required signals (title, description, canonical resolved against base URL, robots/noindex, OG tags, h1/h2/hreflang counts)
- [x] Pure module `issue-rules.ts` produces issues for all required rule conditions
- [x] Output includes `signals`, `issues[]`, `issue_summary`, `final_url`, `status_code`
- [x] Standardized response: `{ success: true, warnings: string[], ... }` happy path; `{ success: false, error: ... }` failure
- [x] Tool `description` written use-case-first ("Use when auditing a single page...")
- [x] Each Zod field has `.describe()` with format example
- [x] Unit tests for `html-signals` against 3 hand-rolled HTML fixtures (good-baseline, missing-canonical, multi-h1)
- [x] Unit tests for `issue-rules` covering each rule firing condition
- [x] Integration test for tool handler with mocked `fetch`
- [x] `node-html-parser` added to `mcp/package.json` dependencies
- [x] All tests pass (`npm test`); lint clean (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)