### PR TITLE
feat(mcp): seo_page_audit redirect tracing + meta-refresh detection

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -11,6 +11,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "csv-parse": "^6.2.1",
         "node-html-parser": "^7.1.0",
+        "tldts": "^7.0.28",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -4138,6 +4139,24 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -16,6 +16,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "csv-parse": "^6.2.1",
     "node-html-parser": "^7.1.0",
+    "tldts": "^7.0.28",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/mcp/src/tools/issue-rules.test.ts
+++ b/mcp/src/tools/issue-rules.test.ts
@@ -164,3 +164,78 @@ describe('summarizeIssues', () => {
     expect(s.infos).toBe(0)
   })
 })
+
+// ============================================================================
+// Redirect chain rules
+// ============================================================================
+
+import type { RedirectHop } from '../utils/redirect-trace.js'
+
+describe('runIssueRules — redirect chain', () => {
+  it('no issues when chain is empty', () => {
+    const issues = runIssueRules(baseSignals, finalUrl, [])
+    expect(issues.some((i: SeoIssue) => i.field.startsWith('redirect.'))).toBe(false)
+  })
+
+  it('redirect.chain_too_long: fires when chain length > 3', () => {
+    const chain: RedirectHop[] = [
+      { from: 'https://example.com/a', to: 'https://example.com/b', status: 301 },
+      { from: 'https://example.com/b', to: 'https://example.com/c', status: 301 },
+      { from: 'https://example.com/c', to: 'https://example.com/d', status: 301 },
+      { from: 'https://example.com/d', to: 'https://example.com/page', status: 301 },
+    ]
+    const issues = runIssueRules(baseSignals, finalUrl, chain)
+    expect(issues.some((i: SeoIssue) => i.field === 'redirect.chain_too_long' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('redirect.chain_too_long: does NOT fire for chain of exactly 3', () => {
+    const chain: RedirectHop[] = [
+      { from: 'https://example.com/a', to: 'https://example.com/b', status: 301 },
+      { from: 'https://example.com/b', to: 'https://example.com/c', status: 301 },
+      { from: 'https://example.com/c', to: 'https://example.com/page', status: 301 },
+    ]
+    const issues = runIssueRules(baseSignals, finalUrl, chain)
+    expect(issues.some((i: SeoIssue) => i.field === 'redirect.chain_too_long')).toBe(false)
+  })
+
+  it('redirect.non_permanent: fires when chain contains a 302', () => {
+    const chain: RedirectHop[] = [
+      { from: 'https://example.com/a', to: 'https://example.com/page', status: 302 },
+    ]
+    const issues = runIssueRules(baseSignals, finalUrl, chain)
+    expect(issues.some((i: SeoIssue) => i.field === 'redirect.non_permanent' && i.severity === 'info')).toBe(true)
+  })
+
+  it('redirect.non_permanent: does NOT fire for 301-only chain', () => {
+    const chain: RedirectHop[] = [
+      { from: 'https://example.com/a', to: 'https://example.com/page', status: 301 },
+    ]
+    const issues = runIssueRules(baseSignals, finalUrl, chain)
+    expect(issues.some((i: SeoIssue) => i.field === 'redirect.non_permanent')).toBe(false)
+  })
+
+  it('redirect.cross_domain: fires when eTLD+1 differs between start and final URL', () => {
+    const chain: RedirectHop[] = [
+      { from: 'https://old-site.com/', to: 'https://example.com/page', status: 301 },
+    ]
+    const issues = runIssueRules(baseSignals, 'https://example.com/page', chain)
+    expect(issues.some((i: SeoIssue) => i.field === 'redirect.cross_domain' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('redirect.cross_domain: does NOT fire for same eTLD+1 (different subdomain)', () => {
+    const chain: RedirectHop[] = [
+      { from: 'https://www.example.com/', to: 'https://example.com/page', status: 301 },
+    ]
+    const issues = runIssueRules(baseSignals, 'https://example.com/page', chain)
+    expect(issues.some((i: SeoIssue) => i.field === 'redirect.cross_domain')).toBe(false)
+  })
+
+  it('redirect.loop: fires when same URL appears twice in chain', () => {
+    const chain: RedirectHop[] = [
+      { from: 'https://example.com/a', to: 'https://example.com/b', status: 301 },
+      { from: 'https://example.com/a', to: 'https://example.com/c', status: 301 },
+    ]
+    const issues = runIssueRules(baseSignals, finalUrl, chain)
+    expect(issues.some((i: SeoIssue) => i.field === 'redirect.loop' && i.severity === 'error')).toBe(true)
+  })
+})

--- a/mcp/src/tools/issue-rules.ts
+++ b/mcp/src/tools/issue-rules.ts
@@ -2,7 +2,9 @@
 // issue-rules.ts — pure issue detection engine, no I/O
 // ============================================================================
 
+import { parse as parseDomain } from 'tldts'
 import type { HtmlSignals } from './html-signals.js'
+import type { RedirectHop } from '../utils/redirect-trace.js'
 
 export interface SeoIssue {
   field: string
@@ -16,10 +18,63 @@ export interface IssueSummary {
   infos: number
 }
 
-export function runIssueRules(signals: HtmlSignals, finalUrl: string): SeoIssue[] {
+function registrableDomain(url: string): string | null {
+  try {
+    return parseDomain(url).domain ?? null
+  } catch {
+    return null
+  }
+}
+
+export function runIssueRules(signals: HtmlSignals, finalUrl: string, chain: RedirectHop[] = []): SeoIssue[] {
   const issues: SeoIssue[] = []
 
-  // Title
+  // ── Redirect chain rules ──────────────────────────────────────────────────
+
+  if (chain.length > 0) {
+    // redirect.loop — same URL visited twice in chain
+    const seen = new Set<string>()
+    for (const hop of chain) {
+      if (seen.has(hop.from)) {
+        issues.push({ field: 'redirect.loop', severity: 'error', message: `Redirect loop: ${hop.from} was visited twice` })
+        break
+      }
+      seen.add(hop.from)
+    }
+
+    // redirect.chain_too_long — more than 3 hops
+    if (chain.length > 3) {
+      issues.push({
+        field: 'redirect.chain_too_long',
+        severity: 'warning',
+        message: `Redirect chain is ${chain.length} hops long (max recommended: 3)`,
+      })
+    }
+
+    // redirect.non_permanent — any 302 in chain
+    if (chain.some((h) => h.status === 302)) {
+      issues.push({
+        field: 'redirect.non_permanent',
+        severity: 'info',
+        message: 'Redirect chain contains a 302 (temporary) redirect; use 301 for SEO-safe permanent redirects',
+      })
+    }
+
+    // redirect.cross_domain — final eTLD+1 differs from start eTLD+1
+    const startUrl = chain[0].from
+    const startDomain = registrableDomain(startUrl)
+    const finalDomain = registrableDomain(finalUrl)
+    if (startDomain && finalDomain && startDomain !== finalDomain) {
+      issues.push({
+        field: 'redirect.cross_domain',
+        severity: 'warning',
+        message: `Redirect crosses domain boundary: ${startDomain} → ${finalDomain}`,
+      })
+    }
+  }
+
+  // ── Title ─────────────────────────────────────────────────────────────────
+
   if (!signals.title) {
     issues.push({ field: 'title', severity: 'error', message: 'Page is missing a <title> tag' })
   } else {
@@ -38,7 +93,8 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string): SeoIssue[
     }
   }
 
-  // Description
+  // ── Description ───────────────────────────────────────────────────────────
+
   if (!signals.description) {
     issues.push({ field: 'description', severity: 'warning', message: 'Page is missing a meta description' })
   } else if (signals.description_length > 160) {
@@ -49,7 +105,8 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string): SeoIssue[
     })
   }
 
-  // Canonical
+  // ── Canonical ─────────────────────────────────────────────────────────────
+
   if (!signals.canonical) {
     issues.push({ field: 'canonical', severity: 'warning', message: 'Page is missing a canonical link tag' })
   } else {
@@ -72,7 +129,8 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string): SeoIssue[
     }
   }
 
-  // Robots noindex
+  // ── Robots noindex ────────────────────────────────────────────────────────
+
   if (signals.noindex) {
     issues.push({
       field: 'robots',
@@ -81,7 +139,8 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string): SeoIssue[
     })
   }
 
-  // H1
+  // ── H1 ────────────────────────────────────────────────────────────────────
+
   if (signals.h1_count === 0) {
     issues.push({ field: 'h1', severity: 'warning', message: 'Page has no <h1> tag' })
   } else if (signals.h1_count > 1) {
@@ -92,7 +151,8 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string): SeoIssue[
     })
   }
 
-  // OG image
+  // ── OG image ──────────────────────────────────────────────────────────────
+
   if (!signals.og.image) {
     issues.push({ field: 'og:image', severity: 'info', message: 'Page is missing og:image meta tag' })
   }

--- a/mcp/src/tools/seo-page-audit.test.ts
+++ b/mcp/src/tools/seo-page-audit.test.ts
@@ -691,3 +691,183 @@ describe('seoPageAuditTool definition', () => {
     expect(props.psi_strategy).toBeDefined()
   })
 })
+
+// ============================================================================
+// runSeoPageAudit — redirect chain integration
+// ============================================================================
+
+function makeRedirectResponse(status: number, location: string) {
+  return {
+    ok: false,
+    status,
+    url: '',
+    headers: { get: (h: string) => (h.toLowerCase() === 'location' ? location : null) },
+    text: () => Promise.resolve(''),
+  }
+}
+
+function makeOkResponse(url: string, body: string) {
+  return {
+    ok: true,
+    status: 200,
+    url,
+    headers: { get: () => null },
+    text: () => Promise.resolve(body),
+  }
+}
+
+const GOOD_HTML = `<!DOCTYPE html>
+<html><head>
+  <title>Good Page Title For Testing</title>
+  <meta name="description" content="Good description for this test page here.">
+  <link rel="canonical" href="https://example.com/final">
+  <meta property="og:image" content="https://example.com/img.jpg">
+</head><body><h1>Heading</h1></body></html>`
+
+describe('runSeoPageAudit — redirect chain', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('output includes redirect_chain field (empty when no redirect)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(makeOkResponse('https://example.com/page', GOOD_HTML)),
+    )
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/page' })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.redirect_chain).toBeDefined()
+    expect(result.redirect_chain).toHaveLength(0)
+  })
+
+  it('multi-hop: redirect_chain has correct length and entries', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/step2'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/final'))
+        .mockResolvedValueOnce(makeOkResponse('https://example.com/final', GOOD_HTML)),
+    )
+
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/start' })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(true)
+    expect(result.redirect_chain).toHaveLength(2)
+    expect(result.redirect_chain[0]).toMatchObject({ from: 'https://example.com/start', status: 301 })
+    expect(result.redirect_chain[1]).toMatchObject({ from: 'https://example.com/step2', status: 301 })
+    expect(result.final_url).toBe('https://example.com/final')
+  })
+
+  it('redirect.chain_too_long issue fires for 4-hop chain', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/b'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/c'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/d'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/final'))
+        .mockResolvedValueOnce(makeOkResponse('https://example.com/final', GOOD_HTML)),
+    )
+
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/a' })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.redirect_chain).toHaveLength(4)
+    expect(result.issues.some((i) => i.field === 'redirect.chain_too_long' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('returns success=false with error message on redirect loop', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/b'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/a')),
+    )
+
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/a' })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/loop/i)
+    expect(result.redirect_chain).toHaveLength(0)
+  })
+
+  it('returns success=false with error message when hop limit exceeded', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/b'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/c'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/d'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/e'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/f')),
+    )
+
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/a' })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/hop limit/i)
+  })
+})
+
+// ============================================================================
+// runSeoPageAudit — meta-refresh detection
+// ============================================================================
+
+describe('runSeoPageAudit — meta-refresh', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('adds meta_refresh info issue when meta http-equiv="refresh" present', async () => {
+    const htmlWithRefresh = `<!DOCTYPE html>
+<html><head>
+  <title>Redirecting Page Title OK</title>
+  <meta name="description" content="This page redirects you soon.">
+  <link rel="canonical" href="https://example.com/">
+  <meta property="og:image" content="https://example.com/img.jpg">
+  <meta http-equiv="refresh" content="5; url=https://example.com/new-page">
+</head><body><h1>Redirecting</h1></body></html>`
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: 'https://example.com/',
+        headers: { get: () => null },
+        text: () => Promise.resolve(htmlWithRefresh),
+      }),
+    )
+
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/' })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.success).toBe(true)
+    const metaIssue = result.issues.find((i) => i.field === 'meta_refresh')
+    expect(metaIssue).toBeDefined()
+    expect(metaIssue?.severity).toBe('info')
+    expect(metaIssue?.message).toContain('https://example.com/new-page')
+  })
+
+  it('no meta_refresh issue when tag absent', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        url: 'https://example.com/',
+        headers: { get: () => null },
+        text: () => Promise.resolve(GOOD_HTML),
+      }),
+    )
+
+    const input = seoPageAuditInputSchema.parse({ url: 'https://example.com/' })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.issues.some((i) => i.field === 'meta_refresh')).toBe(false)
+  })
+})

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
 import { extractSignals, type HtmlSignals } from './html-signals.js'
 import { runIssueRules, summarizeIssues, type SeoIssue, type IssueSummary } from './issue-rules.js'
+import { fetchWithTrace, type RedirectHop } from '../utils/redirect-trace.js'
+import { ToolError } from '../utils/errors.js'
 
 // Re-export granular helpers so existing imports continue to work
 export {
@@ -18,6 +20,7 @@ export {
   type SeoIssue,
   type IssueSummary,
 } from './issue-rules.js'
+export type { RedirectHop } from '../utils/redirect-trace.js'
 
 // ============================================================================
 // Input Schema
@@ -77,6 +80,7 @@ export interface SeoPageAuditOutput {
   url: string
   final_url: string
   status_code: number
+  redirect_chain: RedirectHop[]
   signals: HtmlSignals
   issues: SeoIssue[]
   issue_summary: IssueSummary
@@ -133,6 +137,22 @@ export async function fetchCwv(
 }
 
 // ============================================================================
+// Meta-refresh extraction
+// ============================================================================
+
+function extractMetaRefreshUrl(html: string): string | null {
+  // Matches: <meta http-equiv="refresh" content="5; url=https://example.com">
+  // and reversed attribute order
+  const match = html.match(
+    /<meta[^>]+http-equiv=["']refresh["'][^>]+content=["']([^"']*)["']|<meta[^>]+content=["']([^"']*)["'][^>]+http-equiv=["']refresh["']/i,
+  )
+  if (!match) return null
+  const content = (match[1] ?? match[2] ?? '').trim()
+  const urlMatch = content.match(/url\s*=\s*([^\s;,]+)/i)
+  return urlMatch ? urlMatch[1] : null
+}
+
+// ============================================================================
 // Main Tool Function
 // ============================================================================
 
@@ -157,21 +177,35 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
   const { url, user_agent, check_cwv, psi_api_key, psi_strategy } = input
   const warnings: string[] = []
 
-  let fetchResponse: Response
   let finalUrl: string
   let statusCode: number
   let html: string
+  let chain: RedirectHop[] = []
 
   try {
-    fetchResponse = await fetch(url, {
+    const traceResult = await fetchWithTrace(url, {
       headers: { 'User-Agent': user_agent },
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-      redirect: 'follow',
     })
-    finalUrl = fetchResponse.url || url
-    statusCode = fetchResponse.status
-    html = await fetchResponse.text()
+    chain = traceResult.chain
+    finalUrl = traceResult.finalUrl
+    statusCode = traceResult.finalRes.status
+    html = await traceResult.finalRes.text()
   } catch (err) {
+    if (err instanceof ToolError) {
+      return {
+        success: false,
+        warnings,
+        url,
+        final_url: url,
+        status_code: 0,
+        redirect_chain: [],
+        signals: emptySignals,
+        issues: [],
+        issue_summary: { errors: 0, warnings: 0, infos: 0 },
+        error: err.message,
+      }
+    }
     const message =
       err instanceof Error
         ? err.name === 'TimeoutError'
@@ -184,6 +218,7 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
       url,
       final_url: url,
       status_code: 0,
+      redirect_chain: [],
       signals: emptySignals,
       issues: [],
       issue_summary: { errors: 0, warnings: 0, infos: 0 },
@@ -192,10 +227,20 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
   }
 
   const signals = extractSignals(html, finalUrl)
-  let issues = runIssueRules(signals, finalUrl)
+  let issues = runIssueRules(signals, finalUrl, chain)
 
   if (statusCode < 200 || statusCode >= 300) {
     issues = [{ field: 'status', severity: 'error', message: `Page returned HTTP ${statusCode}` }, ...issues]
+  }
+
+  // Meta-refresh detection
+  const metaRefreshUrl = extractMetaRefreshUrl(html)
+  if (metaRefreshUrl) {
+    issues.push({
+      field: 'meta_refresh',
+      severity: 'info',
+      message: `Page has meta refresh redirect to: ${metaRefreshUrl}`,
+    })
   }
 
   const issue_summary = summarizeIssues(issues)
@@ -217,6 +262,7 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
     url,
     final_url: finalUrl,
     status_code: statusCode,
+    redirect_chain: chain,
     signals,
     issues,
     issue_summary,
@@ -232,9 +278,9 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
 export const seoPageAuditTool = {
   name: 'seo_page_audit',
   description:
-    'Use when auditing a single page for SEO problems: missing title or description, bad canonical, noindex directives, missing OG image, heading structure issues. ' +
-    'Fetches the URL and parses on-page signals (title, meta description, canonical, robots, Open Graph, Schema.org types, h1/h2 counts, hreflang). ' +
-    'Returns a structured issues list with severity (error/warning/info). ' +
+    'Use when auditing a single page for SEO problems: missing title or description, bad canonical, noindex directives, missing OG image, heading structure issues, redirect chain problems. ' +
+    'Fetches the URL with manual redirect tracing (max 5 hops), parses on-page signals (title, meta description, canonical, robots, Open Graph, Schema.org types, h1/h2 counts, hreflang). ' +
+    'Returns a structured issues list with severity (error/warning/info) and the full redirect chain. ' +
     'Optionally checks Core Web Vitals via PageSpeed Insights API.',
   inputSchema: {
     type: 'object',

--- a/mcp/src/utils/redirect-trace.test.ts
+++ b/mcp/src/utils/redirect-trace.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchWithTrace } from './redirect-trace.js'
+import { ToolError, ErrorCode } from './errors.js'
+
+function makeRedirectResponse(status: number, location: string) {
+  return {
+    status,
+    ok: false,
+    headers: { get: (h: string) => (h.toLowerCase() === 'location' ? location : null) },
+  }
+}
+
+function makeOkResponse(status = 200) {
+  return {
+    status,
+    ok: true,
+    headers: { get: () => null },
+    text: () => Promise.resolve('<html></html>'),
+  }
+}
+
+describe('fetchWithTrace', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('no redirect: chain is empty, returns final response', async () => {
+    const ok = makeOkResponse()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ok))
+
+    const result = await fetchWithTrace('https://example.com/')
+
+    expect(result.chain).toHaveLength(0)
+    expect(result.finalUrl).toBe('https://example.com/')
+    expect(result.finalRes.status).toBe(200)
+  })
+
+  it('single redirect: chain has one hop', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/new'))
+        .mockResolvedValueOnce(makeOkResponse()),
+    )
+
+    const result = await fetchWithTrace('https://example.com/old')
+
+    expect(result.chain).toHaveLength(1)
+    expect(result.chain[0]).toEqual({
+      from: 'https://example.com/old',
+      to: 'https://example.com/new',
+      status: 301,
+    })
+    expect(result.finalUrl).toBe('https://example.com/new')
+  })
+
+  it('records 302, 307, 308 statuses in chain', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(302, 'https://example.com/b'))
+        .mockResolvedValueOnce(makeRedirectResponse(307, 'https://example.com/c'))
+        .mockResolvedValueOnce(makeRedirectResponse(308, 'https://example.com/d'))
+        .mockResolvedValueOnce(makeOkResponse()),
+    )
+
+    const result = await fetchWithTrace('https://example.com/a')
+
+    expect(result.chain).toHaveLength(3)
+    expect(result.chain[0].status).toBe(302)
+    expect(result.chain[1].status).toBe(307)
+    expect(result.chain[2].status).toBe(308)
+  })
+
+  it('resolves relative location header against current URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(301, '/new-path'))
+        .mockResolvedValueOnce(makeOkResponse()),
+    )
+
+    const result = await fetchWithTrace('https://example.com/old-path')
+
+    expect(result.chain[0].to).toBe('https://example.com/new-path')
+  })
+
+  it('throws UPSTREAM_5XX on redirect loop', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/b'))
+        .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/a')),
+      // /a is where we started — loop
+    )
+
+    await expect(fetchWithTrace('https://example.com/a')).rejects.toSatisfy(
+      (e: unknown) => e instanceof ToolError && e.code === ErrorCode.UPSTREAM_5XX && /loop/i.test(e.message),
+    )
+  })
+
+  it('throws UPSTREAM_5XX when hop limit (5) exceeded', async () => {
+    const mockFetch = vi.fn()
+    // 5 redirects: a→b→c→d→e→f, then would need 6th fetch
+    mockFetch
+      .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/b'))
+      .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/c'))
+      .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/d'))
+      .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/e'))
+      .mockResolvedValueOnce(makeRedirectResponse(301, 'https://example.com/f'))
+    // 6th call would be for /f but it should throw before fetching
+    vi.stubGlobal('fetch', mockFetch)
+
+    await expect(fetchWithTrace('https://example.com/a')).rejects.toSatisfy(
+      (e: unknown) => e instanceof ToolError && e.code === ErrorCode.UPSTREAM_5XX && /hop limit/i.test(e.message),
+    )
+  })
+
+  it('uses redirect: manual when calling fetch', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse())
+    vi.stubGlobal('fetch', mockFetch)
+
+    await fetchWithTrace('https://example.com/')
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(opts.redirect).toBe('manual')
+  })
+
+  it('passes caller options (headers) through to fetch', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse())
+    vi.stubGlobal('fetch', mockFetch)
+
+    await fetchWithTrace('https://example.com/', { headers: { 'User-Agent': 'TestBot/1.0' } })
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect((opts.headers as Record<string, string>)['User-Agent']).toBe('TestBot/1.0')
+    // redirect: manual must still be set
+    expect(opts.redirect).toBe('manual')
+  })
+
+  it('returns without following if redirect has no Location header', async () => {
+    const noLocation = {
+      status: 301,
+      ok: false,
+      headers: { get: () => null },
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(noLocation))
+
+    const result = await fetchWithTrace('https://example.com/')
+
+    expect(result.chain).toHaveLength(0)
+    expect(result.finalUrl).toBe('https://example.com/')
+    expect(result.finalRes.status).toBe(301)
+  })
+})

--- a/mcp/src/utils/redirect-trace.ts
+++ b/mcp/src/utils/redirect-trace.ts
@@ -1,0 +1,61 @@
+// ============================================================================
+// redirect-trace.ts — manual redirect following with hop recording
+// ============================================================================
+
+import { ToolError, ErrorCode } from './errors.js'
+
+export interface RedirectHop {
+  from: string
+  to: string
+  status: number
+}
+
+export interface TraceResult {
+  chain: RedirectHop[]
+  finalRes: Response
+  finalUrl: string
+}
+
+const MAX_HOPS = 5
+const REDIRECT_STATUSES = new Set([301, 302, 307, 308])
+
+/**
+ * Fetch URL with manual redirect following. Returns each hop in the chain.
+ * Throws ToolError(UPSTREAM_5XX) on redirect loop or when hop limit exceeded.
+ */
+export async function fetchWithTrace(url: string, opts?: RequestInit): Promise<TraceResult> {
+  const chain: RedirectHop[] = []
+  const visited = new Set<string>()
+  let currentUrl = url
+
+  for (;;) {
+    if (visited.has(currentUrl)) {
+      throw new ToolError(
+        ErrorCode.UPSTREAM_5XX,
+        `Redirect loop detected: ${currentUrl} was visited twice`,
+      )
+    }
+    if (chain.length >= MAX_HOPS) {
+      throw new ToolError(
+        ErrorCode.UPSTREAM_5XX,
+        `Redirect hop limit exceeded (max ${MAX_HOPS})`,
+      )
+    }
+
+    visited.add(currentUrl)
+    const res = await fetch(currentUrl, { ...opts, redirect: 'manual' })
+
+    if (!REDIRECT_STATUSES.has(res.status)) {
+      return { chain, finalRes: res, finalUrl: currentUrl }
+    }
+
+    const location = res.headers.get('location')
+    if (!location) {
+      return { chain, finalRes: res, finalUrl: currentUrl }
+    }
+
+    const toUrl = new URL(location, currentUrl).href
+    chain.push({ from: currentUrl, to: toUrl, status: res.status })
+    currentUrl = toUrl
+  }
+}

--- a/progress-21.txt
+++ b/progress-21.txt
@@ -1,0 +1,34 @@
+## Iteration 1 — 2026-04-25
+
+All acceptance criteria implemented in one pass.
+
+### Criteria completed
+- mcp/src/utils/redirect-trace.ts created: exports fetchWithTrace(url, opts) → { chain, finalRes, finalUrl }
+- Manual redirect loop, max 5 hops; throws ToolError(UPSTREAM_5XX) on loop or hop limit
+- Each chain entry: { from, to, status (301/302/307/308) }
+- Cross-domain detection via tldts parse().domain (eTLD+1) in issue-rules.ts
+- seo_page_audit swaps fetch for fetchWithTrace; output adds redirect_chain field
+- New issue rules: redirect.chain_too_long (>3 hops, warning), redirect.cross_domain (eTLD+1 differs, warning), redirect.non_permanent (302 in chain, info), redirect.loop (duplicate from URL, error)
+- Meta-refresh detection: extractMetaRefreshUrl() in seo-page-audit.ts adds meta_refresh info issue with target URL
+- tldts added to mcp/package.json + installed
+- Unit tests: mcp/src/utils/redirect-trace.test.ts (loop, max-hops, single, no-redirect, relative location, no-location, options forwarding)
+- Integration tests: redirect chain tests in seo-page-audit.test.ts, redirect rules in issue-rules.test.ts
+
+### Files touched
+- mcp/src/utils/redirect-trace.ts (new)
+- mcp/src/utils/redirect-trace.test.ts (new)
+- mcp/src/tools/issue-rules.ts (redirect rules + tldts import)
+- mcp/src/tools/issue-rules.test.ts (redirect chain rule tests)
+- mcp/src/tools/seo-page-audit.ts (fetchWithTrace, redirect_chain output, meta-refresh)
+- mcp/src/tools/seo-page-audit.test.ts (redirect chain + meta-refresh integration tests)
+- mcp/package.json (tldts dep)
+- mcp/pnpm-lock.yaml (irrelevant, npm used)
+
+### Decisions
+- fetchWithTrace throws ToolError on loop/hop-limit; seo-page-audit catches and returns success:false
+- redirect.loop issue rule detects duplicate `from` URLs in chain (for testability even though fetchWithTrace throws first)
+- meta-refresh detection in seo-page-audit (not html-signals) because it triggers an issue, not a signal
+- tldts parse().domain gives eTLD+1; same subdomain→apex redirect does NOT fire cross_domain
+
+### Blockers
+None. All criteria satisfied. Build+test+lint pass (1150 tests).


### PR DESCRIPTION
Closes #21

## Acceptance criteria

- [x] `mcp/src/utils/redirect-trace.ts` exports `fetchWithTrace(url, opts): Promise<{ chain, finalRes, finalUrl }>`
- [x] Manual loop with `redirect: 'manual'`, max 5 hops; throws `ToolError('UPSTREAM_5XX')` on loop or hop limit
- [x] Each chain entry records `from`, `to`, `status` (301/302/307/308)
- [x] Cross-domain redirect detection compares registrable domain (eTLD+1) via `tldts` package
- [x] `seo_page_audit` swaps default `fetch` for `fetchWithTrace`; output includes `redirect_chain` field
- [x] New issue rules added to `issue-rules.ts`:
  - `redirect.chain_too_long` — chain length > 3 → warning
  - `redirect.cross_domain` — final domain differs from start (eTLD+1) → warning
  - `redirect.non_permanent` — any 302 in chain when 301 would be appropriate → info
  - `redirect.loop` — same URL visited twice → error
- [x] Meta-refresh detection: after HTML parse, look for `<meta http-equiv="refresh">`; if present, add `meta_refresh` issue (info severity) with target URL
- [x] `tldts` added to `mcp/package.json` dependencies
- [x] Unit tests for `redirect-trace` with mocked `fetch` (loop, max-hops, single redirect, no redirect)
- [x] Integration test: tool handler with multi-hop fixture chain, asserts `redirect_chain` length and issues fire
- [x] Tests pass; lint clean

## Summary

- New `mcp/src/utils/redirect-trace.ts`: `fetchWithTrace` follows redirects manually (max 5 hops), records each hop, detects loops, throws `ToolError(UPSTREAM_5XX)` on loop/limit
- `issue-rules.ts`: four new redirect rules using `tldts` for eTLD+1 comparison
- `seo-page-audit.ts`: uses `fetchWithTrace`, adds `redirect_chain` to output, detects `<meta http-equiv="refresh">`
- 1150 tests pass, lint clean, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)