### PR TITLE
feat(mcp): PSI cache + throttle + force_refresh for seo_page_audit

### DIFF
--- a/mcp/src/tools/seo-page-audit.test.ts
+++ b/mcp/src/tools/seo-page-audit.test.ts
@@ -11,6 +11,7 @@ import {
   summarizeIssues,
   fetchCwv,
   runSeoPageAudit,
+  psiCache,
   SeoSignals,
 } from './seo-page-audit.js'
 
@@ -91,6 +92,14 @@ describe('seoPageAuditInputSchema', () => {
       psi_strategy: 'tablet',
     })
     expect(result.success).toBe(false)
+  })
+
+  it('applies default force_refresh=false', () => {
+    const result = seoPageAuditInputSchema.safeParse({ url: 'https://example.com/' })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.force_refresh).toBe(false)
+    }
   })
 })
 
@@ -468,6 +477,104 @@ describe('fetchCwv', () => {
 })
 
 // ============================================================================
+// PSI cache — cache key shape and force_refresh behavior
+// ============================================================================
+
+describe('PSI cache', () => {
+  const PSI_RESPONSE = {
+    lighthouseResult: {
+      categories: { performance: { score: 0.8 } },
+      audits: {
+        'largest-contentful-paint': { numericValue: 2000 },
+        'first-contentful-paint': { numericValue: 1000 },
+        'cumulative-layout-shift': { numericValue: 0.1 },
+        'total-blocking-time': { numericValue: 150 },
+      },
+    },
+  }
+
+  const PAGE_HTML = `<!DOCTYPE html>
+<html><head>
+  <title>Test Page For Cache</title>
+  <meta name="description" content="Cache test description here.">
+  <link rel="canonical" href="https://psi-cache-test.example.com/">
+  <meta property="og:image" content="https://psi-cache-test.example.com/img.jpg">
+</head><body><h1>Cache Test</h1></body></html>`
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Clear PSI cache between tests using a fresh store via set+get cycling is not possible,
+    // but we can force-clear by deleting internal state — instead use unique URLs per test.
+  })
+
+  it('cache key is url|strategy — second call hits cache, fetch called only once for PSI', async () => {
+    const testUrl = 'https://psi-cache-test.example.com/cache-hit'
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, url: testUrl, headers: { get: () => null }, text: () => Promise.resolve(PAGE_HTML) })
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(PSI_RESPONSE) })
+      // Third call would be a second PSI fetch — should NOT happen if cache works
+      .mockResolvedValueOnce({ ok: true, status: 200, url: testUrl, headers: { get: () => null }, text: () => Promise.resolve(PAGE_HTML) })
+    vi.stubGlobal('fetch', mockFetch)
+
+    const input = seoPageAuditInputSchema.parse({ url: testUrl, check_cwv: true, psi_api_key: 'key' })
+    // First call — populates cache
+    const r1 = await runSeoPageAudit(input)
+    expect(r1.cwv).toBeDefined()
+
+    // Second call — should hit cache; no additional PSI fetch
+    const r2 = await runSeoPageAudit(input)
+    expect(r2.cwv).toBeDefined()
+    expect(r2.cwv?.performance_score).toBe(r1.cwv?.performance_score)
+
+    // PSI fetch (googleapis.com) called exactly once
+    const psiCalls = mockFetch.mock.calls.filter((args) =>
+      typeof args[0] === 'string' && (args[0] as string).includes('googleapis.com/pagespeedonline'),
+    )
+    expect(psiCalls).toHaveLength(1)
+  })
+
+  it('force_refresh=true skips cache read but writes to cache', async () => {
+    const testUrl = 'https://psi-cache-test.example.com/force-refresh'
+    const mockFetch = vi.fn()
+      .mockResolvedValue({ ok: true, status: 200, url: testUrl, headers: { get: () => null }, text: () => Promise.resolve(PAGE_HTML) })
+
+    // Pre-populate cache so first call would normally hit it
+    const cacheKey = `${testUrl}|mobile`
+    psiCache.set(cacheKey, { lcp: 999, fcp: 999, cls: 0, tbt: 999, performance_score: 99, strategy: 'mobile' })
+
+    const psiMock = vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve(PSI_RESPONSE) })
+    // page fetch + psi fetch interleaved — use mockImplementation to route
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      if (typeof url === 'string' && url.includes('googleapis.com')) return psiMock(url)
+      return mockFetch(url)
+    }))
+
+    const input = seoPageAuditInputSchema.parse({ url: testUrl, check_cwv: true, psi_api_key: 'key', force_refresh: true })
+    const result = await runSeoPageAudit(input)
+
+    // force_refresh bypassed the cached value (99), fetched fresh (80)
+    expect(result.cwv?.performance_score).toBe(80)
+    expect(psiMock).toHaveBeenCalledOnce()
+
+    // And cache was updated with the fresh value
+    const cached = psiCache.get(cacheKey)
+    expect(cached?.performance_score).toBe(80)
+  })
+
+  it('check_cwv=false returns no cwv block', async () => {
+    const testUrl = 'https://psi-cache-test.example.com/no-cwv'
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true, status: 200, url: testUrl, headers: { get: () => null }, text: () => Promise.resolve(PAGE_HTML),
+    }))
+
+    const input = seoPageAuditInputSchema.parse({ url: testUrl, check_cwv: false })
+    const result = await runSeoPageAudit(input)
+
+    expect(result.cwv).toBeUndefined()
+  })
+})
+
+// ============================================================================
 // runSeoPageAudit — integration (mocked fetch)
 // ============================================================================
 
@@ -593,41 +700,44 @@ describe('runSeoPageAudit', () => {
     const input = seoPageAuditInputSchema.parse({
       url: 'https://example.com/page',
       check_cwv: true,
+      psi_api_key: 'dummy-key-to-skip-throttle',
     })
     const result = await runSeoPageAudit(input)
 
     expect(result.success).toBe(true)
     expect(result.cwv).toBeDefined()
     expect(result.cwv?.performance_score).toBe(90)
-    expect(result.cwv_error).toBeUndefined()
+    expect(result.warnings.some((w) => w.startsWith('psi_unavailable:'))).toBe(false)
   })
 
-  it('sets cwv_error when PSI fails and omits cwv', async () => {
+  it('adds psi_unavailable warning when PSI returns 500 and omits cwv', async () => {
+    const failUrl = 'https://example.com/psi-fail-test'
     vi.stubGlobal(
       'fetch',
       vi.fn()
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          url: 'https://example.com/page',
+          url: failUrl,
           text: () => Promise.resolve(SAMPLE_HTML),
         })
         .mockResolvedValueOnce({
           ok: false,
-          status: 429,
-          text: () => Promise.resolve('Rate Limited'),
+          status: 500,
+          text: () => Promise.resolve('Internal Server Error'),
         }),
     )
 
     const input = seoPageAuditInputSchema.parse({
-      url: 'https://example.com/page',
+      url: failUrl,
       check_cwv: true,
+      psi_api_key: 'dummy-key-to-skip-throttle',
     })
     const result = await runSeoPageAudit(input)
 
     expect(result.success).toBe(true)
     expect(result.cwv).toBeUndefined()
-    expect(result.cwv_error).toBeDefined()
+    expect(result.warnings.some((w) => w.startsWith('psi_unavailable:'))).toBe(true)
   })
 
   it('uses GA4Manager honest user-agent by default', async () => {
@@ -695,6 +805,7 @@ describe('seoPageAuditTool definition', () => {
     expect(props.check_cwv).toBeDefined()
     expect(props.psi_api_key).toBeDefined()
     expect(props.psi_strategy).toBeDefined()
+    expect(props.force_refresh).toBeDefined()
   })
 })
 

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -5,6 +5,7 @@ import { runIssueRules, summarizeIssues, type SeoIssue, type IssueSummary } from
 import { fetchWithTrace, type RedirectHop } from '../utils/redirect-trace.js'
 import { ToolError } from '../utils/errors.js'
 import { isAllowed as robotsIsAllowed } from '../utils/robots-check.js'
+import { TTLCache } from '../utils/cache.js'
 
 // Re-export granular helpers so existing imports continue to work
 export {
@@ -68,6 +69,11 @@ export const seoPageAuditInputSchema = z.object({
     .optional()
     .default(false)
     .describe('Override user_agent with the standard Googlebot UA string (default: false)'),
+  force_refresh: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Bypass the 5-minute PSI cache and fetch fresh Core Web Vitals data (default: false)'),
 })
 
 export type SeoPageAuditInput = z.infer<typeof seoPageAuditInputSchema>
@@ -101,7 +107,6 @@ export interface SeoPageAuditOutput {
   issues: SeoIssue[]
   issue_summary: IssueSummary
   cwv?: CwvData
-  cwv_error?: string
   error?: string
 }
 
@@ -169,6 +174,16 @@ function extractMetaRefreshUrl(html: string): string | null {
 }
 
 // ============================================================================
+// PSI cache + keyless throttle
+// ============================================================================
+
+// 5-minute TTL; keyed by `${url}|${strategy}`
+export const psiCache = new TTLCache<CwvData>(5 * 60 * 1000)
+
+// When no API key, PSI rate-limits to ~1 req/100s. A single shared limiter enforces this.
+const keylessPsiLimiter = new Bottleneck({ minTime: 100_000, maxConcurrent: 1 })
+
+// ============================================================================
 // Per-host throttle (1 req/sec per hostname, scoped to MCP session lifetime)
 // ============================================================================
 
@@ -205,7 +220,7 @@ const emptySignals: HtmlSignals = {
 }
 
 export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPageAuditOutput> {
-  const { url, check_cwv, psi_api_key, psi_strategy, respect_robots, as_googlebot } = input
+  const { url, check_cwv, psi_api_key, psi_strategy, respect_robots, as_googlebot, force_refresh } = input
   const effectiveUA = as_googlebot ? GOOGLEBOT_UA : input.user_agent
   const warnings: string[] = []
 
@@ -301,13 +316,21 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
   const issue_summary = summarizeIssues(issues)
 
   let cwv: CwvData | undefined
-  let cwv_error: string | undefined
 
   if (check_cwv) {
-    try {
-      cwv = await fetchCwv(finalUrl, psi_strategy, psi_api_key)
-    } catch (err) {
-      cwv_error = err instanceof Error ? err.message : String(err)
+    const cacheKey = `${finalUrl}|${psi_strategy}`
+    if (!force_refresh) {
+      cwv = psiCache.get(cacheKey)
+    }
+    if (!cwv) {
+      try {
+        const doFetch = () => fetchCwv(finalUrl, psi_strategy, psi_api_key)
+        cwv = psi_api_key ? await doFetch() : await keylessPsiLimiter.schedule(doFetch)
+        psiCache.set(cacheKey, cwv)
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err)
+        warnings.push(`psi_unavailable: ${reason}`)
+      }
     }
   }
 
@@ -322,7 +345,6 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
     issues,
     issue_summary,
     ...(cwv ? { cwv } : {}),
-    ...(cwv_error ? { cwv_error } : {}),
   }
 }
 
@@ -373,6 +395,11 @@ export const seoPageAuditTool = {
       as_googlebot: {
         type: 'boolean',
         description: 'Override user_agent with the standard Googlebot UA string (default: false)',
+        default: false,
+      },
+      force_refresh: {
+        type: 'boolean',
+        description: 'Bypass the 5-minute PSI cache and fetch fresh Core Web Vitals data (default: false)',
         default: false,
       },
     },

--- a/progress-23.txt
+++ b/progress-23.txt
@@ -1,0 +1,25 @@
+## Iteration 1 — 2026-04-25
+
+Criteria completed (all 9):
+- force_refresh?: boolean (default false) added to input schema + tool definition
+- psi-client (fetchCwv) already existed; added TTLCache + Bottleneck wrapping at call site
+- PSI cache: TTLCache<CwvData> 5-min TTL, key "${url}|${strategy}"; force_refresh skips read, always writes
+- PSI throttle: keylessPsiLimiter (minTime: 100000) used when no psi_api_key; no throttle when key present
+- CWV output block already correct (only included when check_cwv=true and PSI succeeds)
+- PSI failure now pushes "psi_unavailable: <reason>" to warnings; removed cwv_error field from output type
+- Unit tests: cache key shape + force_refresh behavior (skips read, writes fresh)
+- Integration tests: check_cwv=false no cwv, check_cwv=true PSI success, check_cwv=true PSI 500 → warning
+- All tests pass (1182), lint clean, build clean
+
+Files touched:
+- mcp/src/tools/seo-page-audit.ts (schema, PSI cache/throttle, failure handling)
+- mcp/src/tools/seo-page-audit.test.ts (new PSI cache describe block, updated PSI failure test)
+
+Decisions:
+- Imported TTLCache from utils/cache.ts (already existed from issue #22)
+- Exported psiCache from seo-page-audit.ts for direct cache manipulation in tests
+- Used unique URLs per test to avoid PSI cache cross-contamination (cache is module-level singleton)
+- dist/ test files compiled by tsc alongside src; both sets must pass (existing repo behavior)
+- PSI cache tests use psi_api_key to bypass keylessPsiLimiter (avoids 100s wait in tests)
+
+Blockers: none


### PR DESCRIPTION
Closes #23

## Acceptance criteria

- [x] `seo_page_audit` input schema gains `check_cwv?: boolean` (default `false`), `psi_api_key?: string`, `psi_strategy?: "mobile" | "desktop"` (default `"mobile"`), `force_refresh?: boolean`
- [x] `psi-client` calls `https://www.googleapis.com/pagespeedonline/v5/runPagespeed?url={url}&strategy={strategy}` (with optional `&key=`)
- [x] PSI cache: `TTLCache` with 5-minute TTL keyed by `${url}|${strategy}`. `force_refresh: true` skips cache read but still writes
- [x] Bottleneck throttle: when no `psi_api_key`, enforce `minTime: 100000` (100s between PSI calls). When key present, no throttle
- [x] Output includes `cwv` block (only when `check_cwv: true` and PSI succeeded): `lcp`, `fcp`, `cls`, `tbt`, `performance_score`, `strategy`
- [x] If PSI fails: `cwv` omitted, `warnings` array gets `psi_unavailable: <reason>` entry; tool still returns `success: true`
- [x] Unit test for cache key shape and `force_refresh` behavior
- [x] Integration tests: `check_cwv: false` returns no `cwv` block, `check_cwv: true` with mocked PSI returns `cwv` block, `check_cwv: true` with PSI 500 returns warning
- [x] Tests pass; lint clean

## Changes

- `mcp/src/tools/seo-page-audit.ts`: added `force_refresh` to Zod schema + MCP tool definition; imported `TTLCache`; added module-level `psiCache` (5-min TTL) and `keylessPsiLimiter` (100s); updated `runSeoPageAudit` to check/write cache, apply throttle conditionally, push `psi_unavailable:` to warnings on failure; removed `cwv_error` from output type
- `mcp/src/tools/seo-page-audit.test.ts`: new `PSI cache` describe block with cache-hit, force_refresh, and no-cwv tests; updated PSI failure test to assert `warnings` contains `psi_unavailable:`; added `force_refresh` default assertion to schema tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)