### PR TITLE
feat(seo): pixel-width estimation + JSON-LD coverage + canonical severity escalation

### DIFF
--- a/mcp/src/tools/html-signals.test.ts
+++ b/mcp/src/tools/html-signals.test.ts
@@ -122,6 +122,17 @@ describe('extractSchemaTypes', () => {
     expect(() => extractSchemaTypes(html)).not.toThrow()
     expect(extractSchemaTypes(html)).toHaveLength(0)
   })
+
+  it('extracts types from multiple <script> blocks with different types', () => {
+    const html = `
+      <script type="application/ld+json">{"@type":"Article"}</script>
+      <script type="application/ld+json">{"@type":"WebPage"}</script>
+    `
+    const types = extractSchemaTypes(html)
+    expect(types).toContain('Article')
+    expect(types).toContain('WebPage')
+    expect(types).toHaveLength(2)
+  })
 })
 
 // ============================================================================
@@ -136,6 +147,7 @@ describe('extractSignals — good-baseline.html', () => {
   it('extracts title text and length', () => {
     expect(signals.title).toBe('Best Practices for Web Performance')
     expect(signals.title_length).toBe(34)
+    expect(signals.title_estimated_pixels).toBeGreaterThan(0)
   })
 
   it('extracts meta description and length', () => {

--- a/mcp/src/tools/html-signals.ts
+++ b/mcp/src/tools/html-signals.ts
@@ -2,11 +2,15 @@
 // html-signals.ts — pure HTML signal extraction, no I/O
 // ============================================================================
 
+import { estimatePixelWidth } from '../utils/pixel-width.js'
+
 export interface HtmlSignals {
   title: string | null
   title_length: number
+  title_estimated_pixels: number
   description: string | null
   description_length: number
+  description_estimated_pixels: number
   canonical: string | null
   robots: string | null
   noindex: boolean
@@ -116,8 +120,10 @@ export function extractSignals(html: string, baseUrl: string): HtmlSignals {
   return {
     title,
     title_length: title ? title.length : 0,
+    title_estimated_pixels: title ? estimatePixelWidth(title) : 0,
     description,
     description_length: description ? description.length : 0,
+    description_estimated_pixels: description ? estimatePixelWidth(description) : 0,
     canonical,
     robots,
     noindex,

--- a/mcp/src/tools/issue-rules.test.ts
+++ b/mcp/src/tools/issue-rules.test.ts
@@ -5,8 +5,10 @@ import type { HtmlSignals } from './html-signals.js'
 const baseSignals: HtmlSignals = {
   title: 'A Good Page Title Here For Testing',
   title_length: 35,
+  title_estimated_pixels: 200,
   description: 'A good meta description for this page that is reasonable length.',
   description_length: 64,
+  description_estimated_pixels: 400,
   canonical: 'https://example.com/page',
   robots: null,
   noindex: false,
@@ -37,19 +39,27 @@ describe('runIssueRules', () => {
   })
 
   it('flags short title (<10 chars) as warning', () => {
-    const signals = { ...baseSignals, title: 'Hi', title_length: 2 }
+    const signals = { ...baseSignals, title: 'Hi', title_length: 2, title_estimated_pixels: 14 }
     const issues = runIssueRules(signals, finalUrl)
     expect(issues.some((i: SeoIssue) => i.field === 'title' && i.severity === 'warning')).toBe(true)
   })
 
   it('flags long title (>70 chars) as warning', () => {
-    const signals = { ...baseSignals, title: 'A'.repeat(71), title_length: 71 }
+    const signals = { ...baseSignals, title: 'A'.repeat(71), title_length: 71, title_estimated_pixels: 71 * 9 }
     const issues = runIssueRules(signals, finalUrl)
     expect(issues.some((i: SeoIssue) => i.field === 'title' && i.severity === 'warning')).toBe(true)
   })
 
-  it('accepts title at exactly 70 chars', () => {
-    const signals = { ...baseSignals, title: 'A'.repeat(70), title_length: 70 }
+  it('flags title exceeding pixel limit (>580px) as warning even when chars <= 70', () => {
+    // 70 'W' chars × 11px = 770px
+    const signals = { ...baseSignals, title: 'W'.repeat(70), title_length: 70, title_estimated_pixels: 770 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'title' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('accepts title at exactly 70 chars and <=580px', () => {
+    // 70 'i' chars × 3px = 210px
+    const signals = { ...baseSignals, title: 'i'.repeat(70), title_length: 70, title_estimated_pixels: 210 }
     const issues = runIssueRules(signals, finalUrl)
     expect(issues.some((i: SeoIssue) => i.field === 'title')).toBe(false)
   })
@@ -62,34 +72,60 @@ describe('runIssueRules', () => {
   })
 
   it('flags description >160 chars as warning', () => {
-    const signals = { ...baseSignals, description: 'A'.repeat(161), description_length: 161 }
+    const signals = { ...baseSignals, description: 'A'.repeat(161), description_length: 161, description_estimated_pixels: 161 * 9 }
     const issues = runIssueRules(signals, finalUrl)
     expect(issues.some((i: SeoIssue) => i.field === 'description' && i.severity === 'warning')).toBe(true)
   })
 
-  it('accepts description at exactly 160 chars', () => {
-    const signals = { ...baseSignals, description: 'A'.repeat(160), description_length: 160 }
+  it('flags description exceeding pixel limit (>920px) as warning even when chars <= 160', () => {
+    // 160 'W' chars × 11px = 1760px
+    const signals = { ...baseSignals, description: 'W'.repeat(160), description_length: 160, description_estimated_pixels: 1760 }
+    const issues = runIssueRules(signals, finalUrl)
+    expect(issues.some((i: SeoIssue) => i.field === 'description' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('accepts description at exactly 160 chars and <=920px', () => {
+    // 160 'i' chars × 3px = 480px
+    const signals = { ...baseSignals, description: 'i'.repeat(160), description_length: 160, description_estimated_pixels: 480 }
     const issues = runIssueRules(signals, finalUrl)
     expect(issues.some((i: SeoIssue) => i.field === 'description')).toBe(false)
   })
 
-  // Canonical rules
+  // Canonical severity escalation
   it('flags missing canonical as warning', () => {
     const signals = { ...baseSignals, canonical: null }
     const issues = runIssueRules(signals, finalUrl)
     expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'warning')).toBe(true)
   })
 
-  it('flags cross-domain canonical as error', () => {
+  it('no issue when canonical matches same host and path', () => {
+    const signals = { ...baseSignals, canonical: 'https://example.com/page' }
+    const issues = runIssueRules(signals, 'https://example.com/page')
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical')).toBe(false)
+  })
+
+  it('info when same eTLD+1 but different path (intentional canonicalization)', () => {
+    const signals = { ...baseSignals, canonical: 'https://example.com/canonical-page' }
+    const issues = runIssueRules(signals, 'https://example.com/page')
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'info')).toBe(true)
+  })
+
+  it('warning when canonical uses different scheme (http vs https), same host', () => {
+    const signals = { ...baseSignals, canonical: 'http://example.com/page' }
+    const issues = runIssueRules(signals, 'https://example.com/page')
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('warning when canonical points to different subdomain, same eTLD+1', () => {
+    const signals = { ...baseSignals, canonical: 'https://www.example.com/page' }
+    const issues = runIssueRules(signals, 'https://example.com/page')
+    expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'warning')).toBe(true)
+  })
+
+  it('error when canonical resolves to different eTLD+1', () => {
     const signals = { ...baseSignals, canonical: 'https://other-domain.com/page' }
     const issues = runIssueRules(signals, finalUrl)
     expect(issues.some((i: SeoIssue) => i.field === 'canonical' && i.severity === 'error')).toBe(true)
-  })
-
-  it('accepts same-domain canonical', () => {
-    const signals = { ...baseSignals, canonical: 'https://example.com/page' }
-    const issues = runIssueRules(signals, finalUrl)
-    expect(issues.some((i: SeoIssue) => i.field === 'canonical')).toBe(false)
   })
 
   it('flags invalid canonical URL as warning', () => {

--- a/mcp/src/tools/issue-rules.ts
+++ b/mcp/src/tools/issue-rules.ts
@@ -84,11 +84,11 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string, chain: Red
         severity: 'warning',
         message: `Title is too short (${signals.title_length} chars, minimum 10)`,
       })
-    } else if (signals.title_length > 70) {
+    } else if (signals.title_length > 70 || signals.title_estimated_pixels > 580) {
       issues.push({
         field: 'title',
         severity: 'warning',
-        message: `Title may be truncated in SERPs (${signals.title_length} chars, max 70)`,
+        message: `Title may be truncated in SERPs (${signals.title_length} chars / ~${signals.title_estimated_pixels}px, max 70 chars or 580px)`,
       })
     }
   }
@@ -97,11 +97,11 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string, chain: Red
 
   if (!signals.description) {
     issues.push({ field: 'description', severity: 'warning', message: 'Page is missing a meta description' })
-  } else if (signals.description_length > 160) {
+  } else if (signals.description_length > 160 || signals.description_estimated_pixels > 920) {
     issues.push({
       field: 'description',
       severity: 'warning',
-      message: `Meta description may be truncated (${signals.description_length} chars, max 160)`,
+      message: `Meta description may be truncated (${signals.description_length} chars / ~${signals.description_estimated_pixels}px, max 160 chars or 920px)`,
     })
   }
 
@@ -111,15 +111,43 @@ export function runIssueRules(signals: HtmlSignals, finalUrl: string, chain: Red
     issues.push({ field: 'canonical', severity: 'warning', message: 'Page is missing a canonical link tag' })
   } else {
     try {
-      const canonicalHost = new URL(signals.canonical).hostname
-      const finalHost = new URL(finalUrl).hostname
-      if (canonicalHost !== finalHost) {
+      const canonUrl = new URL(signals.canonical)
+      const pageUrl = new URL(finalUrl)
+      const canonEtld = registrableDomain(signals.canonical)
+      const pageEtld = registrableDomain(finalUrl)
+
+      if (!canonEtld || !pageEtld) {
+        issues.push({
+          field: 'canonical',
+          severity: 'warning',
+          message: `Canonical URL appears invalid: ${signals.canonical}`,
+        })
+      } else if (canonEtld !== pageEtld) {
         issues.push({
           field: 'canonical',
           severity: 'error',
           message: `Canonical points to different domain: ${signals.canonical}`,
         })
+      } else if (canonUrl.hostname !== pageUrl.hostname) {
+        issues.push({
+          field: 'canonical',
+          severity: 'warning',
+          message: `Canonical points to different subdomain: ${canonUrl.hostname} vs ${pageUrl.hostname}`,
+        })
+      } else if (canonUrl.protocol !== pageUrl.protocol) {
+        issues.push({
+          field: 'canonical',
+          severity: 'warning',
+          message: `Canonical uses different scheme (${canonUrl.protocol.replace(':', '')} vs ${pageUrl.protocol.replace(':', '')})`,
+        })
+      } else if (canonUrl.pathname !== pageUrl.pathname) {
+        issues.push({
+          field: 'canonical',
+          severity: 'info',
+          message: `Canonical points to different path: ${signals.canonical} (intentional, e.g. pagination)`,
+        })
       }
+      // same host + path → no issue
     } catch {
       issues.push({
         field: 'canonical',

--- a/mcp/src/tools/seo-page-audit.test.ts
+++ b/mcp/src/tools/seo-page-audit.test.ts
@@ -256,8 +256,10 @@ describe('extractSchemaTypes', () => {
 const baseSignals: SeoSignals = {
   title: 'A Good Page Title Here',
   title_length: 25,
+  title_estimated_pixels: 150,
   description: 'A good meta description for this page content.',
   description_length: 47,
+  description_estimated_pixels: 300,
   canonical: 'https://example.com/page',
   robots: null,
   noindex: false,

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -207,8 +207,10 @@ const FETCH_TIMEOUT_MS = 10_000
 const emptySignals: HtmlSignals = {
   title: null,
   title_length: 0,
+  title_estimated_pixels: 0,
   description: null,
   description_length: 0,
+  description_estimated_pixels: 0,
   canonical: null,
   robots: null,
   noindex: false,

--- a/mcp/src/utils/pixel-width.test.ts
+++ b/mcp/src/utils/pixel-width.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { estimatePixelWidth } from './pixel-width.js'
+
+describe('estimatePixelWidth', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimatePixelWidth('')).toBe(0)
+  })
+
+  it('measures single known char: uppercase W = 11', () => {
+    expect(estimatePixelWidth('W')).toBe(11)
+  })
+
+  it('measures single known char: lowercase i = 3', () => {
+    expect(estimatePixelWidth('i')).toBe(3)
+  })
+
+  it('golden value: "Hello World"', () => {
+    // H=9 e=7 l=3 l=3 o=7 ' '=3 W=11 o=7 r=4 l=3 d=7 = 64
+    expect(estimatePixelWidth('Hello World')).toBe(64)
+  })
+
+  it('golden value: "abc" = 20', () => {
+    // a=7 b=7 c=6 = 20
+    expect(estimatePixelWidth('abc')).toBe(20)
+  })
+
+  it('golden value: "123" = 21', () => {
+    // 1=7 2=7 3=7 = 21
+    expect(estimatePixelWidth('123')).toBe(21)
+  })
+
+  it('uses default 8px for unmapped chars (emoji)', () => {
+    // Single emoji = 8px default
+    expect(estimatePixelWidth('🎉')).toBe(8)
+  })
+
+  it('uses default 8px for multi-byte / CJK chars', () => {
+    // CJK char = 8px default
+    expect(estimatePixelWidth('中')).toBe(8)
+  })
+
+  it('accumulates width across mixed mapped and unmapped chars', () => {
+    // 'A' = 9, '🎉' = 8 (default) → 17
+    expect(estimatePixelWidth('A🎉')).toBe(17)
+  })
+
+  it('sums all chars in a realistic title', () => {
+    // "SEO" = S=7+E=7+O=9 = 23; verify non-zero
+    const width = estimatePixelWidth('SEO Best Practices for 2024')
+    expect(width).toBeGreaterThan(0)
+    expect(typeof width).toBe('number')
+  })
+})

--- a/mcp/src/utils/pixel-width.ts
+++ b/mcp/src/utils/pixel-width.ts
@@ -1,0 +1,26 @@
+// Arial 13px character width table. Default 8px for unmapped chars.
+const WIDTHS: Record<string, number> = {
+  // Uppercase
+  A: 9, B: 8, C: 8, D: 9, E: 7, F: 7, G: 9, H: 9, I: 3, J: 5,
+  K: 8, L: 7, M: 10, N: 9, O: 9, P: 7, Q: 9, R: 8, S: 7, T: 7,
+  U: 9, V: 8, W: 11, X: 8, Y: 7, Z: 8,
+  // Lowercase
+  a: 7, b: 7, c: 6, d: 7, e: 7, f: 4, g: 7, h: 7, i: 3, j: 3,
+  k: 7, l: 3, m: 11, n: 7, o: 7, p: 7, q: 7, r: 4, s: 6, t: 5,
+  u: 7, v: 6, w: 9, x: 6, y: 6, z: 6,
+  // Digits
+  '0': 7, '1': 7, '2': 7, '3': 7, '4': 7, '5': 7, '6': 7, '7': 7, '8': 7, '9': 7,
+  // Common punctuation
+  ' ': 3, '.': 4, ',': 4, ':': 4, ';': 4, '!': 4, '?': 7, '-': 4, '_': 7, '/': 4,
+  '\\': 4, '(': 4, ')': 4, '[': 4, ']': 4, '{': 4, '}': 4, '+': 7, '=': 7, '<': 7,
+  '>': 7, '|': 3, '"': 5, "'": 3, '`': 5, '^': 8, '~': 7, '#': 7, '%': 9, '&': 9,
+  '*': 6, '@': 12, $: 7,
+}
+
+export function estimatePixelWidth(text: string): number {
+  let total = 0
+  for (const char of text) {
+    total += WIDTHS[char] ?? 8
+  }
+  return total
+}

--- a/progress-24.txt
+++ b/progress-24.txt
@@ -1,0 +1,39 @@
+## Iteration 1 — 2026-04-25
+
+### Criteria completed (all AC in one pass)
+
+AC1: mcp/src/utils/pixel-width.ts — exports estimatePixelWidth(text): number with inlined Arial-13px width table, default 8px for unmapped chars.
+
+AC2: HtmlSignals now includes title_estimated_pixels + description_estimated_pixels; extractSignals computes them via estimatePixelWidth.
+
+AC3: issue-rules.ts title rule fires if chars > 70 OR pixels > 580; description fires if chars > 160 OR pixels > 920. Short title (<10) check unchanged.
+
+AC4: JSON-LD extraction (extractSchemaTypes) already handled all variants (root @type, @graph, @type array, multi-script, malformed, dedupe). Added explicit multi-script-different-types test.
+
+AC5: Canonical severity escalation replaces binary check: missing→warning, same host+path→no issue, same eTLD+1 diff path→info, diff scheme same host→warning, diff subdomain same eTLD+1→warning, diff eTLD+1→error.
+
+AC6: mcp/src/utils/pixel-width.test.ts — golden value tests including emoji/CJK default fallback.
+
+AC7: html-signals.test.ts — added explicit multi-script test for different types; pixel fields verified.
+
+AC8: issue-rules.test.ts — full canonical severity suite (all 7 branches) + pixel OR threshold tests for title and description.
+
+AC9: npm run build, npm run test:run (1214 tests pass), npm run lint — all clean.
+
+### Files touched
+- mcp/src/utils/pixel-width.ts (new)
+- mcp/src/utils/pixel-width.test.ts (new)
+- mcp/src/tools/html-signals.ts
+- mcp/src/tools/html-signals.test.ts
+- mcp/src/tools/issue-rules.ts
+- mcp/src/tools/issue-rules.test.ts
+- mcp/src/tools/seo-page-audit.ts (emptySignals updated)
+- mcp/src/tools/seo-page-audit.test.ts (baseSignals updated)
+
+### Decisions
+- estimatePixelWidth: pure fn, for-of loop over chars handles emoji/multi-byte via default 8px.
+- Canonical escalation: uses tldts registrableDomain (already imported) for eTLD+1 comparison.
+- baseSignals in tests: added pixel fields with plausible values that don't trigger pixel thresholds.
+- "relative canonical resolved before comparison" criterion satisfied by existing extractCanonical(html, baseUrl) in extractSignals.
+
+### No blockers.


### PR DESCRIPTION
Closes #24

## Acceptance criteria

- [x] `mcp/src/utils/pixel-width.ts` exports `estimatePixelWidth(text): number` using an inlined Arial-13px width table (default 8px for unmapped chars). Pure function, zero deps.
- [x] `seo_page_audit` output `signals` adds `title_estimated_pixels` and `description_estimated_pixels` alongside existing char counts
- [x] Issue rules updated:
  - title: warning when chars > 70 OR pixels > 580
  - description: warning when chars > 160 OR pixels > 920
  - title char check stays at < 10 (warning)
- [x] `html-signals.ts` JSON-LD extraction handles:
  - root `@type` (existing)
  - `@graph: [...]` array (iterate entities, push each `@type`)
  - `@type: ["A", "B"]` array form (push all)
  - multiple `<script type="application/ld+json">` blocks in same HTML
  - malformed JSON inside script (try/catch, skip)
  - dedupe final array (no duplicate types)
- [x] Canonical severity rule replaces binary check:
  - missing canonical → warning
  - canonical resolves to same `(host, path)` as audited URL → no issue
  - canonical resolves to same eTLD+1, different path → info
  - canonical resolves to different scheme (http vs https), same host → warning
  - canonical resolves to different subdomain, same eTLD+1 → warning
  - canonical resolves to different eTLD+1 → error
  - relative canonical paths resolved against base URL before comparison
- [x] Unit tests for `pixel-width` (golden values for known strings, including emoji and multi-byte chars)
- [x] Unit tests for JSON-LD extraction covering each variant (root, @graph, multi-type, multi-script, malformed)
- [x] Unit tests for canonical severity covering each branch (same, eTLD+1 different path, different scheme, different subdomain, different eTLD+1)
- [x] Tests pass (1214); lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)