### PR TITLE
feat(mcp): url-normalize + date validation + site format flexibility for gsc_traffic_compare

### DIFF
--- a/mcp/src/tools/compute-traffic-diff.test.ts
+++ b/mcp/src/tools/compute-traffic-diff.test.ts
@@ -185,4 +185,91 @@ describe('computeTrafficDiff', () => {
     expect(summary.urls_only_in_a).toBe(1)
     expect(summary.urls_only_in_b).toBe(1)
   })
+
+  // ── normalize_mode_used ────────────────────────────────────────────────
+
+  it('includes normalize_mode_used in result (default: minimal)', () => {
+    const result = computeTrafficDiff([], [])
+    expect(result.normalize_mode_used).toBe('minimal')
+  })
+
+  it('includes normalize_mode_used when explicitly set', () => {
+    const result = computeTrafficDiff([], [], { normalize: 'aggressive' })
+    expect(result.normalize_mode_used).toBe('aggressive')
+  })
+
+  it('includes normalize_mode_used: none when none passed', () => {
+    const result = computeTrafficDiff([], [], { normalize: 'none' })
+    expect(result.normalize_mode_used).toBe('none')
+  })
+
+  // ── URL normalization — integration ───────────────────────────────────
+
+  function fullRow(
+    url: string,
+    clicks: number,
+    impressions = 1000,
+    ctr = 0.05,
+    position = 5.0,
+  ): GscRow {
+    return { keys: [url], clicks, impressions, ctr, position }
+  }
+
+  it('minimal: trailing-slash variant inner-joins with non-trailing-slash variant', () => {
+    // period_a has trailing slash; period_b does not → should still match
+    const { drops, summary } = computeTrafficDiff(
+      [fullRow('https://example.com/blog/', 100)],
+      [fullRow('https://example.com/blog', 70)],
+      { normalize: 'minimal' },
+    )
+    expect(summary.urls_compared).toBe(1)
+    expect(drops[0].clicks_delta).toBe(-30)
+  })
+
+  it('minimal: different host casing inner-joins', () => {
+    const { summary } = computeTrafficDiff(
+      [fullRow('https://EXAMPLE.COM/page', 100)],
+      [fullRow('https://example.com/page', 80)],
+      { normalize: 'minimal' },
+    )
+    expect(summary.urls_compared).toBe(1)
+  })
+
+  it('aggressive: www vs apex inner-joins', () => {
+    const { summary } = computeTrafficDiff(
+      [fullRow('https://www.example.com/page', 100)],
+      [fullRow('https://example.com/page', 80)],
+      { normalize: 'aggressive' },
+    )
+    expect(summary.urls_compared).toBe(1)
+  })
+
+  it('aggressive: http vs https inner-joins', () => {
+    const { summary } = computeTrafficDiff(
+      [fullRow('http://example.com/page', 100)],
+      [fullRow('https://example.com/page', 80)],
+      { normalize: 'aggressive' },
+    )
+    expect(summary.urls_compared).toBe(1)
+  })
+
+  it('aggressive: query string variants inner-join', () => {
+    const { summary } = computeTrafficDiff(
+      [fullRow('https://example.com/page?utm_source=google', 100)],
+      [fullRow('https://example.com/page', 80)],
+      { normalize: 'aggressive' },
+    )
+    expect(summary.urls_compared).toBe(1)
+  })
+
+  it('none: trailing-slash variants do NOT inner-join', () => {
+    const { summary } = computeTrafficDiff(
+      [fullRow('https://example.com/blog/', 100)],
+      [fullRow('https://example.com/blog', 70)],
+      { normalize: 'none' },
+    )
+    expect(summary.urls_compared).toBe(0)
+    expect(summary.urls_only_in_a).toBe(1)
+    expect(summary.urls_only_in_b).toBe(1)
+  })
 })

--- a/mcp/src/tools/compute-traffic-diff.ts
+++ b/mcp/src/tools/compute-traffic-diff.ts
@@ -1,6 +1,8 @@
 // Pure module for computing per-URL traffic deltas between two GSC periods.
 // Extracted from gsc-traffic-compare for isolated unit testing.
 
+import { normalizeUrl, type NormalizeMode } from '../utils/url-normalize.js'
+
 export interface GscRow {
   keys: string[]
   clicks: number
@@ -36,6 +38,7 @@ export interface TrafficDiffOptions {
   min_clicks_a?: number
   sort_by?: 'clicks_abs' | 'clicks_pct' | 'impressions_abs'
   output_limit?: number
+  normalize?: NormalizeMode
 }
 
 export interface TrafficDiffResult {
@@ -43,12 +46,29 @@ export interface TrafficDiffResult {
   gains: TrafficDiff[]
   unchanged: number
   summary: TrafficDiffSummary
+  normalize_mode_used: NormalizeMode
 }
 
-function buildUrlMap(rows: GscRow[]): Map<string, GscRow> {
+function buildUrlMap(rows: GscRow[], normalize: NormalizeMode): Map<string, GscRow> {
   const map = new Map<string, GscRow>()
   for (const row of rows) {
-    map.set(row.keys.join('|'), row)
+    // Normalize the first key (page URL) only; other dimensions (country, etc.) are kept verbatim
+    const normalizedFirstKey = normalizeUrl(row.keys[0] ?? '', normalize)
+    const compositeKey = [normalizedFirstKey, ...row.keys.slice(1)].join('|')
+    // Last writer wins when normalization collapses multiple forms to the same key
+    const existing = map.get(compositeKey)
+    if (existing === undefined) {
+      map.set(compositeKey, row)
+    } else {
+      // Merge by summing clicks/impressions, averaging position and ctr
+      map.set(compositeKey, {
+        keys: [normalizedFirstKey, ...row.keys.slice(1)],
+        clicks: existing.clicks + row.clicks,
+        impressions: existing.impressions + row.impressions,
+        ctr: (existing.ctr + row.ctr) / 2,
+        position: (existing.position + row.position) / 2,
+      })
+    }
   }
   return map
 }
@@ -80,10 +100,10 @@ export function computeTrafficDiff(
   rowsB: GscRow[],
   opts: TrafficDiffOptions = {},
 ): TrafficDiffResult {
-  const { min_clicks_a = 0, sort_by = 'clicks_abs', output_limit = 50 } = opts
+  const { min_clicks_a = 0, sort_by = 'clicks_abs', output_limit = 50, normalize = 'minimal' } = opts
 
-  const mapA = buildUrlMap(rowsA)
-  const mapB = buildUrlMap(rowsB)
+  const mapA = buildUrlMap(rowsA, normalize)
+  const mapB = buildUrlMap(rowsB, normalize)
 
   const keysA = new Set(mapA.keys())
   const keysB = new Set(mapB.keys())
@@ -148,5 +168,6 @@ export function computeTrafficDiff(
       urls_only_in_a,
       urls_only_in_b,
     },
+    normalize_mode_used: normalize,
   }
 }

--- a/mcp/src/tools/gsc-traffic-compare.test.ts
+++ b/mcp/src/tools/gsc-traffic-compare.test.ts
@@ -133,6 +133,40 @@ describe('gscTrafficCompareInputSchema', () => {
       expect(result.success).toBe(true)
     }
   })
+
+  it('accepts normalize field with valid values', () => {
+    for (const normalize of ['none', 'minimal', 'aggressive'] as const) {
+      const result = gscTrafficCompareInputSchema.safeParse({
+        site: 'sc-domain:example.com',
+        period_a: { start: '2026-03-01', end: '2026-03-31' },
+        period_b: { start: '2026-04-01', end: '2026-04-24' },
+        normalize,
+      })
+      expect(result.success).toBe(true)
+    }
+  })
+
+  it('rejects invalid normalize value', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+      normalize: 'extreme',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('defaults normalize to "minimal"', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.normalize).toBe('minimal')
+    }
+  })
 })
 
 // ============================================================================
@@ -247,10 +281,11 @@ describe('querySearchAnalytics', () => {
 // runGscTrafficCompare — integration (mocked fetch)
 // ============================================================================
 
+// Use same-length periods safely in the past (no lag warning, no length mismatch)
 const baseInput = {
   site: 'sc-domain:example.com',
-  period_a: { start: '2026-03-01', end: '2026-03-31' },
-  period_b: { start: '2026-04-01', end: '2026-04-24' },
+  period_a: { start: '2026-01-01', end: '2026-01-31' },
+  period_b: { start: '2026-02-01', end: '2026-03-03' },
 }
 
 describe('runGscTrafficCompare', () => {
@@ -259,7 +294,7 @@ describe('runGscTrafficCompare', () => {
     vi.stubGlobal('fetch', vi.fn())
   })
 
-  it('happy path: returns success with drops/gains/summary', async () => {
+  it('happy path: returns success with drops/gains/summary and normalize_mode_used', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn()
@@ -285,8 +320,8 @@ describe('runGscTrafficCompare', () => {
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.site).toBe('sc-domain:example.com')
-      expect(result.period_a).toBe('2026-03-01 to 2026-03-31')
-      expect(result.period_b).toBe('2026-04-01 to 2026-04-24')
+      expect(result.period_a).toBe('2026-01-01 to 2026-01-31')
+      expect(result.period_b).toBe('2026-02-01 to 2026-03-03')
       expect(result.drops).toHaveLength(1)
       expect(result.drops[0].url).toBe('/page-a')
       expect(result.drops[0].clicks_delta).toBe(-30)
@@ -294,6 +329,7 @@ describe('runGscTrafficCompare', () => {
       expect(result.drops[0]).toHaveProperty('position_delta')
       expect(result.gains).toHaveLength(0)
       expect(result.warnings).toEqual([])
+      expect(result.normalize_mode_used).toBe('minimal')
     }
   })
 
@@ -409,6 +445,140 @@ describe('runGscTrafficCompare', () => {
 })
 
 // ============================================================================
+// Date validation + warnings
+// ============================================================================
+
+describe('runGscTrafficCompare — date validation and warnings', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  const emptyFetch = () =>
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ rows: [] }),
+    })
+
+  it('returns INVALID_INPUT when period_a start > end', async () => {
+    const input = gscTrafficCompareInputSchema.parse({
+      ...baseInput,
+      period_a: { start: '2026-03-31', end: '2026-03-01' },
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('INVALID_INPUT')
+      expect(result.error.message).toContain('period_a')
+    }
+  })
+
+  it('returns INVALID_INPUT when period_b start > end', async () => {
+    const input = gscTrafficCompareInputSchema.parse({
+      ...baseInput,
+      period_b: { start: '2026-04-30', end: '2026-04-01' },
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('INVALID_INPUT')
+      expect(result.error.message).toContain('period_b')
+    }
+  })
+
+  it('warns when periods overlap (period_a.end >= period_b.start)', async () => {
+    vi.stubGlobal('fetch', emptyFetch())
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-04-10' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.warnings.some((w) => w.toLowerCase().includes('overlap'))).toBe(true)
+    }
+  })
+
+  it('warns when period_b.end is within 48-hour GSC lag window', async () => {
+    vi.stubGlobal('fetch', emptyFetch())
+    const today = new Date().toISOString().slice(0, 10)
+    const yesterday = new Date(Date.now() - 86400000).toISOString().slice(0, 10)
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: yesterday, end: today },
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.warnings.some((w) => w.includes('48 hours') || w.includes('incomplete'))).toBe(true)
+    }
+  })
+
+  it('warns when periods are different lengths', async () => {
+    vi.stubGlobal('fetch', emptyFetch())
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-01-01', end: '2026-01-31' }, // 31 days
+      period_b: { start: '2026-02-01', end: '2026-02-14' }, // 14 days
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.warnings.some((w) => w.includes('different lengths'))).toBe(true)
+    }
+  })
+
+  it('no warning when periods are same length and non-overlapping', async () => {
+    vi.stubGlobal('fetch', emptyFetch())
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-01-01', end: '2026-01-31' },
+      period_b: { start: '2026-02-01', end: '2026-03-03' }, // also 31 days
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      const nonLagWarnings = result.warnings.filter(
+        (w) => !w.includes('48 hours') && !w.includes('incomplete'),
+      )
+      expect(nonLagWarnings).toHaveLength(0)
+    }
+  })
+
+  it('warns when raw domain site input is normalised to sc-domain', async () => {
+    vi.stubGlobal('fetch', emptyFetch())
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'example.com',
+      period_a: { start: '2026-01-01', end: '2026-01-31' },
+      period_b: { start: '2026-02-01', end: '2026-03-03' },
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.warnings.some((w) => w.includes('sc-domain'))).toBe(true)
+      expect(result.site).toBe('sc-domain:example.com')
+    }
+  })
+
+  it('normalised site warning included when https URL missing trailing slash', async () => {
+    vi.stubGlobal('fetch', emptyFetch())
+    const input = gscTrafficCompareInputSchema.parse({
+      site: 'https://example.com',
+      period_a: { start: '2026-01-01', end: '2026-01-31' },
+      period_b: { start: '2026-02-01', end: '2026-03-03' },
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.warnings.some((w) => w.includes('trailing slash'))).toBe(true)
+      expect(result.site).toBe('https://example.com/')
+    }
+  })
+})
+
+// ============================================================================
 // Tool Definition
 // ============================================================================
 
@@ -428,12 +598,13 @@ describe('gscTrafficCompareTool definition', () => {
     expect(gscTrafficCompareTool.inputSchema.required).toContain('period_b')
   })
 
-  it('defines all optional parameters', () => {
+  it('defines all optional parameters including normalize', () => {
     const { properties: props } = gscTrafficCompareTool.inputSchema
     expect(props.dimensions).toBeDefined()
     expect(props.limit).toBeDefined()
     expect(props.min_clicks_a).toBeDefined()
     expect(props.sort_by).toBeDefined()
+    expect(props.normalize).toBeDefined()
   })
 
   it('period_a and period_b are objects with start/end', () => {

--- a/mcp/src/tools/gsc-traffic-compare.ts
+++ b/mcp/src/tools/gsc-traffic-compare.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import { getGoogleAuthHeaders } from '../utils/google-auth.js'
 import { ToolError, ErrorCode } from '../utils/errors.js'
+import { normalizeGscSite } from '../utils/url-normalize.js'
 import {
   computeTrafficDiff,
   type GscRow,
@@ -60,6 +61,13 @@ export const gscTrafficCompareInputSchema = z.object({
     .optional()
     .default('clicks_abs')
     .describe('Sort metric for drops/gains: "clicks_abs" (default), "clicks_pct", "impressions_abs"'),
+  normalize: z
+    .enum(['none', 'minimal', 'aggressive'])
+    .optional()
+    .default('minimal')
+    .describe(
+      'URL normalization before inner-join: "none" (no change), "minimal" (strip trailing slash, lowercase host, default), "aggressive" (minimal + drop www., force https://, drop query string)',
+    ),
 })
 
 export type GscTrafficCompareInput = z.infer<typeof gscTrafficCompareInputSchema>
@@ -79,6 +87,7 @@ export type GscTrafficCompareResult =
       drops: TrafficDiff[]
       gains: TrafficDiff[]
       unchanged: number
+      normalize_mode_used: string
     }
   | {
       success: false
@@ -148,11 +157,74 @@ export async function querySearchAnalytics(
  * Both GSC period requests run in parallel via Promise.allSettled so a single
  * period failure is diagnosable without blocking the other.
  */
+// Returns number of days between two YYYY-MM-DD dates (end - start, inclusive)
+function periodDays(start: string, end: string): number {
+  return (Date.parse(end) - Date.parse(start)) / 86400000 + 1
+}
+
 export async function runGscTrafficCompare(
   input: GscTrafficCompareInput,
 ): Promise<GscTrafficCompareResult> {
-  const { site, period_a, period_b, dimensions, limit, min_clicks_a, sort_by } =
+  const { site: rawSite, period_a, period_b, dimensions, limit, min_clicks_a, sort_by, normalize } =
     input
+
+  // ── Date-range validation ────────────────────────────────────────────────
+
+  if (period_a.start > period_a.end) {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.INVALID_INPUT,
+        message: `period_a start (${period_a.start}) is after end (${period_a.end})`,
+        hint: 'Ensure start <= end in YYYY-MM-DD format',
+      },
+    }
+  }
+
+  if (period_b.start > period_b.end) {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.INVALID_INPUT,
+        message: `period_b start (${period_b.start}) is after end (${period_b.end})`,
+        hint: 'Ensure start <= end in YYYY-MM-DD format',
+      },
+    }
+  }
+
+  const warnings: string[] = []
+
+  // Warn if periods overlap
+  if (period_a.end >= period_b.start) {
+    warnings.push(
+      `Periods overlap (period_a ends ${period_a.end}, period_b starts ${period_b.start}); results may double-count shared dates`,
+    )
+  }
+
+  // Warn if period_b.end is within the GSC 48-hour data lag
+  const today = new Date().toISOString().slice(0, 10)
+  const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString().slice(0, 10)
+  if (period_b.end > twoDaysAgo) {
+    warnings.push(
+      `period_b end (${period_b.end}) is within 48 hours of today (${today}); GSC data may be incomplete`,
+    )
+  }
+
+  // Warn if periods are different lengths
+  const daysA = periodDays(period_a.start, period_a.end)
+  const daysB = periodDays(period_b.start, period_b.end)
+  if (daysA !== daysB) {
+    warnings.push(
+      `Periods are different lengths (period_a: ${daysA} days, period_b: ${daysB} days); per-period totals are not directly comparable`,
+    )
+  }
+
+  // ── Site normalization ───────────────────────────────────────────────────
+
+  const { site, warning: siteWarning } = normalizeGscSite(rawSite)
+  if (siteWarning !== undefined) {
+    warnings.push(siteWarning)
+  }
 
   const [resultA, resultB] = await Promise.allSettled([
     querySearchAnalytics(site, period_a.start, period_a.end, dimensions, limit),
@@ -213,14 +285,15 @@ export async function runGscTrafficCompare(
   const rowsA = (resultA as PromiseFulfilledResult<GscRow[]>).value
   const rowsB = (resultB as PromiseFulfilledResult<GscRow[]>).value
 
-  const { drops, gains, unchanged, summary } = computeTrafficDiff(rowsA, rowsB, {
+  const { drops, gains, unchanged, summary, normalize_mode_used } = computeTrafficDiff(rowsA, rowsB, {
     min_clicks_a,
     sort_by,
+    normalize,
   })
 
   return {
     success: true,
-    warnings: [],
+    warnings,
     site,
     period_a: `${period_a.start} to ${period_a.end}`,
     period_b: `${period_b.start} to ${period_b.end}`,
@@ -228,6 +301,7 @@ export async function runGscTrafficCompare(
     drops,
     gains,
     unchanged,
+    normalize_mode_used,
   }
 }
 
@@ -296,6 +370,13 @@ export const gscTrafficCompareTool = {
         description:
           'Sort metric for drops/gains (default: clicks_abs — absolute click change)',
         default: 'clicks_abs',
+      },
+      normalize: {
+        type: 'string',
+        enum: ['none', 'minimal', 'aggressive'],
+        description:
+          'URL normalization mode before inner-join: "none" (no change), "minimal" (strip trailing slash + lowercase host, default), "aggressive" (minimal + drop www. + force https:// + drop query string)',
+        default: 'minimal',
       },
     },
   },

--- a/mcp/src/utils/url-normalize.test.ts
+++ b/mcp/src/utils/url-normalize.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeUrl, normalizeGscSite } from './url-normalize.js'
+
+// ============================================================================
+// normalizeUrl
+// ============================================================================
+
+describe('normalizeUrl — mode: none', () => {
+  it('returns URL unchanged', () => {
+    expect(normalizeUrl('https://Example.COM/Page/', 'none')).toBe('https://Example.COM/Page/')
+  })
+
+  it('preserves query string', () => {
+    expect(normalizeUrl('https://example.com/page?q=1', 'none')).toBe('https://example.com/page?q=1')
+  })
+
+  it('preserves www prefix', () => {
+    expect(normalizeUrl('https://www.example.com/page', 'none')).toBe('https://www.example.com/page')
+  })
+})
+
+describe('normalizeUrl — mode: minimal', () => {
+  it('strips trailing slash on non-root path', () => {
+    expect(normalizeUrl('https://example.com/page/', 'minimal')).toBe('https://example.com/page')
+  })
+
+  it('lowercases host', () => {
+    expect(normalizeUrl('https://EXAMPLE.COM/page', 'minimal')).toBe('https://example.com/page')
+  })
+
+  it('preserves trailing slash on root path', () => {
+    expect(normalizeUrl('https://example.com/', 'minimal')).toBe('https://example.com/')
+  })
+
+  it('preserves query string', () => {
+    expect(normalizeUrl('https://example.com/page?q=hello', 'minimal')).toBe(
+      'https://example.com/page?q=hello',
+    )
+  })
+
+  it('preserves www prefix', () => {
+    expect(normalizeUrl('https://www.example.com/page', 'minimal')).toBe(
+      'https://www.example.com/page',
+    )
+  })
+
+  it('handles URL with mixed-case host and trailing slash', () => {
+    expect(normalizeUrl('https://Example.COM/Blog/', 'minimal')).toBe('https://example.com/Blog')
+  })
+})
+
+describe('normalizeUrl — mode: aggressive', () => {
+  it('drops trailing slash on non-root path', () => {
+    expect(normalizeUrl('https://example.com/page/', 'aggressive')).toBe('https://example.com/page')
+  })
+
+  it('lowercases host', () => {
+    expect(normalizeUrl('https://EXAMPLE.COM/page', 'aggressive')).toBe('https://example.com/page')
+  })
+
+  it('drops www prefix', () => {
+    expect(normalizeUrl('https://www.example.com/page', 'aggressive')).toBe(
+      'https://example.com/page',
+    )
+  })
+
+  it('forces https scheme from http', () => {
+    expect(normalizeUrl('http://example.com/page', 'aggressive')).toBe('https://example.com/page')
+  })
+
+  it('drops query string', () => {
+    expect(normalizeUrl('https://example.com/page?q=hello&foo=bar', 'aggressive')).toBe(
+      'https://example.com/page',
+    )
+  })
+
+  it('applies all transforms together', () => {
+    expect(
+      normalizeUrl('http://WWW.Example.COM/Blog/?utm_source=google', 'aggressive'),
+    ).toBe('https://example.com/Blog')
+  })
+
+  it('preserves root path', () => {
+    expect(normalizeUrl('http://www.example.com/', 'aggressive')).toBe('https://example.com/')
+  })
+
+  it('different forms of same logical URL collapse to same key', () => {
+    const a = normalizeUrl('https://www.Example.COM/Blog/', 'aggressive')
+    const b = normalizeUrl('http://example.com/Blog?foo=bar', 'aggressive')
+    expect(a).toBe(b)
+  })
+})
+
+describe('normalizeUrl — non-absolute URL', () => {
+  it('strips trailing slash from relative path under minimal', () => {
+    expect(normalizeUrl('/blog/', 'minimal')).toBe('/blog')
+  })
+
+  it('returns relative path unchanged under none', () => {
+    expect(normalizeUrl('/blog/', 'none')).toBe('/blog/')
+  })
+})
+
+// ============================================================================
+// normalizeGscSite
+// ============================================================================
+
+describe('normalizeGscSite', () => {
+  it('accepts sc-domain: prefix as-is, no warning', () => {
+    const result = normalizeGscSite('sc-domain:example.com')
+    expect(result.site).toBe('sc-domain:example.com')
+    expect(result.warning).toBeUndefined()
+  })
+
+  it('accepts https URL with trailing slash as-is, no warning', () => {
+    const result = normalizeGscSite('https://example.com/')
+    expect(result.site).toBe('https://example.com/')
+    expect(result.warning).toBeUndefined()
+  })
+
+  it('accepts http URL with trailing slash as-is, no warning', () => {
+    const result = normalizeGscSite('http://example.com/')
+    expect(result.site).toBe('http://example.com/')
+    expect(result.warning).toBeUndefined()
+  })
+
+  it('adds trailing slash to https URL without one, emits warning', () => {
+    const result = normalizeGscSite('https://example.com')
+    expect(result.site).toBe('https://example.com/')
+    expect(result.warning).toContain('trailing slash')
+  })
+
+  it('adds trailing slash to http URL without one, emits warning', () => {
+    const result = normalizeGscSite('http://example.com')
+    expect(result.site).toBe('http://example.com/')
+    expect(result.warning).toContain('trailing slash')
+  })
+
+  it('raw domain assumes sc-domain property, emits warning', () => {
+    const result = normalizeGscSite('example.com')
+    expect(result.site).toBe('sc-domain:example.com')
+    expect(result.warning).toContain('sc-domain:example.com')
+  })
+
+  it('raw subdomain assumes sc-domain property', () => {
+    const result = normalizeGscSite('blog.example.com')
+    expect(result.site).toBe('sc-domain:blog.example.com')
+    expect(result.warning).toBeDefined()
+  })
+
+  it('trims whitespace before processing', () => {
+    const result = normalizeGscSite('  sc-domain:example.com  ')
+    expect(result.site).toBe('sc-domain:example.com')
+    expect(result.warning).toBeUndefined()
+  })
+
+  it('https URL with path and trailing slash passes through', () => {
+    const result = normalizeGscSite('https://example.com/subfolder/')
+    expect(result.site).toBe('https://example.com/subfolder/')
+    expect(result.warning).toBeUndefined()
+  })
+})

--- a/mcp/src/utils/url-normalize.ts
+++ b/mcp/src/utils/url-normalize.ts
@@ -1,0 +1,81 @@
+// Pure URL normalization utilities for GSC traffic comparison.
+
+export type NormalizeMode = 'none' | 'minimal' | 'aggressive'
+
+/**
+ * Normalize a page URL before inner-joining across GSC periods.
+ *
+ * - none:       no change
+ * - minimal:    lowercase host, strip trailing slash
+ * - aggressive: minimal + drop www., force https://, drop query string
+ */
+export function normalizeUrl(url: string, mode: NormalizeMode): string {
+  if (mode === 'none') return url
+
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    // Not an absolute URL (e.g. a bare path) — apply simple slash stripping only
+    if (mode === 'minimal' || mode === 'aggressive') {
+      return url.replace(/\/$/, '') || '/'
+    }
+    return url
+  }
+
+  if (mode === 'aggressive') {
+    parsed.protocol = 'https:'
+    parsed.hostname = parsed.hostname.toLowerCase().replace(/^www\./, '')
+    parsed.search = ''
+  } else {
+    // minimal
+    parsed.hostname = parsed.hostname.toLowerCase()
+  }
+
+  let result = parsed.toString()
+  // Strip trailing slash on non-root paths
+  if (parsed.pathname !== '/') {
+    result = result.replace(/\/$/, '')
+  }
+  return result
+}
+
+export interface NormalizeGscSiteResult {
+  site: string
+  warning?: string
+}
+
+/**
+ * Accept flexible GSC site formats and return the canonical form used
+ * by the Search Console API.
+ *
+ * Accepted formats:
+ *   sc-domain:example.com        → returned as-is (domain property)
+ *   https://example.com/         → returned as-is (URL-prefix property)
+ *   https://example.com          → adds trailing slash, emits warning
+ *   example.com                  → assumes domain property, emits warning
+ */
+export function normalizeGscSite(input: string): NormalizeGscSiteResult {
+  const trimmed = input.trim()
+
+  if (trimmed.startsWith('sc-domain:')) {
+    return { site: trimmed }
+  }
+
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    if (trimmed.endsWith('/')) {
+      return { site: trimmed }
+    }
+    return {
+      site: trimmed + '/',
+      warning: `Added trailing slash to URL-prefix property; use "${trimmed}/" to avoid this warning`,
+    }
+  }
+
+  // Raw domain — assume sc-domain property
+  const assumed = `sc-domain:${trimmed}`
+  return {
+    site: assumed,
+    warning: `Assumed domain property "${assumed}"; pass sc-domain:${trimmed} explicitly to avoid this warning`,
+  }
+}

--- a/progress-26.txt
+++ b/progress-26.txt
@@ -1,0 +1,27 @@
+## Iteration 1 — 2026-04-25
+
+Criteria completed:
+- url-normalize.ts exports normalizeUrl(url, mode) and normalizeGscSite(input)
+- gsc_traffic_compare schema gains normalize (default "minimal")
+- compute-traffic-diff applies normalization before inner-join; exposes normalize_mode_used
+- Date validation: INVALID_INPUT error when start > end in either period
+- Warnings: overlap, GSC 48h lag, different period lengths
+- site normalized via normalizeGscSite; warning propagated to output warnings[]
+- Unit tests: normalizeUrl (all modes, fixtures) and normalizeGscSite (all formats + edge cases)
+- Integration tests: same URL in different forms inner-joins under minimal/aggressive
+- Integration tests: each warning condition (overlap, lag, length mismatch, site normalization)
+- Integration test: start > end returns INVALID_INPUT error
+
+Files touched:
+- mcp/src/utils/url-normalize.ts (new)
+- mcp/src/utils/url-normalize.test.ts (new)
+- mcp/src/tools/compute-traffic-diff.ts (normalize option + normalize_mode_used)
+- mcp/src/tools/gsc-traffic-compare.ts (normalize schema field + date validation + site normalization)
+- mcp/src/tools/gsc-traffic-compare.test.ts (normalize schema tests + warning/validation tests)
+- mcp/src/tools/compute-traffic-diff.test.ts (normalization + normalize_mode_used tests)
+
+Decisions:
+- When normalization collapses two URLs to same key, merge by summing clicks/impressions and averaging ctr/position (avoids silent data loss)
+- baseInput in gsc-traffic-compare.test.ts uses equal-length past periods to avoid triggering lag/length warnings in existing happy-path test
+
+Blockers: none. All criteria from issue #26 satisfied.


### PR DESCRIPTION
Closes #26

## Acceptance criteria

- [x] `mcp/src/utils/url-normalize.ts` exports `normalizeUrl(url, mode: "none"|"minimal"|"aggressive")` and `normalizeGscSite(input)` — both pure functions
- [x] `gsc_traffic_compare` input schema gains `normalize?: "none" | "minimal" | "aggressive"` (default `"minimal"`)
- [x] `compute-traffic-diff` applies URL normalization to both row sets before inner-join; output includes `normalize_mode_used` field
- [x] Date-range validation: **Error** (`INVALID_INPUT`) if `start > end` within either period; **Warning** if periods overlap, if `period_b.end > today - 2`, or if periods are different lengths
- [x] `site` input passed through `normalizeGscSite` before API call; normalization warning forwarded to `warnings[]`
- [x] Unit tests for `normalizeUrl` covering each mode against fixtures (trailing slash, www, scheme, query string, mixed)
- [x] Unit tests for `normalizeGscSite` covering each accepted format and edge cases
- [x] Integration test: same logical URL in different forms inner-joins correctly under `minimal` and `aggressive`
- [x] Integration tests for each warning condition (overlap, lag, length mismatch, site normalization)
- [x] Integration test for `start > end` returning error
- [x] Tests pass; lint clean

## Changes

- **new** `mcp/src/utils/url-normalize.ts` — `normalizeUrl` + `normalizeGscSite` pure functions
- **new** `mcp/src/utils/url-normalize.test.ts` — full unit test coverage for both functions
- `mcp/src/tools/compute-traffic-diff.ts` — `normalize` option; URL-key normalisation before map build (with merge-on-collision); `normalize_mode_used` in result
- `mcp/src/tools/gsc-traffic-compare.ts` — `normalize` Zod field; date validation; `normalizeGscSite` call; warnings propagation; `normalize_mode_used` in output
- `mcp/src/tools/gsc-traffic-compare.test.ts` — schema tests for `normalize`; warning + error condition integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)