### PR TITLE
feat(mcp): gsc_traffic_compare — fetch/output limits + tail summaries + sort/filter controls

### DIFF
--- a/mcp/src/tools/compute-traffic-diff.test.ts
+++ b/mcp/src/tools/compute-traffic-diff.test.ts
@@ -139,6 +139,73 @@ describe('computeTrafficDiff', () => {
     expect(drops).toHaveLength(50)
   })
 
+  // ── Tail summaries ─────────────────────────────────────────────────────
+
+  it('drops_tail count = total drops minus output_limit', () => {
+    const rowsA = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 100))
+    const rowsB = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 50))
+    const { drops_tail } = computeTrafficDiff(rowsA, rowsB, { output_limit: 50 })
+    expect(drops_tail.count).toBe(20)
+  })
+
+  it('drops_tail total_clicks_delta sums the tail rows', () => {
+    // 70 drops each -50 clicks; top 50 captured, tail 20 each -50 = -1000
+    const rowsA = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 100))
+    const rowsB = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 50))
+    const { drops_tail } = computeTrafficDiff(rowsA, rowsB, { output_limit: 50 })
+    expect(drops_tail.total_clicks_delta).toBe(-1000)
+  })
+
+  it('drops_tail sample has at most 5 rows', () => {
+    const rowsA = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 100))
+    const rowsB = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 50))
+    const { drops_tail } = computeTrafficDiff(rowsA, rowsB, { output_limit: 50 })
+    expect(drops_tail.sample.length).toBeLessThanOrEqual(5)
+    expect(drops_tail.sample).toHaveLength(5)
+  })
+
+  it('gains_tail count = total gains minus output_limit', () => {
+    const rowsA = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 50))
+    const rowsB = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 100))
+    const { gains_tail } = computeTrafficDiff(rowsA, rowsB, { output_limit: 50 })
+    expect(gains_tail.count).toBe(20)
+  })
+
+  it('gains_tail total_clicks_delta sums the tail rows', () => {
+    // 70 gains each +50 clicks; top 50 captured, tail 20 each +50 = +1000
+    const rowsA = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 50))
+    const rowsB = Array.from({ length: 70 }, (_, i) => row(`/page-${i}`, 100))
+    const { gains_tail } = computeTrafficDiff(rowsA, rowsB, { output_limit: 50 })
+    expect(gains_tail.total_clicks_delta).toBe(1000)
+  })
+
+  it('tail is empty when drops/gains count <= output_limit', () => {
+    const { drops_tail, gains_tail } = computeTrafficDiff(
+      [row('/a', 100)],
+      [row('/a', 50)],
+      { output_limit: 50 },
+    )
+    expect(drops_tail).toEqual({ count: 0, total_clicks_delta: 0, sample: [] })
+    expect(gains_tail).toEqual({ count: 0, total_clicks_delta: 0, sample: [] })
+  })
+
+  it('integration: 1000-row fixture — drops/gains bounded by output_limit', () => {
+    const rowsA = Array.from({ length: 1000 }, (_, i) => row(`/page-${i}`, 100 + i))
+    // Even pages: -50% drop; odd pages: +50% gain
+    const rowsB = Array.from({ length: 1000 }, (_, i) =>
+      row(`/page-${i}`, i % 2 === 0 ? Math.round((100 + i) * 0.5) : Math.round((100 + i) * 1.5)),
+    )
+    const limit = 30
+    const { drops, gains, drops_tail, gains_tail } = computeTrafficDiff(rowsA, rowsB, {
+      output_limit: limit,
+    })
+    expect(drops.length).toBeLessThanOrEqual(limit)
+    expect(gains.length).toBeLessThanOrEqual(limit)
+    // Tail must account for the rest
+    expect(drops.length + drops_tail.count).toBe(500) // 500 even pages = drops
+    expect(gains.length + gains_tail.count).toBe(500) // 500 odd pages = gains
+  })
+
   // ── Edge cases ─────────────────────────────────────────────────────────
 
   it('handles empty input', () => {

--- a/mcp/src/tools/compute-traffic-diff.ts
+++ b/mcp/src/tools/compute-traffic-diff.ts
@@ -41,9 +41,17 @@ export interface TrafficDiffOptions {
   normalize?: NormalizeMode
 }
 
+export interface TrafficTail {
+  count: number
+  total_clicks_delta: number
+  sample: TrafficDiff[]
+}
+
 export interface TrafficDiffResult {
   drops: TrafficDiff[]
+  drops_tail: TrafficTail
   gains: TrafficDiff[]
+  gains_tail: TrafficTail
   unchanged: number
   summary: TrafficDiffSummary
   normalize_mode_used: NormalizeMode
@@ -159,9 +167,24 @@ export function computeTrafficDiff(
   drops.sort((a, b) => getSortValue(b, sort_by) - getSortValue(a, sort_by))
   gains.sort((a, b) => getSortValue(b, sort_by) - getSortValue(a, sort_by))
 
+  const dropsTop = drops.slice(0, output_limit)
+  const dropsTailRows = drops.slice(output_limit)
+  const gainsTop = gains.slice(0, output_limit)
+  const gainsTailRows = gains.slice(output_limit)
+
+  function buildTail(rows: TrafficDiff[]): TrafficTail {
+    return {
+      count: rows.length,
+      total_clicks_delta: rows.reduce((sum, r) => sum + r.clicks_delta, 0),
+      sample: rows.slice(0, 5),
+    }
+  }
+
   return {
-    drops: drops.slice(0, output_limit),
-    gains: gains.slice(0, output_limit),
+    drops: dropsTop,
+    drops_tail: buildTail(dropsTailRows),
+    gains: gainsTop,
+    gains_tail: buildTail(gainsTailRows),
     unchanged,
     summary: {
       urls_compared: commonKeys.length,

--- a/mcp/src/tools/gsc-traffic-compare.test.ts
+++ b/mcp/src/tools/gsc-traffic-compare.test.ts
@@ -36,7 +36,8 @@ describe('gscTrafficCompareInputSchema', () => {
       period_a: { start: '2026-02-01', end: '2026-02-28' },
       period_b: { start: '2026-03-01', end: '2026-03-31' },
       dimensions: ['page', 'country'],
-      limit: 1000,
+      fetch_limit: 2000,
+      output_limit: 100,
       min_clicks_a: 10,
       sort_by: 'clicks_pct',
     })
@@ -52,7 +53,8 @@ describe('gscTrafficCompareInputSchema', () => {
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.data.dimensions).toEqual(['page'])
-      expect(result.data.limit).toBe(500)
+      expect(result.data.fetch_limit).toBe(5000)
+      expect(result.data.output_limit).toBe(50)
       expect(result.data.min_clicks_a).toBe(0)
       expect(result.data.sort_by).toBe('clicks_abs')
     }
@@ -92,22 +94,32 @@ describe('gscTrafficCompareInputSchema', () => {
     expect(result.success).toBe(false)
   })
 
-  it('rejects limit above maximum', () => {
+  it('rejects fetch_limit above maximum', () => {
     const result = gscTrafficCompareInputSchema.safeParse({
       site: 'sc-domain:example.com',
       period_a: { start: '2026-03-01', end: '2026-03-31' },
       period_b: { start: '2026-04-01', end: '2026-04-24' },
-      limit: 25001,
+      fetch_limit: 25001,
     })
     expect(result.success).toBe(false)
   })
 
-  it('rejects limit below minimum', () => {
+  it('rejects fetch_limit below minimum', () => {
     const result = gscTrafficCompareInputSchema.safeParse({
       site: 'sc-domain:example.com',
       period_a: { start: '2026-03-01', end: '2026-03-31' },
       period_b: { start: '2026-04-01', end: '2026-04-24' },
-      limit: 0,
+      fetch_limit: 0,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects output_limit above maximum', () => {
+    const result = gscTrafficCompareInputSchema.safeParse({
+      site: 'sc-domain:example.com',
+      period_a: { start: '2026-03-01', end: '2026-03-31' },
+      period_b: { start: '2026-04-01', end: '2026-04-24' },
+      output_limit: 501,
     })
     expect(result.success).toBe(false)
   })
@@ -294,6 +306,20 @@ describe('runGscTrafficCompare', () => {
     vi.stubGlobal('fetch', vi.fn())
   })
 
+  it('returns INVALID_INPUT when fetch_limit <= output_limit', async () => {
+    const input = gscTrafficCompareInputSchema.parse({
+      ...baseInput,
+      fetch_limit: 50,
+      output_limit: 50,
+    })
+    const result = await runGscTrafficCompare(input)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('INVALID_INPUT')
+      expect(result.error.message).toContain('fetch_limit')
+    }
+  })
+
   it('happy path: returns success with drops/gains/summary and normalize_mode_used', async () => {
     vi.stubGlobal(
       'fetch',
@@ -328,6 +354,8 @@ describe('runGscTrafficCompare', () => {
       expect(result.drops[0]).toHaveProperty('ctr_delta')
       expect(result.drops[0]).toHaveProperty('position_delta')
       expect(result.gains).toHaveLength(0)
+      expect(result.drops_tail).toMatchObject({ count: 0, total_clicks_delta: 0, sample: [] })
+      expect(result.gains_tail).toMatchObject({ count: 0, total_clicks_delta: 0, sample: [] })
       expect(result.warnings).toEqual([])
       expect(result.normalize_mode_used).toBe('minimal')
     }
@@ -601,7 +629,8 @@ describe('gscTrafficCompareTool definition', () => {
   it('defines all optional parameters including normalize', () => {
     const { properties: props } = gscTrafficCompareTool.inputSchema
     expect(props.dimensions).toBeDefined()
-    expect(props.limit).toBeDefined()
+    expect(props.fetch_limit).toBeDefined()
+    expect(props.output_limit).toBeDefined()
     expect(props.min_clicks_a).toBeDefined()
     expect(props.sort_by).toBeDefined()
     expect(props.normalize).toBeDefined()

--- a/mcp/src/tools/gsc-traffic-compare.ts
+++ b/mcp/src/tools/gsc-traffic-compare.ts
@@ -7,10 +7,11 @@ import {
   type GscRow,
   type TrafficDiff,
   type TrafficDiffSummary,
+  type TrafficTail,
 } from './compute-traffic-diff.js'
 
 // Re-export for consumers that need the diff types
-export type { TrafficDiff, TrafficDiffSummary }
+export type { TrafficDiff, TrafficDiffSummary, TrafficTail }
 
 // ============================================================================
 // Input Schema
@@ -41,14 +42,22 @@ export const gscTrafficCompareInputSchema = z.object({
     .optional()
     .default(['page'])
     .describe('Dimensions to query, e.g. ["page"] or ["page","country"]'),
-  limit: z
+  fetch_limit: z
     .number()
     .int()
     .min(1)
     .max(25000)
     .optional()
-    .default(500)
-    .describe('Max rows per period from GSC API (default: 500, max 25000)'),
+    .default(5000)
+    .describe('Max rows fetched per period from GSC API (default: 5000, max 25000)'),
+  output_limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(500)
+    .optional()
+    .default(50)
+    .describe('Max drops/gains rows returned in output arrays (default: 50, max 500)'),
   min_clicks_a: z
     .number()
     .int()
@@ -85,7 +94,9 @@ export type GscTrafficCompareResult =
       period_b: string
       summary: TrafficDiffSummary
       drops: TrafficDiff[]
+      drops_tail: TrafficTail
       gains: TrafficDiff[]
+      gains_tail: TrafficTail
       unchanged: number
       normalize_mode_used: string
     }
@@ -165,8 +176,21 @@ function periodDays(start: string, end: string): number {
 export async function runGscTrafficCompare(
   input: GscTrafficCompareInput,
 ): Promise<GscTrafficCompareResult> {
-  const { site: rawSite, period_a, period_b, dimensions, limit, min_clicks_a, sort_by, normalize } =
+  const { site: rawSite, period_a, period_b, dimensions, fetch_limit, output_limit, min_clicks_a, sort_by, normalize } =
     input
+
+  // ── Input validation ────────────────────────────────────────────────────
+
+  if (fetch_limit <= output_limit) {
+    return {
+      success: false,
+      error: {
+        code: ErrorCode.INVALID_INPUT,
+        message: `fetch_limit (${fetch_limit}) must be greater than output_limit (${output_limit})`,
+        hint: 'Increase fetch_limit or decrease output_limit so output_limit < fetch_limit',
+      },
+    }
+  }
 
   // ── Date-range validation ────────────────────────────────────────────────
 
@@ -227,8 +251,8 @@ export async function runGscTrafficCompare(
   }
 
   const [resultA, resultB] = await Promise.allSettled([
-    querySearchAnalytics(site, period_a.start, period_a.end, dimensions, limit),
-    querySearchAnalytics(site, period_b.start, period_b.end, dimensions, limit),
+    querySearchAnalytics(site, period_a.start, period_a.end, dimensions, fetch_limit),
+    querySearchAnalytics(site, period_b.start, period_b.end, dimensions, fetch_limit),
   ])
 
   const aFailed = resultA.status === 'rejected'
@@ -285,11 +309,13 @@ export async function runGscTrafficCompare(
   const rowsA = (resultA as PromiseFulfilledResult<GscRow[]>).value
   const rowsB = (resultB as PromiseFulfilledResult<GscRow[]>).value
 
-  const { drops, gains, unchanged, summary, normalize_mode_used } = computeTrafficDiff(rowsA, rowsB, {
-    min_clicks_a,
-    sort_by,
-    normalize,
-  })
+  const { drops, drops_tail, gains, gains_tail, unchanged, summary, normalize_mode_used } =
+    computeTrafficDiff(rowsA, rowsB, {
+      min_clicks_a,
+      sort_by,
+      normalize,
+      output_limit,
+    })
 
   return {
     success: true,
@@ -299,7 +325,9 @@ export async function runGscTrafficCompare(
     period_b: `${period_b.start} to ${period_b.end}`,
     summary,
     drops,
+    drops_tail,
     gains,
+    gains_tail,
     unchanged,
     normalize_mode_used,
   }
@@ -314,7 +342,12 @@ export const gscTrafficCompareTool = {
   description:
     'Use when the user asks why organic traffic dropped or which pages changed. ' +
     'Compares Google Search Console search analytics between two date ranges per URL, ' +
-    'returning the top drops and gains by clicks. ' +
+    'returning the top drops and gains. ' +
+    'Controls: fetch_limit (rows fetched from GSC, default 5000, max 25000), ' +
+    'output_limit (rows returned per drops/gains array, default 50, max 500), ' +
+    'sort_by (clicks_abs|clicks_pct|impressions_abs, default clicks_abs), ' +
+    'min_clicks_a (filter low-traffic URLs before sort, default 0). ' +
+    'Tail summaries (drops_tail, gains_tail) report count + total_clicks_delta + 5-row sample for rows beyond output_limit. ' +
     'Makes 2 GSC requests per call (one per period). ' +
     'GSC quota is 2000 requests/day.',
   inputSchema: {
@@ -350,12 +383,19 @@ export const gscTrafficCompareTool = {
         description: 'Dimensions to break down by (default: ["page"])',
         default: ['page'],
       },
-      limit: {
+      fetch_limit: {
         type: 'number',
-        description: 'Max rows per period from GSC API (default: 500, max 25000)',
-        default: 500,
+        description: 'Max rows fetched per period from GSC API (default: 5000, max 25000)',
+        default: 5000,
         minimum: 1,
         maximum: 25000,
+      },
+      output_limit: {
+        type: 'number',
+        description: 'Max drops/gains rows returned in output arrays (default: 50, max 500)',
+        default: 50,
+        minimum: 1,
+        maximum: 500,
       },
       min_clicks_a: {
         type: 'number',

--- a/progress-27.txt
+++ b/progress-27.txt
@@ -1,0 +1,21 @@
+progress-27.txt — issue #27: fetch/output limits + tail summary + sort modes + min_clicks_a
+
+Branch: mcp-tools/issue-27
+Parent: main (issues #25 merged via PRs #38, #39)
+
+--- Iteration 1 ---
+Completed: All acceptance criteria in one pass (all checkboxes)
+
+Files touched:
+- mcp/src/tools/compute-traffic-diff.ts — added TrafficTail type; added drops_tail/gains_tail to TrafficDiffResult and computeTrafficDiff return value
+- mcp/src/tools/compute-traffic-diff.test.ts — added tail summary tests (count, total_clicks_delta, sample), 1000-row integration test
+- mcp/src/tools/gsc-traffic-compare.ts — renamed limit→fetch_limit (default 5000), added output_limit (default 50, max 500); added fetch_limit>output_limit validation; updated result type with drops_tail/gains_tail; updated tool description to mention all new controls
+- mcp/src/tools/gsc-traffic-compare.test.ts — updated tests for new schema fields; added fetch_limit<=output_limit INVALID_INPUT test; checked drops_tail/gains_tail in happy path
+
+Decisions:
+- fetch_limit default raised 500→5000 per issue spec
+- output_limit default stays 50 per spec
+- validation: fetch_limit>output_limit is a runtime check (not zod) since it involves two fields
+- tail sample = top-5 of the tail rows (already sorted same as drops/gains)
+
+Blockers: none


### PR DESCRIPTION
Closes #27

## Acceptance criteria

- [x] Input schema: `fetch_limit` (default 5000, max 25000), `output_limit` (default 50, max 500), `min_clicks_a`, `sort_by`
- [x] Validation: `fetch_limit > output_limit`; `output_limit <= 500`; `fetch_limit <= 25000`
- [x] `compute-traffic-diff` updated: sort by `sort_by`, `drops`/`gains` truncated to `output_limit`, `drops_tail`/`gains_tail` with count + total_clicks_delta + 5-row sample, `min_clicks_a` filter before sort
- [x] Output shape includes `drops_tail` and `gains_tail`
- [x] Tool description updated to mention new controls and defaults
- [x] Unit tests: each `sort_by` mode, `output_limit` truncation, tail math (count/total/sample), `min_clicks_a` filtering
- [x] Integration test with 1000-row fixture confirms output bounded by `output_limit`
- [x] Tests pass; lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)