### PR TITLE
feat(mcp): ga4_consent_health — events-only redesign

### DIFF
--- a/mcp/src/tools/compute-consent-health.ts
+++ b/mcp/src/tools/compute-consent-health.ts
@@ -1,0 +1,105 @@
+// Pure function: map GA4 Data API event rows to consent health metrics.
+
+export interface ConsentEventStats {
+  name: string
+  event_count: number
+  total_users: number
+}
+
+export interface ConsentHealthResult {
+  events: {
+    grant_event: ConsentEventStats
+    deny_event: ConsentEventStats
+    view_event?: ConsentEventStats
+  }
+  consent_rate_pct: number | null
+  consent_visibility_pct: number | null
+  health_score: 'healthy' | 'warning' | 'critical' | 'no_data'
+  available: boolean
+  warnings: string[]
+}
+
+export interface ConsentReportRow {
+  dimensionValues: { value: string }[]
+  metricValues: { value: string }[]
+}
+
+export interface ConsentEventNames {
+  grant_event: string
+  deny_event: string
+  view_event: string
+}
+
+/**
+ * Map GA4 Data API rows to consent health metrics.
+ *
+ * Rows are expected to have eventName as dimension[0], eventCount as metric[0],
+ * totalUsers as metric[1].
+ */
+export function computeConsentHealth(
+  rows: ConsentReportRow[],
+  eventNames: ConsentEventNames,
+): ConsentHealthResult {
+  const { grant_event, deny_event, view_event } = eventNames
+  const warnings: string[] = []
+
+  const eventMap = new Map<string, { event_count: number; total_users: number }>()
+  for (const row of rows) {
+    const name = row.dimensionValues[0]?.value ?? ''
+    const eventCount = parseInt(row.metricValues[0]?.value ?? '0', 10)
+    const totalUsers = parseInt(row.metricValues[1]?.value ?? '0', 10)
+    eventMap.set(name, { event_count: eventCount, total_users: totalUsers })
+  }
+
+  const grantStats = eventMap.get(grant_event) ?? { event_count: 0, total_users: 0 }
+  const denyStats = eventMap.get(deny_event) ?? { event_count: 0, total_users: 0 }
+  const viewStats = eventMap.get(view_event)
+
+  const grantCount = grantStats.event_count
+  const denyCount = denyStats.event_count
+  const totalConsent = grantCount + denyCount
+  const available = totalConsent > 0
+
+  const consent_rate_pct =
+    totalConsent > 0 ? Math.round((grantCount / totalConsent) * 1000) / 10 : null
+
+  let consent_visibility_pct: number | null = null
+  if (viewStats !== undefined && viewStats.event_count > 0) {
+    consent_visibility_pct =
+      Math.round((totalConsent / viewStats.event_count) * 1000) / 10
+  }
+
+  let health_score: ConsentHealthResult['health_score']
+  if (!available) {
+    health_score = 'no_data'
+  } else if (consent_rate_pct !== null && consent_rate_pct >= 80) {
+    health_score = 'healthy'
+  } else if (consent_rate_pct !== null && consent_rate_pct >= 50) {
+    health_score = 'warning'
+  } else {
+    health_score = 'critical'
+  }
+
+  if (available && (grantCount === 0 || denyCount === 0)) {
+    warnings.push(
+      'only one consent event observed; banner instrumentation may be incomplete',
+    )
+  }
+
+  const events: ConsentHealthResult['events'] = {
+    grant_event: { name: grant_event, ...grantStats },
+    deny_event: { name: deny_event, ...denyStats },
+  }
+  if (viewStats !== undefined) {
+    events.view_event = { name: view_event, ...viewStats }
+  }
+
+  return {
+    events,
+    consent_rate_pct,
+    consent_visibility_pct,
+    health_score,
+    available,
+    warnings,
+  }
+}

--- a/mcp/src/tools/ga4-consent-health.test.ts
+++ b/mcp/src/tools/ga4-consent-health.test.ts
@@ -2,16 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   ga4ConsentHealthInputSchema,
   ga4ConsentHealthTool,
-  computeHealthScore,
-  parseConsentModeRows,
-  parseCustomEventRows,
-  runDataApiReport,
   runGa4ConsentHealth,
 } from './ga4-consent-health.js'
-
-// ============================================================================
-// Mock google-auth utility
-// ============================================================================
+import { computeConsentHealth } from './compute-consent-health.js'
 
 vi.mock('../utils/google-auth.js', () => ({
   getGoogleAuthHeaders: vi.fn().mockResolvedValue({
@@ -20,310 +13,184 @@ vi.mock('../utils/google-auth.js', () => ({
 }))
 
 // ============================================================================
-// Input Schema Validation
+// Input schema
 // ============================================================================
 
 describe('ga4ConsentHealthInputSchema', () => {
-  it('accepts valid minimal input', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({
+  it('accepts minimal valid input', () => {
+    const r = ga4ConsentHealthInputSchema.safeParse({
       property_id: 'properties/123456789',
+      grant_event: 'consent_granted',
+      deny_event: 'consent_denied',
     })
-    expect(result.success).toBe(true)
+    expect(r.success).toBe(true)
   })
 
-  it('applies defaults', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({
-      property_id: 'properties/123456789',
+  it('applies default days=28 and view_event=page_view', () => {
+    const r = ga4ConsentHealthInputSchema.safeParse({
+      property_id: '123456789',
+      grant_event: 'consent_granted',
+      deny_event: 'consent_denied',
     })
-    expect(result.success).toBe(true)
-    if (result.success) {
-      expect(result.data.days).toBe(28)
+    expect(r.success).toBe(true)
+    if (r.success) {
+      expect(r.data.days).toBe(28)
+      expect(r.data.view_event).toBe('page_view')
     }
   })
 
-  it('accepts all optional fields', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({
-      property_id: 'properties/123456789',
-      days: 90,
-      custom_grant_event: 'consent_granted',
-      custom_deny_event: 'consent_denied',
-    })
-    expect(result.success).toBe(true)
-  })
-
-  it('rejects missing property_id', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({})
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects property_id without properties/ prefix', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({
+  it('accepts raw numeric property_id', () => {
+    const r = ga4ConsentHealthInputSchema.safeParse({
       property_id: '123456789',
+      grant_event: 'consent_granted',
+      deny_event: 'consent_denied',
     })
-    expect(result.success).toBe(false)
+    expect(r.success).toBe(true)
   })
 
-  it('rejects property_id with wrong format', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({
-      property_id: 'properties/abc',
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects days above maximum', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({
+  it('rejects missing grant_event', () => {
+    const r = ga4ConsentHealthInputSchema.safeParse({
       property_id: 'properties/123456789',
+      deny_event: 'consent_denied',
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects missing deny_event', () => {
+    const r = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/123456789',
+      grant_event: 'consent_granted',
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects days above 365', () => {
+    const r = ga4ConsentHealthInputSchema.safeParse({
+      property_id: 'properties/123456789',
+      grant_event: 'g',
+      deny_event: 'd',
       days: 366,
     })
-    expect(result.success).toBe(false)
-  })
-
-  it('rejects days below minimum', () => {
-    const result = ga4ConsentHealthInputSchema.safeParse({
-      property_id: 'properties/123456789',
-      days: 0,
-    })
-    expect(result.success).toBe(false)
+    expect(r.success).toBe(false)
   })
 })
 
 // ============================================================================
-// computeHealthScore
+// computeConsentHealth — pure function unit tests
 // ============================================================================
 
-describe('computeHealthScore', () => {
-  it('returns healthy when denied < 10%', () => {
-    expect(computeHealthScore(0)).toBe('healthy')
-    expect(computeHealthScore(5)).toBe('healthy')
-    expect(computeHealthScore(9.9)).toBe('healthy')
-  })
-
-  it('returns warning when denied 10-30%', () => {
-    expect(computeHealthScore(10)).toBe('warning')
-    expect(computeHealthScore(20)).toBe('warning')
-    expect(computeHealthScore(30)).toBe('warning')
-  })
-
-  it('returns critical when denied > 30%', () => {
-    expect(computeHealthScore(30.1)).toBe('critical')
-    expect(computeHealthScore(50)).toBe('critical')
-    expect(computeHealthScore(100)).toBe('critical')
-  })
+const makeRow = (eventName: string, eventCount: number, totalUsers: number) => ({
+  dimensionValues: [{ value: eventName }],
+  metricValues: [{ value: String(eventCount) }, { value: String(totalUsers) }],
 })
 
-// ============================================================================
-// parseConsentModeRows
-// ============================================================================
+const DEFAULT_NAMES = {
+  grant_event: 'consent_granted',
+  deny_event: 'consent_denied',
+  view_event: 'page_view',
+}
 
-describe('parseConsentModeRows', () => {
-  const makeRow = (
-    analyticsStorage: string,
-    adsStorage: string,
-    sessions: number,
-  ) => ({
-    dimensionValues: [{ value: analyticsStorage }, { value: adsStorage }],
-    metricValues: [{ value: String(sessions) }],
-  })
-
-  it('returns available=false for empty rows', () => {
-    const result = parseConsentModeRows([])
-    expect(result.available).toBe(false)
-    expect(result.analytics_storage.total_sessions).toBe(0)
-  })
-
-  it('computes correct percentages for analytics_storage', () => {
+describe('computeConsentHealth', () => {
+  it('happy path — grant + deny + view all present', () => {
     const rows = [
-      makeRow('GRANTED', 'GRANTED', 700),
-      makeRow('DENIED', 'DENIED', 200),
-      makeRow('UNSET', 'UNSET', 100),
+      makeRow('consent_granted', 800, 750),
+      makeRow('consent_denied', 200, 190),
+      makeRow('page_view', 1200, 1100),
     ]
-    const result = parseConsentModeRows(rows)
-    expect(result.analytics_storage.granted_pct).toBe(70)
-    expect(result.analytics_storage.denied_pct).toBe(20)
-    expect(result.analytics_storage.unset_pct).toBe(10)
-    expect(result.analytics_storage.total_sessions).toBe(1000)
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.available).toBe(true)
+    expect(r.consent_rate_pct).toBe(80)
+    expect(r.health_score).toBe('healthy')
+    expect(r.events.grant_event.event_count).toBe(800)
+    expect(r.events.deny_event.event_count).toBe(200)
+    expect(r.events.view_event?.event_count).toBe(1200)
+    expect(r.consent_visibility_pct).toBe(
+      Math.round(((800 + 200) / 1200) * 1000) / 10,
+    )
+    expect(r.warnings).toHaveLength(0)
   })
 
-  it('computes correct percentages for ads_storage', () => {
+  it('one event missing — only grant present — warns incomplete', () => {
+    const rows = [makeRow('consent_granted', 800, 750)]
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.available).toBe(true)
+    expect(r.consent_rate_pct).toBe(100)
+    expect(r.warnings).toContain(
+      'only one consent event observed; banner instrumentation may be incomplete',
+    )
+  })
+
+  it('one event missing — only deny present — warns incomplete', () => {
+    const rows = [makeRow('consent_denied', 200, 190)]
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.available).toBe(true)
+    expect(r.consent_rate_pct).toBe(0)
+    expect(r.warnings).toContain(
+      'only one consent event observed; banner instrumentation may be incomplete',
+    )
+  })
+
+  it('both events missing — available=false, health_score=no_data', () => {
+    const r = computeConsentHealth([], DEFAULT_NAMES)
+    expect(r.available).toBe(false)
+    expect(r.health_score).toBe('no_data')
+    expect(r.consent_rate_pct).toBeNull()
+    expect(r.warnings).toHaveLength(0)
+  })
+
+  it('threshold 81% → healthy', () => {
     const rows = [
-      makeRow('GRANTED', 'GRANTED', 800),
-      makeRow('GRANTED', 'DENIED', 200),
+      makeRow('consent_granted', 810, 800),
+      makeRow('consent_denied', 190, 180),
     ]
-    const result = parseConsentModeRows(rows)
-    expect(result.ads_storage.granted_pct).toBe(80)
-    expect(result.ads_storage.denied_pct).toBe(20)
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.health_score).toBe('healthy')
   })
 
-  it('sets available=true when granted or denied sessions exist', () => {
-    const rows = [makeRow('GRANTED', 'GRANTED', 100)]
-    const result = parseConsentModeRows(rows)
-    expect(result.available).toBe(true)
-  })
-
-  it('sets available=false when all sessions are UNSET', () => {
-    const rows = [makeRow('UNSET', 'UNSET', 1000)]
-    const result = parseConsentModeRows(rows)
-    expect(result.available).toBe(false)
-  })
-
-  it('handles aggregation of multiple GRANTED rows', () => {
+  it('threshold 65% → warning', () => {
     const rows = [
-      makeRow('GRANTED', 'GRANTED', 300),
-      makeRow('GRANTED', 'DENIED', 200),
+      makeRow('consent_granted', 650, 640),
+      makeRow('consent_denied', 350, 340),
     ]
-    // analytics_storage: 500 granted, 0 denied = 100% granted
-    const result = parseConsentModeRows(rows)
-    expect(result.analytics_storage.granted_pct).toBe(100)
-    expect(result.analytics_storage.denied_pct).toBe(0)
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.health_score).toBe('warning')
+  })
+
+  it('threshold 30% → critical', () => {
+    const rows = [
+      makeRow('consent_granted', 300, 290),
+      makeRow('consent_denied', 700, 690),
+    ]
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.health_score).toBe('critical')
+  })
+
+  it('0% grant → critical', () => {
+    const rows = [makeRow('consent_denied', 1000, 990)]
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.consent_rate_pct).toBe(0)
+    expect(r.health_score).toBe('critical')
+  })
+
+  it('division-by-zero safety — empty rows', () => {
+    const r = computeConsentHealth([], DEFAULT_NAMES)
+    expect(r.consent_rate_pct).toBeNull()
+    expect(r.consent_visibility_pct).toBeNull()
+  })
+
+  it('view_event absent → consent_visibility_pct null', () => {
+    const rows = [
+      makeRow('consent_granted', 800, 750),
+      makeRow('consent_denied', 200, 190),
+    ]
+    const r = computeConsentHealth(rows, DEFAULT_NAMES)
+    expect(r.consent_visibility_pct).toBeNull()
+    expect(r.events.view_event).toBeUndefined()
   })
 })
 
 // ============================================================================
-// parseCustomEventRows
-// ============================================================================
-
-describe('parseCustomEventRows', () => {
-  const makeRow = (eventName: string, count: number) => ({
-    dimensionValues: [{ value: eventName }],
-    metricValues: [{ value: String(count) }],
-  })
-
-  it('correctly parses grant and deny counts', () => {
-    const rows = [
-      makeRow('consent_granted', 800),
-      makeRow('consent_denied', 200),
-    ]
-    const result = parseCustomEventRows(rows, 'consent_granted', 'consent_denied')
-    expect(result.grant_count).toBe(800)
-    expect(result.deny_count).toBe(200)
-    expect(result.consent_rate_pct).toBe(80)
-  })
-
-  it('handles missing grant event', () => {
-    const rows = [makeRow('consent_denied', 200)]
-    const result = parseCustomEventRows(rows, 'consent_granted', 'consent_denied')
-    expect(result.grant_count).toBe(0)
-    expect(result.deny_count).toBe(200)
-    expect(result.consent_rate_pct).toBe(0)
-  })
-
-  it('handles missing deny event', () => {
-    const rows = [makeRow('consent_granted', 800)]
-    const result = parseCustomEventRows(rows, 'consent_granted', 'consent_denied')
-    expect(result.grant_count).toBe(800)
-    expect(result.deny_count).toBe(0)
-    expect(result.consent_rate_pct).toBe(100)
-  })
-
-  it('handles empty rows', () => {
-    const result = parseCustomEventRows([], 'consent_granted', 'consent_denied')
-    expect(result.grant_count).toBe(0)
-    expect(result.deny_count).toBe(0)
-    expect(result.consent_rate_pct).toBe(0)
-  })
-
-  it('echoes event names in output', () => {
-    const rows: ReturnType<typeof makeRow>[] = []
-    const result = parseCustomEventRows(rows, 'my_grant_event', 'my_deny_event')
-    expect(result.grant_event).toBe('my_grant_event')
-    expect(result.deny_event).toBe('my_deny_event')
-  })
-})
-
-// ============================================================================
-// runDataApiReport — API integration (mocked fetch)
-// ============================================================================
-
-describe('runDataApiReport', () => {
-  beforeEach(() => {
-    vi.resetAllMocks()
-    vi.stubGlobal('fetch', vi.fn())
-  })
-
-  it('calls Data API with correct URL and auth', async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ rows: [] }),
-    })
-    vi.stubGlobal('fetch', mockFetch)
-
-    await runDataApiReport('properties/123456789', {
-      dateRanges: [{ startDate: '28daysAgo', endDate: 'today' }],
-      dimensions: [{ name: 'privacyInfoAnalyticsStorage' }],
-      metrics: [{ name: 'sessions' }],
-    })
-
-    expect(mockFetch).toHaveBeenCalledOnce()
-    const [url, options] = mockFetch.mock.calls[0] as [string, RequestInit]
-    expect(url).toBe(
-      'https://analyticsdata.googleapis.com/v1beta/properties/123456789:runReport',
-    )
-    expect(options.method).toBe('POST')
-    const body = JSON.parse(options.body as string)
-    expect(body.dimensions[0].name).toBe('privacyInfoAnalyticsStorage')
-  })
-
-  it('returns empty array when no rows in response', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({}),
-      }),
-    )
-
-    const rows = await runDataApiReport('properties/123456789', {})
-    expect(rows).toHaveLength(0)
-  })
-
-  it('throws descriptive error on 403', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 403,
-        text: () => Promise.resolve('Forbidden'),
-      }),
-    )
-
-    await expect(runDataApiReport('properties/123456789', {})).rejects.toThrow(
-      'GA4 Data API access denied',
-    )
-  })
-
-  it('throws descriptive error on 404', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 404,
-        text: () => Promise.resolve('Not Found'),
-      }),
-    )
-
-    await expect(runDataApiReport('properties/123456789', {})).rejects.toThrow(
-      'Property not found: properties/123456789',
-    )
-  })
-
-  it('throws generic error on other HTTP failures', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: () => Promise.resolve('Server Error'),
-      }),
-    )
-
-    await expect(runDataApiReport('properties/123456789', {})).rejects.toThrow(
-      'GA4 Data API error (HTTP 500)',
-    )
-  })
-})
-
-// ============================================================================
-// runGa4ConsentHealth — integration (mocked fetch)
+// runGa4ConsentHealth — handler with mocked fetch
 // ============================================================================
 
 describe('runGa4ConsentHealth', () => {
@@ -332,16 +199,13 @@ describe('runGa4ConsentHealth', () => {
     vi.stubGlobal('fetch', vi.fn())
   })
 
-  const makeConsentRow = (
-    analyticsStorage: string,
-    adsStorage: string,
-    sessions: number,
-  ) => ({
-    dimensionValues: [{ value: analyticsStorage }, { value: adsStorage }],
-    metricValues: [{ value: String(sessions) }],
-  })
+  const baseInput = {
+    property_id: 'properties/123456789',
+    grant_event: 'consent_granted',
+    deny_event: 'consent_denied',
+  }
 
-  it('returns healthy score when few denied sessions', async () => {
+  it('happy path — returns healthy with event counts', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -349,88 +213,45 @@ describe('runGa4ConsentHealth', () => {
         json: () =>
           Promise.resolve({
             rows: [
-              makeConsentRow('GRANTED', 'GRANTED', 950),
-              makeConsentRow('DENIED', 'DENIED', 50), // 5% denied
+              makeRow('consent_granted', 800, 750),
+              makeRow('consent_denied', 100, 95),
+              makeRow('page_view', 1200, 1100),
             ],
           }),
       }),
     )
-
-    const input = ga4ConsentHealthInputSchema.parse({
-      property_id: 'properties/123456789',
-    })
-    const result = await runGa4ConsentHealth(input)
-
-    expect(result.success).toBe(true)
-    expect(result.health_score).toBe('healthy')
-    expect(result.consent_mode.analytics_storage.denied_pct).toBe(5)
-    expect(result.consent_mode.available).toBe(true)
+    const input = ga4ConsentHealthInputSchema.parse(baseInput)
+    const r = await runGa4ConsentHealth(input)
+    expect(r.success).toBe(true)
+    if (r.success) {
+      expect(r.health_score).toBe('healthy')
+      expect(r.available).toBe(true)
+      expect(r.events.grant_event.event_count).toBe(800)
+      expect(r.events.deny_event.event_count).toBe(100)
+      expect(r.property_id).toBe('properties/123456789')
+      expect(r.period).toBe('last 28 days')
+    }
   })
 
-  it('returns critical when consent mode unavailable (all UNSET)', async () => {
+  it('empty-rows fixture → available=false, health_score=no_data', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
         ok: true,
-        json: () =>
-          Promise.resolve({
-            rows: [makeConsentRow('UNSET', 'UNSET', 1000)],
-          }),
+        json: () => Promise.resolve({ rows: [] }),
       }),
     )
-
-    const input = ga4ConsentHealthInputSchema.parse({
-      property_id: 'properties/123456789',
-    })
-    const result = await runGa4ConsentHealth(input)
-
-    expect(result.success).toBe(true)
-    // UNSET = 100% unset, 0% denied → healthy score since denied=0
-    expect(result.health_score).toBe('healthy')
-    expect(result.consent_mode.available).toBe(false)
+    const input = ga4ConsentHealthInputSchema.parse(baseInput)
+    const r = await runGa4ConsentHealth(input)
+    expect(r.success).toBe(true)
+    if (r.success) {
+      expect(r.available).toBe(false)
+      expect(r.health_score).toBe('no_data')
+      expect(r.warnings.length).toBeGreaterThan(0)
+    }
   })
 
-  it('includes custom_events when custom event names provided', async () => {
-    const consentRows = [makeConsentRow('GRANTED', 'GRANTED', 1000)]
-    const eventRows = [
-      {
-        dimensionValues: [{ value: 'consent_granted' }],
-        metricValues: [{ value: '800' }],
-      },
-      {
-        dimensionValues: [{ value: 'consent_denied' }],
-        metricValues: [{ value: '200' }],
-      },
-    ]
-
-    vi.stubGlobal(
-      'fetch',
-      vi.fn()
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ rows: consentRows }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ rows: eventRows }),
-        }),
-    )
-
-    const input = ga4ConsentHealthInputSchema.parse({
-      property_id: 'properties/123456789',
-      custom_grant_event: 'consent_granted',
-      custom_deny_event: 'consent_denied',
-    })
-    const result = await runGa4ConsentHealth(input)
-
-    expect(result.success).toBe(true)
-    expect(result.custom_events).toBeDefined()
-    expect(result.custom_events?.grant_count).toBe(800)
-    expect(result.custom_events?.deny_count).toBe(200)
-    expect(result.custom_events?.consent_rate_pct).toBe(80)
-  })
-
-  it('returns error result on API failure', async () => {
+  it('403 → AUTH_DENIED error', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -439,17 +260,16 @@ describe('runGa4ConsentHealth', () => {
         text: () => Promise.resolve('Forbidden'),
       }),
     )
-
-    const input = ga4ConsentHealthInputSchema.parse({
-      property_id: 'properties/123456789',
-    })
-    const result = await runGa4ConsentHealth(input)
-
-    expect(result.success).toBe(false)
-    expect(result.error).toContain('GA4 Data API access denied')
+    const input = ga4ConsentHealthInputSchema.parse(baseInput)
+    const r = await runGa4ConsentHealth(input)
+    expect(r.success).toBe(false)
+    if (!r.success) {
+      expect(r.error.code).toBe('AUTH_DENIED')
+      expect(r.error.hint).toContain('PERMISSIONS.md')
+    }
   })
 
-  it('includes period string in output', async () => {
+  it('raw numeric property_id is normalized to properties/N', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -457,39 +277,55 @@ describe('runGa4ConsentHealth', () => {
         json: () => Promise.resolve({ rows: [] }),
       }),
     )
-
     const input = ga4ConsentHealthInputSchema.parse({
-      property_id: 'properties/123456789',
-      days: 90,
+      ...baseInput,
+      property_id: '987654321',
     })
-    const result = await runGa4ConsentHealth(input)
+    const r = await runGa4ConsentHealth(input)
+    expect(r.success).toBe(true)
+    if (r.success) {
+      expect(r.property_id).toBe('properties/987654321')
+    }
+  })
 
-    expect(result.period).toBe('last 90 days')
+  it('G-XXXXXX Measurement ID → INVALID_INPUT error', async () => {
+    const input = ga4ConsentHealthInputSchema.parse({
+      ...baseInput,
+      property_id: 'G-ABC123',
+    })
+    const r = await runGa4ConsentHealth(input)
+    expect(r.success).toBe(false)
+    if (!r.success) {
+      expect(r.error.code).toBe('INVALID_INPUT')
+      expect(r.error.message).toContain('Measurement ID')
+    }
   })
 })
 
 // ============================================================================
-// Tool Definition
+// Tool definition
 // ============================================================================
 
-describe('ga4ConsentHealthTool definition', () => {
+describe('ga4ConsentHealthTool', () => {
   it('has correct tool name', () => {
     expect(ga4ConsentHealthTool.name).toBe('ga4_consent_health')
   })
 
-  it('has a descriptive description', () => {
-    expect(ga4ConsentHealthTool.description).toContain('Consent Mode')
-    expect(ga4ConsentHealthTool.description).toContain('GA4')
+  it('description mentions consent events and clarifies Consent Mode v2 unavailability', () => {
+    expect(ga4ConsentHealthTool.description).toContain('consent_granted')
+    expect(ga4ConsentHealthTool.description).toContain('Consent Mode v2')
+    expect(ga4ConsentHealthTool.description).toContain('NOT exposed')
   })
 
-  it('defines required fields', () => {
+  it('requires property_id, grant_event, deny_event', () => {
     expect(ga4ConsentHealthTool.inputSchema.required).toContain('property_id')
+    expect(ga4ConsentHealthTool.inputSchema.required).toContain('grant_event')
+    expect(ga4ConsentHealthTool.inputSchema.required).toContain('deny_event')
   })
 
-  it('defines all optional parameters', () => {
+  it('defines view_event and days as optional properties', () => {
     const props = ga4ConsentHealthTool.inputSchema.properties
+    expect(props.view_event).toBeDefined()
     expect(props.days).toBeDefined()
-    expect(props.custom_grant_event).toBeDefined()
-    expect(props.custom_deny_event).toBeDefined()
   })
 })

--- a/mcp/src/tools/ga4-consent-health.ts
+++ b/mcp/src/tools/ga4-consent-health.ts
@@ -1,220 +1,93 @@
 import { z } from 'zod'
 import { getGoogleAuthHeaders } from '../utils/google-auth.js'
+import { ToolError, ErrorCode } from '../utils/errors.js'
+import { normalizeGa4Property } from '../utils/url-normalize.js'
+import {
+  computeConsentHealth,
+  type ConsentReportRow,
+  type ConsentHealthResult,
+} from './compute-consent-health.js'
 
 // ============================================================================
 // Input Schema
 // ============================================================================
 
 export const ga4ConsentHealthInputSchema = z.object({
-  /** GA4 property ID in format "properties/123456789" */
   property_id: z
     .string()
     .min(1, 'property_id is required')
-    .regex(/^properties\/\d+$/, 'property_id must be in format "properties/123456789"'),
-  /** Number of days to analyze (default: 28) */
-  days: z.number().int().min(1).max(365).optional().default(28),
-  /** Optional custom consent-granted event name */
-  custom_grant_event: z.string().optional(),
-  /** Optional custom consent-denied event name */
-  custom_deny_event: z.string().optional(),
+    .describe(
+      'GA4 Property ID: numeric (e.g. "123456789") or full form "properties/123456789". Not a Measurement ID (G-XXXXXX).',
+    ),
+  days: z
+    .number()
+    .int()
+    .min(1)
+    .max(365)
+    .optional()
+    .default(28)
+    .describe('Look-back window in days (default: 28; max: 365), e.g. 28'),
+  grant_event: z
+    .string()
+    .min(1, 'grant_event is required')
+    .describe(
+      'GA4 event name fired when user grants consent, e.g. "consent_granted"',
+    ),
+  deny_event: z
+    .string()
+    .min(1, 'deny_event is required')
+    .describe(
+      'GA4 event name fired when user denies consent, e.g. "consent_denied"',
+    ),
+  view_event: z
+    .string()
+    .min(1)
+    .optional()
+    .default('page_view')
+    .describe(
+      'Page/view event used as denominator for consent_visibility_pct (default: "page_view")',
+    ),
 })
 
 export type Ga4ConsentHealthInput = z.infer<typeof ga4ConsentHealthInputSchema>
 
 // ============================================================================
-// Output Types
+// Result Types
 // ============================================================================
 
-export interface ConsentStorageStats {
-  granted_pct: number
-  denied_pct: number
-  unset_pct: number
-  total_sessions: number
-}
-
-export interface ConsentModeData {
-  analytics_storage: ConsentStorageStats
-  ads_storage: ConsentStorageStats
-  available: boolean
-}
-
-export interface CustomEventData {
-  grant_event: string
-  grant_count: number
-  deny_event: string
-  deny_count: number
-  consent_rate_pct: number
-}
-
-export interface Ga4ConsentHealthOutput {
-  success: boolean
+export type Ga4ConsentHealthSuccess = {
+  success: true
+  warnings: string[]
   property_id: string
   period: string
-  consent_mode: ConsentModeData
-  custom_events?: CustomEventData
-  health_score: 'healthy' | 'warning' | 'critical'
-  error?: string
+} & ConsentHealthResult
+
+export interface Ga4ConsentHealthError {
+  success: false
+  error: {
+    code: ErrorCode
+    message: string
+    hint?: string
+  }
 }
+
+export type Ga4ConsentHealthResult =
+  | Ga4ConsentHealthSuccess
+  | Ga4ConsentHealthError
 
 // ============================================================================
-// GA4 Data API Types
+// Data API
 // ============================================================================
-
-interface DimensionValue {
-  value: string
-}
-
-interface MetricValue {
-  value: string
-}
-
-interface DataApiRow {
-  dimensionValues: DimensionValue[]
-  metricValues: MetricValue[]
-}
 
 interface DataApiResponse {
-  rows?: DataApiRow[]
+  rows?: ConsentReportRow[]
+  error?: { code: number; message: string }
 }
 
-// ============================================================================
-// Health Score Logic
-// ============================================================================
-
-/**
- * Compute health score based on analytics_storage denied percentage
- */
-export function computeHealthScore(
-  deniedPct: number,
-): 'healthy' | 'warning' | 'critical' {
-  if (deniedPct > 30) return 'critical'
-  if (deniedPct >= 10) return 'warning'
-  return 'healthy'
-}
-
-// ============================================================================
-// Consent Mode Report Processing
-// ============================================================================
-
-/**
- * Parse consent mode report rows into storage stats
- */
-export function parseConsentModeRows(rows: DataApiRow[]): {
-  analytics_storage: ConsentStorageStats
-  ads_storage: ConsentStorageStats
-  available: boolean
-} {
-  if (rows.length === 0) {
-    const empty: ConsentStorageStats = {
-      granted_pct: 0,
-      denied_pct: 0,
-      unset_pct: 0,
-      total_sessions: 0,
-    }
-    return {
-      analytics_storage: empty,
-      ads_storage: empty,
-      available: false,
-    }
-  }
-
-  // Aggregate sessions by analytics_storage and ads_storage consent values
-  // Dimensions: [0]=privacyInfoAnalyticsStorage, [1]=privacyInfoAdsStorage
-  const analyticsMap = new Map<string, number>()
-  const adsMap = new Map<string, number>()
-
-  for (const row of rows) {
-    const analyticsVal = row.dimensionValues[0]?.value ?? 'UNSET'
-    const adsVal = row.dimensionValues[1]?.value ?? 'UNSET'
-    const sessions = parseInt(row.metricValues[0]?.value ?? '0', 10)
-
-    analyticsMap.set(analyticsVal, (analyticsMap.get(analyticsVal) ?? 0) + sessions)
-    adsMap.set(adsVal, (adsMap.get(adsVal) ?? 0) + sessions)
-  }
-
-  const toStats = (map: Map<string, number>): ConsentStorageStats => {
-    const granted = map.get('GRANTED') ?? 0
-    const denied = map.get('DENIED') ?? 0
-    // Any value not GRANTED or DENIED counts as unset
-    let unset = 0
-    for (const [key, val] of map) {
-      if (key !== 'GRANTED' && key !== 'DENIED') {
-        unset += val
-      }
-    }
-    const total = granted + denied + unset
-
-    if (total === 0) {
-      return { granted_pct: 0, denied_pct: 0, unset_pct: 0, total_sessions: 0 }
-    }
-
-    return {
-      granted_pct: Math.round((granted / total) * 1000) / 10,
-      denied_pct: Math.round((denied / total) * 1000) / 10,
-      unset_pct: Math.round((unset / total) * 1000) / 10,
-      total_sessions: total,
-    }
-  }
-
-  // Check if consent mode data is meaningful (not all UNSET)
-  const analyticsGranted = analyticsMap.get('GRANTED') ?? 0
-  const analyticsDenied = analyticsMap.get('DENIED') ?? 0
-  const available = analyticsGranted > 0 || analyticsDenied > 0
-
-  return {
-    analytics_storage: toStats(analyticsMap),
-    ads_storage: toStats(adsMap),
-    available,
-  }
-}
-
-// ============================================================================
-// Custom Event Processing
-// ============================================================================
-
-/**
- * Parse custom event rows into CustomEventData
- */
-export function parseCustomEventRows(
-  rows: DataApiRow[],
-  grantEvent: string,
-  denyEvent: string,
-): CustomEventData {
-  let grantCount = 0
-  let denyCount = 0
-
-  for (const row of rows) {
-    const eventName = row.dimensionValues[0]?.value ?? ''
-    const count = parseInt(row.metricValues[0]?.value ?? '0', 10)
-    if (eventName === grantEvent) grantCount += count
-    if (eventName === denyEvent) denyCount += count
-  }
-
-  const total = grantCount + denyCount
-  const consent_rate_pct =
-    total > 0 ? Math.round((grantCount / total) * 1000) / 10 : 0
-
-  return {
-    grant_event: grantEvent,
-    grant_count: grantCount,
-    deny_event: denyEvent,
-    deny_count: denyCount,
-    consent_rate_pct,
-  }
-}
-
-// ============================================================================
-// API Calls
-// ============================================================================
-
-
-/**
- * Run a GA4 Data API report
- */
-export async function runDataApiReport(
+async function runDataApiReport(
   propertyId: string,
   body: Record<string, unknown>,
-): Promise<DataApiRow[]> {
+): Promise<ConsentReportRow[]> {
   const authHeaders = await getGoogleAuthHeaders([
     'https://www.googleapis.com/auth/analytics.readonly',
   ])
@@ -223,26 +96,30 @@ export async function runDataApiReport(
 
   const response = await fetch(url, {
     method: 'POST',
-    headers: {
-      ...authHeaders,
-      'Content-Type': 'application/json',
-    },
+    headers: { ...authHeaders, 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
 
   if (!response.ok) {
     const text = await response.text()
     if (response.status === 403) {
-      throw new Error(
-        'GA4 Data API access denied — check service account has Viewer role on property',
+      throw new ToolError(
+        ErrorCode.AUTH_DENIED,
+        `GA4 Data API access denied for ${propertyId} (HTTP 403)`,
+        'Grant the service account Viewer role on the GA4 property. See mcp/PERMISSIONS.md.',
       )
     }
     if (response.status === 404) {
-      throw new Error(
-        `Property not found: ${propertyId} — verify the property ID is correct`,
+      throw new ToolError(
+        ErrorCode.NOT_FOUND,
+        `GA4 property not found: ${propertyId}`,
+        'Verify the property ID in GA4 Admin → Property Settings.',
       )
     }
-    throw new Error(`GA4 Data API error (HTTP ${response.status}): ${text}`)
+    throw new ToolError(
+      ErrorCode.UPSTREAM_5XX,
+      `GA4 Data API error (HTTP ${response.status}): ${text}`,
+    )
   }
 
   const data = (await response.json()) as DataApiResponse
@@ -250,94 +127,79 @@ export async function runDataApiReport(
 }
 
 // ============================================================================
-// Main Tool Function
+// Handler
 // ============================================================================
 
-/**
- * Run the full ga4_consent_health tool
- */
 export async function runGa4ConsentHealth(
   input: Ga4ConsentHealthInput,
-): Promise<Ga4ConsentHealthOutput> {
-  const { property_id, days, custom_grant_event, custom_deny_event } = input
-  const period = `last ${days} days`
-  const endDate = 'today'
-  const startDate = `${days}daysAgo`
+): Promise<Ga4ConsentHealthResult> {
+  const { days, grant_event, deny_event, view_event } = input
 
-  const emptyConsentMode: ConsentModeData = {
-    analytics_storage: {
-      granted_pct: 0,
-      denied_pct: 0,
-      unset_pct: 0,
-      total_sessions: 0,
-    },
-    ads_storage: {
-      granted_pct: 0,
-      denied_pct: 0,
-      unset_pct: 0,
-      total_sessions: 0,
-    },
-    available: false,
+  // Normalize property_id — throws ToolError for G-XXX, UA-XXX, etc.
+  let propertyId: string
+  try {
+    propertyId = normalizeGa4Property(input.property_id)
+  } catch (err) {
+    if (err instanceof ToolError) {
+      return {
+        success: false,
+        error: { code: err.code, message: err.message, ...(err.hint !== undefined ? { hint: err.hint } : {}) },
+      }
+    }
+    throw err
   }
 
+  const period = `last ${days} days`
+
   try {
-    // Call 1: Consent Mode signals
-    const consentRows = await runDataApiReport(property_id, {
-      dateRanges: [{ startDate, endDate }],
-      dimensions: [
-        { name: 'privacyInfoAnalyticsStorage' },
-        { name: 'privacyInfoAdsStorage' },
-      ],
-      metrics: [{ name: 'sessions' }],
-    })
-
-    const consent_mode = parseConsentModeRows(consentRows)
-
-    // Call 2: Custom events (only if requested)
-    let custom_events: CustomEventData | undefined
-    if (custom_grant_event || custom_deny_event) {
-      const grantEvent = custom_grant_event ?? ''
-      const denyEvent = custom_deny_event ?? ''
-
-      // Build event name filter
-      const filterValues = [grantEvent, denyEvent].filter(Boolean)
-      const eventRows = await runDataApiReport(property_id, {
-        dateRanges: [{ startDate, endDate }],
-        dimensions: [{ name: 'eventName' }],
-        metrics: [{ name: 'eventCount' }],
-        dimensionFilter: {
-          filter: {
-            fieldName: 'eventName',
-            inListFilter: {
-              values: filterValues,
-            },
+    const rows = await runDataApiReport(propertyId, {
+      dimensions: [{ name: 'eventName' }],
+      metrics: [{ name: 'eventCount' }, { name: 'totalUsers' }],
+      dateRanges: [{ startDate: `${days}daysAgo`, endDate: 'yesterday' }],
+      dimensionFilter: {
+        filter: {
+          fieldName: 'eventName',
+          inListFilter: {
+            values: [grant_event, deny_event, view_event],
           },
         },
-      })
+      },
+    })
 
-      custom_events = parseCustomEventRows(eventRows, grantEvent, denyEvent)
+    const health = computeConsentHealth(rows, { grant_event, deny_event, view_event })
+
+    const warnings = [...health.warnings]
+    if (!health.available) {
+      warnings.push(
+        `No "${grant_event}" or "${deny_event}" events found in the last ${days} days. ` +
+          'Instrument grant/deny events on banner accept/deny actions. See mcp/PERMISSIONS.md.',
+      )
     }
-
-    const health_score = computeHealthScore(
-      consent_mode.analytics_storage.denied_pct,
-    )
 
     return {
       success: true,
-      property_id,
+      warnings,
+      property_id: propertyId,
       period,
-      consent_mode,
-      custom_events,
-      health_score,
+      events: health.events,
+      consent_rate_pct: health.consent_rate_pct,
+      consent_visibility_pct: health.consent_visibility_pct,
+      health_score: health.health_score,
+      available: health.available,
     }
   } catch (err) {
+    if (err instanceof ToolError) {
+      return {
+        success: false,
+        error: { code: err.code, message: err.message, ...(err.hint !== undefined ? { hint: err.hint } : {}) },
+      }
+    }
     return {
       success: false,
-      property_id,
-      period,
-      consent_mode: emptyConsentMode,
-      health_score: 'critical',
-      error: err instanceof Error ? err.message : String(err),
+      error: {
+        code: ErrorCode.UPSTREAM_5XX,
+        message: err instanceof Error ? err.message : String(err),
+      },
     }
   }
 }
@@ -349,33 +211,39 @@ export async function runGa4ConsentHealth(
 export const ga4ConsentHealthTool = {
   name: 'ga4_consent_health',
   description:
-    'Report Consent Mode v2 health for a GA4 property: what % of sessions have analytics/ads consent granted vs denied. ' +
-    'Uses GA4 Data API (analyticsdata/v1beta). ' +
-    'Returns health score: healthy (<10% denied), warning (10-30%), critical (>30%).',
+    'Report GA4 consent banner health by counting `consent_granted` / `consent_denied` events vs page views. ' +
+    'Use when traffic looks suspiciously low, after changing the cookie banner, or auditing privacy compliance. ' +
+    'Requires the site to instrument grant/deny events on banner actions — ' +
+    'Consent Mode v2 dimensions are NOT exposed on the Data API and not used here.',
   inputSchema: {
     type: 'object',
-    required: ['property_id'],
+    required: ['property_id', 'grant_event', 'deny_event'],
     properties: {
       property_id: {
         type: 'string',
-        description: 'GA4 property ID in format "properties/123456789"',
+        description:
+          'GA4 Property ID: numeric (e.g. "123456789") or "properties/123456789". Not a Measurement ID (G-XXXXXX).',
       },
       days: {
         type: 'number',
-        description: 'Number of days to analyze (default: 28, max: 365)',
+        description: 'Look-back window in days (default: 28; max: 365)',
         default: 28,
         minimum: 1,
         maximum: 365,
       },
-      custom_grant_event: {
+      grant_event: {
         type: 'string',
-        description:
-          'Optional: custom event name for consent granted (e.g. "consent_granted")',
+        description: 'GA4 event fired on consent grant, e.g. "consent_granted"',
       },
-      custom_deny_event: {
+      deny_event: {
+        type: 'string',
+        description: 'GA4 event fired on consent deny, e.g. "consent_denied"',
+      },
+      view_event: {
         type: 'string',
         description:
-          'Optional: custom event name for consent denied (e.g. "consent_denied")',
+          'Page/view event as denominator for visibility ratio (default: "page_view")',
+        default: 'page_view',
       },
     },
   },

--- a/mcp/src/utils/url-normalize.ts
+++ b/mcp/src/utils/url-normalize.ts
@@ -1,4 +1,52 @@
-// Pure URL normalization utilities for GSC traffic comparison.
+// Pure URL normalization utilities for GSC traffic comparison and GA4 property IDs.
+
+import { ToolError, ErrorCode } from './errors.js'
+
+/**
+ * Normalize a GA4 property identifier to "properties/N" form.
+ *
+ * Accepted:
+ *   properties/123456789  → returned as-is
+ *   123456789             → "properties/123456789"
+ *
+ * Rejected with INVALID_INPUT:
+ *   G-XXXXXX (Measurement ID)
+ *   UA-XXXXXX-X (Universal Analytics)
+ *   anything else
+ */
+export function normalizeGa4Property(input: string): string {
+  const trimmed = input.trim()
+
+  if (/^G-[A-Z0-9]+$/i.test(trimmed)) {
+    throw new ToolError(
+      ErrorCode.INVALID_INPUT,
+      `"${trimmed}" is a Measurement ID (G-XXXXXX), not a GA4 Property ID`,
+      'Find your Property ID in GA4 Admin → Property Settings — it is a plain number like 123456789 or properties/123456789',
+    )
+  }
+
+  if (/^UA-\d+-\d+$/i.test(trimmed)) {
+    throw new ToolError(
+      ErrorCode.INVALID_INPUT,
+      `"${trimmed}" is a Universal Analytics Property ID (UA-XXXXXX-X), not a GA4 Property ID`,
+      'GA4 properties use plain numeric IDs like 123456789 or properties/123456789',
+    )
+  }
+
+  if (/^properties\/\d+$/.test(trimmed)) {
+    return trimmed
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    return `properties/${trimmed}`
+  }
+
+  throw new ToolError(
+    ErrorCode.INVALID_INPUT,
+    `Unrecognized GA4 property ID format: "${trimmed}"`,
+    'Pass a numeric Property ID (e.g. "123456789") or "properties/123456789"',
+  )
+}
 
 export type NormalizeMode = 'none' | 'minimal' | 'aggressive'
 

--- a/progress-28.txt
+++ b/progress-28.txt
@@ -1,0 +1,30 @@
+## Iteration 1 — 2026-04-25
+
+### Done: Full redesign — events-only ga4_consent_health (all acceptance criteria)
+
+Files touched:
+- mcp/src/utils/url-normalize.ts — added normalizeGa4Property (accepts properties/N, raw N; errors on G-XXX, UA-XXX)
+- mcp/src/tools/compute-consent-health.ts — NEW pure function: computeConsentHealth(rows, eventNames) → health metrics
+- mcp/src/tools/ga4-consent-health.ts — REWRITTEN: new input schema (grant_event+deny_event required, view_event optional default page_view), single API call with inListFilter, errors via ToolError/errorResult, tool description per issue spec
+- mcp/src/tools/ga4-consent-health.test.ts — REWRITTEN: unit tests for compute-consent-health + handler integration tests with mocked fetch
+
+Decisions:
+- normalizeGa4Property placed in url-normalize.ts alongside normalizeGscSite (same normalization category)
+- compute-consent-health.ts in tools/ matching compute-traffic-diff.ts pattern
+- Flat success response shape (success, warnings, property_id, period, events, consent_rate_pct, consent_visibility_pct, health_score, available) matches gsc-traffic-compare pattern
+- "no_data" hint goes into warnings[] on success response (no error field on success)
+- 403 → AUTH_DENIED with hint to PERMISSIONS.md
+- 404 → NOT_FOUND
+- 400/5xx → UPSTREAM_5XX
+
+All AC checked:
+- Tool surface: schema, handler, index.ts already registered, normalizeGa4Property
+- Single Data API call with inListFilter
+- compute-consent-health pure module exported
+- Output shape per spec
+- Error handling per spec
+- Unit + integration tests (all thresholds, missing events, 403)
+- Tool description matches spec verbatim
+- build/test/lint all pass
+
+Blockers: none


### PR DESCRIPTION
Closes #28

## What changed

Complete redesign of `ga4_consent_health` from Consent Mode dimensions (confirmed broken in #19) to an events-based approach. Single Data API call, structured errors, pure-function compute module.

## Acceptance criteria

### Tool surface
- [x] `mcp/src/tools/ga4-consent-health.ts` exports input schema + handler
- [x] Tool registered in `mcp/src/index.ts`
- [x] Input schema: `property_id` (required, normalized via `normalizeGa4Property`), `days?` (default 28), `grant_event` (required), `deny_event` (required), `view_event?` (default `"page_view"`)
- [x] `normalizeGa4Property` accepts `properties/N`, raw `N`, errors with hint on `G-XXX` and `UA-XXX`

### Data API call
- [x] Single `POST` to `analyticsdata.googleapis.com/v1beta/{property_id}:runReport` with `eventName` dimension, `eventCount` + `totalUsers` metrics, `inListFilter` on the three event names
- [x] Auth via shared `getGoogleAuthHeaders(["analytics.readonly"])`
- [x] Quota project handled by `google-auth-library` automatically when ADC has `quota_project_id`

### Pure module
- [x] `compute-consent-health(reportRows, eventNames)` exported pure function: maps API rows back to grant/deny/view counts, computes `consent_rate_pct`, `consent_visibility_pct`, `health_score`, handles missing/zero rows

### Output
- [x] Standardized response shape: `success`, `warnings`, optional `error` (per #18 PRD)
- [x] Output includes per-event `event_count` and `total_users`
- [x] `consent_rate_pct: null` when both events have 0 count
- [x] `available: false` when neither grant nor deny event fired
- [x] `health_score` assigned per spec table

### Error handling
- [x] 403 → `AUTH_DENIED` with hint to `mcp/PERMISSIONS.md`
- [x] 400 → propagated with API message (UPSTREAM_5XX)
- [x] Property-not-found → `NOT_FOUND`

### Tests
- [x] Unit tests for `compute-consent-health`: happy path, one event missing, both missing, thresholds (81%/65%/30%/0%), division-by-zero safety
- [x] Integration tests for handler: happy path, empty-rows → `available: false`, 403 → `AUTH_DENIED`

### Tool description (per #18 P15)
- [x] `description` use-case-driven, mentions required events, clarifies Consent Mode v2 unavailability
- [x] Each Zod field has a `.describe()` with a concrete example value

### Build & lint
- [x] `cd mcp && npm run build` passes
- [x] `cd mcp && npm run test:run` passes (1322 tests)
- [x] `cd mcp && npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)