### PR TITLE
fix(mcp): support ADC user credentials in google-auth utility

### DIFF
--- a/mcp/src/utils/google-auth.ts
+++ b/mcp/src/utils/google-auth.ts
@@ -3,10 +3,22 @@ import { createSign } from 'crypto'
 import { ToolError, ErrorCode } from './errors.js'
 
 /**
- * Service account credentials JSON structure
+ * Headers returned by getGoogleAuthHeaders. Always includes Authorization.
+ * For ADC user credentials with a quota_project_id, also includes
+ * X-Goog-User-Project so the API call bills the right project.
+ */
+export type AuthHeaders = {
+  Authorization: string
+} & {
+  [k: string]: string
+}
+
+/**
+ * Service account credentials JSON structure.
+ * `type: "service_account"`.
  */
 interface ServiceAccountCredentials {
-  type: string
+  type: 'service_account'
   project_id: string
   private_key_id: string
   private_key: string
@@ -17,10 +29,25 @@ interface ServiceAccountCredentials {
 }
 
 /**
+ * ADC user credentials JSON structure (from `gcloud auth application-default login`).
+ * `type: "authorized_user"`.
+ */
+interface AuthorizedUserCredentials {
+  type: 'authorized_user'
+  client_id: string
+  client_secret: string
+  refresh_token: string
+  quota_project_id?: string
+  token_uri?: string
+}
+
+type AnyCredentials = ServiceAccountCredentials | AuthorizedUserCredentials
+
+/**
  * Cached token entry
  */
 interface CachedToken {
-  accessToken: string
+  headers: AuthHeaders
   expiresAt: number // Unix timestamp ms
 }
 
@@ -44,7 +71,7 @@ function signJwt(header: object, claimSet: object, privateKey: string): string {
 }
 
 /**
- * Exchange a signed JWT assertion for an OAuth2 access token
+ * Exchange a signed JWT assertion for an OAuth2 access token (service account).
  */
 async function exchangeJwtForToken(
   jwt: string,
@@ -76,65 +103,22 @@ async function exchangeJwtForToken(
 }
 
 /**
- * Obtain Google OAuth2 authorization headers for the requested scopes.
- *
- * Reads the service account key at GOOGLE_APPLICATION_CREDENTIALS, mints a
- * short-lived JWT, exchanges it for an access token, caches the token until
- * 5 minutes before expiry, and returns the Authorization header value.
- *
- * @param scopes - OAuth2 scopes to request (e.g. ["https://www.googleapis.com/auth/webmasters.readonly"])
- * @returns Object with Authorization header ready for use
- * @throws If credentials are missing, invalid, or the token exchange fails
+ * Mint an access token from a service account using JWT bearer flow.
  */
-export async function getGoogleAuthHeaders(
+async function authFromServiceAccount(
+  creds: ServiceAccountCredentials,
   scopes: string[],
-): Promise<{ Authorization: string }> {
-  const cacheKey = scopes.slice().sort().join(' ')
-  const now = Date.now()
-
-  // Return cached token if still valid (with 5-min buffer)
-  const cached = tokenCache.get(cacheKey)
-  if (cached && cached.expiresAt - now > 5 * 60 * 1000) {
-    return { Authorization: `Bearer ${cached.accessToken}` }
-  }
-
-  // Resolve credentials path
-  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS
-  if (!credPath) {
+): Promise<{ accessToken: string; expiresIn: number }> {
+  if (!creds.private_key || !creds.client_email) {
     throw new ToolError(
       ErrorCode.AUTH_DENIED,
-      'GOOGLE_APPLICATION_CREDENTIALS environment variable is not set.',
-      'Set GOOGLE_APPLICATION_CREDENTIALS to the path of your service account JSON key file.',
-    )
-  }
-
-  // Load credentials
-  let creds: ServiceAccountCredentials
-  try {
-    const raw = await readFile(credPath, 'utf-8')
-    creds = JSON.parse(raw) as ServiceAccountCredentials
-  } catch (err) {
-    throw new Error(
-      `Failed to load service account credentials from ${credPath}: ${err instanceof Error ? err.message : String(err)}`,
-    )
-  }
-
-  if (creds.type !== 'service_account') {
-    throw new Error(
-      `Invalid credentials type "${creds.type}" — expected "service_account". ` +
-        'Ensure GOOGLE_APPLICATION_CREDENTIALS points to a service account JSON key.',
-    )
-  }
-
-  if (!creds.private_key || !creds.client_email) {
-    throw new Error(
       'Service account credentials are missing private_key or client_email fields.',
+      'Re-download the JSON key from Google Cloud Console → IAM → Service Accounts → Keys.',
     )
   }
 
-  // Build JWT claim set
   const issuedAt = Math.floor(Date.now() / 1000)
-  const expiresAt = issuedAt + 3600 // 1 hour
+  const expiresAt = issuedAt + 3600
 
   const header = { alg: 'RS256', typ: 'JWT' }
   const claimSet = {
@@ -146,20 +130,159 @@ export async function getGoogleAuthHeaders(
   }
 
   const jwt = signJwt(header, claimSet, creds.private_key)
-
-  // Exchange for access token
-  const tokenUri =
-    creds.token_uri || 'https://oauth2.googleapis.com/token'
+  const tokenUri = creds.token_uri || 'https://oauth2.googleapis.com/token'
   const tokenResponse = await exchangeJwtForToken(jwt, tokenUri)
 
-  // Cache the token
-  const expiresAtMs = now + tokenResponse.expires_in * 1000
-  tokenCache.set(cacheKey, {
+  return {
     accessToken: tokenResponse.access_token,
-    expiresAt: expiresAtMs,
+    expiresIn: tokenResponse.expires_in,
+  }
+}
+
+/**
+ * Mint an access token from ADC user credentials by exchanging the refresh token.
+ *
+ * Note: the access token's scopes are determined by the refresh token's grant
+ * (set during `gcloud auth application-default login --scopes=...`), NOT by
+ * the `scopes` argument. If the user did not consent the required scope at
+ * login time, the API call will fail with ACCESS_TOKEN_SCOPE_INSUFFICIENT.
+ * The fix is to re-run the login with the correct scopes (see TROUBLESHOOTING.md).
+ */
+async function authFromAuthorizedUser(
+  creds: AuthorizedUserCredentials,
+): Promise<{ accessToken: string; expiresIn: number }> {
+  if (!creds.refresh_token || !creds.client_id || !creds.client_secret) {
+    throw new ToolError(
+      ErrorCode.AUTH_DENIED,
+      'ADC user credentials missing refresh_token, client_id, or client_secret.',
+      'Re-run: gcloud auth application-default login --scopes=...',
+    )
+  }
+
+  const tokenUri = creds.token_uri || 'https://oauth2.googleapis.com/token'
+
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: creds.refresh_token,
+    client_id: creds.client_id,
+    client_secret: creds.client_secret,
   })
 
-  return { Authorization: `Bearer ${tokenResponse.access_token}` }
+  const response = await fetch(tokenUri, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new ToolError(
+      ErrorCode.AUTH_DENIED,
+      `Failed to refresh ADC user credentials (HTTP ${response.status}): ${text}`,
+      'Re-run: gcloud auth application-default login --scopes=openid,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/analytics.readonly,https://www.googleapis.com/auth/webmasters.readonly,https://www.googleapis.com/auth/userinfo.email',
+    )
+  }
+
+  const data = (await response.json()) as {
+    access_token: string
+    expires_in: number
+  }
+
+  return { accessToken: data.access_token, expiresIn: data.expires_in }
+}
+
+/**
+ * Obtain Google OAuth2 authorization headers for the requested scopes.
+ *
+ * Reads credentials at GOOGLE_APPLICATION_CREDENTIALS, supports two formats:
+ *
+ *  - Service account key (`type: "service_account"`): mints a JWT, exchanges
+ *    for an access token with the requested scopes.
+ *
+ *  - ADC user credentials (`type: "authorized_user"`): refreshes the user's
+ *    refresh token. Scopes are fixed at gcloud-login time, not per-call.
+ *    Adds X-Goog-User-Project header from `quota_project_id` so the API call
+ *    bills the right project (avoids SERVICE_DISABLED errors on user creds).
+ *
+ * Caches the headers per-scope-set until 5 minutes before expiry.
+ *
+ * @param scopes - OAuth2 scopes to request (only used for service accounts)
+ * @returns Headers object: { Authorization, [X-Goog-User-Project]? }
+ * @throws ToolError if credentials are missing, invalid, or token exchange fails
+ */
+export async function getGoogleAuthHeaders(
+  scopes: string[],
+): Promise<AuthHeaders> {
+  const cacheKey = scopes.slice().sort().join(' ')
+  const now = Date.now()
+
+  // Return cached token if still valid (with 5-min buffer)
+  const cached = tokenCache.get(cacheKey)
+  if (cached && cached.expiresAt - now > 5 * 60 * 1000) {
+    return cached.headers
+  }
+
+  // Resolve credentials path
+  const credPath = process.env.GOOGLE_APPLICATION_CREDENTIALS
+  if (!credPath) {
+    throw new ToolError(
+      ErrorCode.AUTH_DENIED,
+      'GOOGLE_APPLICATION_CREDENTIALS environment variable is not set.',
+      'Set GOOGLE_APPLICATION_CREDENTIALS to a service account JSON key OR an ADC file (~/.config/gcloud/application_default_credentials.json). Run ./scripts/setup.sh for guided setup.',
+    )
+  }
+
+  // Load credentials
+  let creds: AnyCredentials
+  try {
+    const raw = await readFile(credPath, 'utf-8')
+    creds = JSON.parse(raw) as AnyCredentials
+  } catch (err) {
+    throw new ToolError(
+      ErrorCode.AUTH_DENIED,
+      `Failed to load credentials from ${credPath}: ${err instanceof Error ? err.message : String(err)}`,
+      'Verify GOOGLE_APPLICATION_CREDENTIALS points to a readable JSON file.',
+    )
+  }
+
+  let accessToken: string
+  let expiresIn: number
+  let quotaProject: string | undefined
+
+  switch (creds.type) {
+    case 'service_account': {
+      const result = await authFromServiceAccount(creds, scopes)
+      accessToken = result.accessToken
+      expiresIn = result.expiresIn
+      break
+    }
+    case 'authorized_user': {
+      const result = await authFromAuthorizedUser(creds)
+      accessToken = result.accessToken
+      expiresIn = result.expiresIn
+      quotaProject = creds.quota_project_id
+      break
+    }
+    default: {
+      const t = (creds as { type?: unknown }).type
+      throw new ToolError(
+        ErrorCode.AUTH_DENIED,
+        `Unsupported credentials type "${String(t)}". Expected "service_account" or "authorized_user".`,
+        'Use a service account JSON key OR run: gcloud auth application-default login --scopes=... See mcp/PERMISSIONS.md.',
+      )
+    }
+  }
+
+  const headers: AuthHeaders = { Authorization: `Bearer ${accessToken}` }
+  if (quotaProject) {
+    headers['X-Goog-User-Project'] = quotaProject
+  }
+
+  // Cache the full headers (incl. quota project) for the next call
+  const expiresAtMs = now + expiresIn * 1000
+  tokenCache.set(cacheKey, { headers, expiresAt: expiresAtMs })
+
+  return headers
 }
 
 /**


### PR DESCRIPTION
## Problem

PR #43 just shipped `mcp/PERMISSIONS.md` and `scripts/setup.sh` advertising **ADC user credentials** (`~/.config/gcloud/application_default_credentials.json` from `gcloud auth application-default login`) as the recommended path for personal use:

> **A — ADC user creds** ... When to use: Personal/dev use ... Pros: Free, fast, no separate user to manage; uses your existing GA4/GSC access

But the underlying utility hardcoded SA-only:

```ts
// mcp/src/utils/google-auth.ts (before)
if (creds.type !== 'service_account') {
  throw new Error('Invalid credentials type ... expected "service_account"')
}
```

Result: every tool that calls `getGoogleAuthHeaders` (`gsc_traffic_compare`, `ga4_consent_health`) fails immediately for any user following the recommended setup.

Verified empirically by testing the live MCP tools against `properties/514673271` (Wealth-Sim):

```
{
  "success": false,
  "error": "Invalid credentials type \"authorized_user\" — expected \"service_account\"."
}
```

`seo_page_audit` is unaffected because it does not need Google auth.

## Fix

`mcp/src/utils/google-auth.ts` now dispatches on `creds.type`:

| Type | Flow |
|------|------|
| `service_account` | Existing JWT bearer flow (unchanged) |
| `authorized_user` | New refresh-token grant flow |

For `authorized_user`, the utility reads `quota_project_id` from the ADC file and emits an `X-Goog-User-Project` header on every call. Without this header, ADC user creds against `analyticsdata.googleapis.com` fail with `SERVICE_DISABLED` (as documented in the new `mcp/TROUBLESHOOTING.md`).

The token cache now stores the full headers object (including the quota-project header) per-scope-set instead of just the access-token string.

Error paths upgraded from raw `Error` to `ToolError` with actionable hints pointing at `setup.sh` and the exact `gcloud auth application-default login` command.

## Public API change

```diff
- export async function getGoogleAuthHeaders(scopes: string[]): Promise<{ Authorization: string }>
+ export async function getGoogleAuthHeaders(scopes: string[]): Promise<AuthHeaders>

  type AuthHeaders = { Authorization: string } & { [k: string]: string }
```

Callers that already did `headers: { ...authHeaders, 'Content-Type': 'application/json' }` (i.e. `gsc_traffic_compare` and `ga4_consent_health`) continue to work unchanged — the spread now also carries the quota-project header through automatically.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test:run` — 1322 / 1322 passing
- [x] `npm run lint` — clean
- [ ] Reviewer: rebuild `mcp/dist/` and re-run `gsc_traffic_compare` + `ga4_consent_health` against a real GA4 property using ADC user creds — expect success now
- [ ] Reviewer: confirm `seo_page_audit` still works (no regression for the auth-free path)

## Why now

We literally just merged docs (PR #43, 30 minutes ago) telling users to use ADC. Letting the contract violation sit while the docs lie is worse than fixing it. This is a 1-file 175-line change with no public API breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)