### PR TITLE
fix(setup): detect missing OAuth scopes in existing ADC + fix ANSI heredoc

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,7 +39,10 @@ done
 # ── Color / format helpers ───────────────────────────────────────────────────
 
 if [[ -t 1 ]]; then
-  C_OK="\033[32m"; C_WARN="\033[33m"; C_ERR="\033[31m"; C_DIM="\033[2m"; C_BOLD="\033[1m"; C_OFF="\033[0m"
+  # ANSI-C quoting ($'...') so the variables hold real escape bytes.
+  # This makes the colors work inside heredocs (cat <<EOF), not just printf.
+  C_OK=$'\033[32m'; C_WARN=$'\033[33m'; C_ERR=$'\033[31m'
+  C_DIM=$'\033[2m'; C_BOLD=$'\033[1m'; C_OFF=$'\033[0m'
 else
   C_OK=""; C_WARN=""; C_ERR=""; C_DIM=""; C_BOLD=""; C_OFF=""
 fi
@@ -152,16 +155,54 @@ SCOPES="openid,https://www.googleapis.com/auth/cloud-platform,https://www.google
 if [[ "$AUTH_PATH" == "A" ]]; then
   ADC_FILE="$HOME/.config/gcloud/application_default_credentials.json"
 
-  # If ADC already exists, ask whether to re-login (might be missing scopes)
+  REQUIRED_SCOPES=(
+    "https://www.googleapis.com/auth/cloud-platform"
+    "https://www.googleapis.com/auth/analytics.readonly"
+    "https://www.googleapis.com/auth/webmasters.readonly"
+  )
+
+  # If ADC already exists, check whether its token has the required scopes
   RELOGIN=1
   if [[ -f "$ADC_FILE" ]]; then
-    dim "ADC file already exists at $ADC_FILE"
-    if [[ "$NON_INTERACTIVE" == "1" ]]; then
+    dim "ADC file already exists at $ADC_FILE — checking scopes..."
+
+    # Mint a token from the existing ADC and ask Google what scopes it carries
+    EXISTING_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null || echo "")
+    GRANTED_SCOPES=""
+    if [[ -n "$EXISTING_TOKEN" ]]; then
+      GRANTED_SCOPES=$(curl -s "https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=$EXISTING_TOKEN" \
+        | jq -r '.scope // ""' 2>/dev/null || echo "")
+    fi
+
+    MISSING=()
+    for scope in "${REQUIRED_SCOPES[@]}"; do
+      if [[ "$GRANTED_SCOPES" != *"$scope"* ]]; then
+        MISSING+=("$scope")
+      fi
+    done
+
+    if [[ ${#MISSING[@]} -eq 0 ]]; then
+      ok "All required scopes already granted (cloud-platform, analytics.readonly, webmasters.readonly)"
       RELOGIN=0
-      dim "Skipping re-login in non-interactive mode (assume scopes are already granted)"
     else
-      ans=$(ask "Re-login to ensure all required scopes are granted? (y/n)" "y")
-      [[ "$ans" =~ ^[Yy]$ ]] || RELOGIN=0
+      warn "Existing ADC is missing ${#MISSING[@]} required scope(s):"
+      for s in "${MISSING[@]}"; do
+        printf "    - %s\n" "$s"
+      done
+      if [[ "$NON_INTERACTIVE" == "1" ]]; then
+        dim "Re-running login automatically (non-interactive)"
+        RELOGIN=1
+      else
+        ans=$(ask "Re-login now to grant the missing scopes? (y/n)" "y")
+        if [[ "$ans" =~ ^[Yy]$ ]]; then
+          RELOGIN=1
+        else
+          RELOGIN=0
+          warn "Continuing without re-login. Tools that need the missing scopes will fail."
+          warn "Re-run setup.sh later, or run the gcloud login command manually:"
+          printf "    gcloud auth application-default login --scopes=%s\n" "$SCOPES"
+        fi
+      fi
     fi
   fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -352,8 +352,11 @@ ${C_BOLD}2. Configure your MCP client${C_OFF}
 
 ${C_BOLD}3. Verify with the CLI${C_OFF}
 
-   ./ga4 validate
-   ./ga4 report --property-id <YOUR_NUMERIC_PROPERTY_ID> --days 28
+   ./ga4 --version                              # binary works
+   ./ga4 validate --all                         # validates every config under configs/
+   ./ga4 report --config configs/<your-file>.yaml   # report from a config file
+   # or after editing configs/examples/*.yaml with your real GA4 property ID:
+   ./ga4 report --project basic-ecommerce
 
 ${C_BOLD}4. Common errors${C_OFF}
 


### PR DESCRIPTION
## Two bugs from a real setup.sh run

After PR #43 shipped, a fresh user ran `./scripts/setup.sh` and hit:

```
── Smoke-testing API access
GA4 Admin (analyticsadmin.googleapis.com) — listing account summaries...
✓ GA4 Admin reachable — 4 property summaries visible
Search Console (searchconsole.googleapis.com) — listing sites...
✗ Search Console returned HTTP 403
Request had insufficient authentication scopes.
```

And in the next-steps section:

```
\033[1m1. Per-resource permissions (manual)\033[0m
   \033[1mSearch Console\033[0m — Add yourself ...
```

(Literal `\033[1m`, not bold text.)

## Root causes

### 1. Missing-scope blindness on existing ADC

The script asked the user *"Re-login to ensure all required scopes are granted?"* with no way to actually know whether the existing `application_default_credentials.json` carried those scopes. Users who declined (because the file existed) ended up with a token missing `webmasters.readonly`, then hit the 403 on the GSC smoke test minutes later.

**Fix:** before prompting, the script now mints a token from the existing ADC, calls Google's [`oauth2/v3/tokeninfo`](https://www.googleapis.com/oauth2/v3/tokeninfo?access_token=...) endpoint to read the granted `scope` field, and computes the set difference against the required scopes:

```
ADC file already exists at /Users/.../application_default_credentials.json — checking scopes...
! Existing ADC is missing 1 required scope(s):
    - https://www.googleapis.com/auth/webmasters.readonly
Re-login now to grant the missing scopes? (y/n) [y]:
```

If the user still says "no" the script warns loudly and prints the exact `gcloud` command for later. In `--non-interactive` mode it re-logs automatically.

### 2. Literal `\033[1m` in heredoc

The color variables were assigned with double-quoted strings (`"\033[1m"`), which contain seven literal characters, not an ANSI escape. The earlier `printf` calls happen to interpret escapes in their first argument, so `ok()`/`warn()`/`step()` worked. The `cat <<EOF ... EOF` heredoc at the end of the next-steps section did not.

**Fix:** switched to ANSI-C quoting (`$'\033[1m'`), so the variables hold real escape bytes and render in any context (heredoc, printf, echo).

## Test plan

- [x] `bash -n scripts/setup.sh` — syntax clean
- [ ] Reviewer: re-run `./scripts/setup.sh` on a machine with an existing ADC missing one scope. Expect:
  - "Existing ADC is missing 1 required scope(s):" with the missing scope name
  - Default re-login prompt to "y"
  - On accepting "y": browser opens for re-login
  - On declining "n": warning + exact gcloud command printed
  - Final next-steps section displays bold text properly (no `\033[1m` literals)
- [ ] Reviewer: re-run on a machine with a complete ADC. Expect:
  - "All required scopes already granted (cloud-platform, analytics.readonly, webmasters.readonly)"
  - No re-login prompt

## Why now

The first user who ran setup.sh after PR #43 landed got both bugs in the same session. Cheap fix, single file, no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)