### PR TITLE
fix: handle PSI zero-quota trap with actionable error + docs (closes #46)

### DIFF
--- a/mcp/PERMISSIONS.md
+++ b/mcp/PERMISSIONS.md
@@ -149,21 +149,40 @@ Repeat for every GA4 property you want to manage.
 
 **Affects tools:** `seo_page_audit` (when `check_cwv: true`)
 
-PageSpeed Insights works without an API key (rate-limited to ~1 request per 100 seconds). An optional API key removes the rate limit.
+> **An API key is effectively required.** The keyless free-tier path is documented as 1 request / 100 seconds, but in practice Google attributes any PSI request from a gcloud-configured environment to your quota project, where the per-day default is **0**. Without a key, `check_cwv: true` calls return HTTP 429 immediately. See [TROUBLESHOOTING.md → "PSI returns 429 with quota_limit_value: 0"](./TROUBLESHOOTING.md#seo_page_audit--psi-returns-429-with-quota_limit_value-0) for the full mechanics.
 
-### Without an API key
+### Recommended — provision a free PSI API key
 
-No setup needed. The server automatically throttles requests to stay within the free quota. Pass `check_cwv: true` to enable Core Web Vitals data.
+The free tier with API key gives 25,000 requests / day, no per-request rate limit.
 
-### With an API key (optional)
+1. Open [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials).
+2. Select the same project you used as your GCP quota project (`gcloud auth application-default set-quota-project ...`).
+3. **+ Create Credentials** → **API key**.
+4. Click **Edit** on the new key. Restrict it:
+   - **Application restrictions:** None (or HTTP referrers if calling from a browser).
+   - **API restrictions:** Restrict key → check **PageSpeed Insights API** only.
+5. Copy the key.
+6. Pass it to every `seo_page_audit` call:
 
-1. Open [Google Cloud Console](https://console.cloud.google.com) and select your project.
-2. Navigate to **APIs & Services → Library**.
-3. Search for **PageSpeed Insights API** and click **Enable**.
-4. Navigate to **APIs & Services → Credentials**.
-5. Click **Create Credentials → API key**.
-6. Copy the key and restrict it to the PageSpeed Insights API (recommended).
-7. Pass the key as `psi_api_key` in `seo_page_audit` calls, or set it in a shared config.
+   ```jsonc
+   {
+     "url": "https://example.com/page",
+     "check_cwv": true,
+     "psi_api_key": "AIzaSy...your-key"
+   }
+   ```
+
+   Or set it in your MCP client config so you don't have to pass it each call. See `mcp/CONFIGURATION.md`.
+
+### Keyless (NOT recommended)
+
+If you skip the API key, PSI calls will return:
+
+```json
+{ "error": { "code": 429, "metadata": { "quota_limit_value": "0", ... } } }
+```
+
+The tool surfaces this as a `psi_unavailable` warning and returns the HTML audit without `cwv` data. The `check_cwv: false` path continues to work unaffected.
 
 ---
 

--- a/mcp/TROUBLESHOOTING.md
+++ b/mcp/TROUBLESHOOTING.md
@@ -331,6 +331,48 @@ To override the UA freely:
 
 ---
 
+### `seo_page_audit` — PSI returns 429 with `quota_limit_value: "0"`
+
+```json
+{
+  "warnings": [
+    "psi_unavailable: PSI API error (HTTP 429): ... \"quota_limit_value\": \"0\", \"quota_limit\": \"defaultPerDayPerProject\" ..."
+  ]
+}
+```
+
+**Cause:** Even though the tool calls PSI without an Authorization header, Google attributes the request to your gcloud-configured quota project (visible in the error as `consumer: projects/<number>`). The default per-project per-day PSI quota is **0**, not the documented 25k. Without an API key, the request lands in the zero-allocation lane and gets immediately rejected — no warm-up grace, no fallback to keyless rate-limited mode.
+
+This affects every user who follows `scripts/setup.sh` exactly: the API enables fine, the smoke test fails, and `check_cwv: true` calls fail forever until the API key is provisioned.
+
+**Fix — create a free PSI API key:**
+
+1. Open [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials).
+2. Select your project (the same one used for `GCP_PROJECT` / quota project, e.g. `portfolio-blog-479009`).
+3. **+ Create Credentials** → **API key**.
+4. Click **Edit** on the new key:
+   - **Application restrictions:** None (or HTTP referrers if calling from a browser).
+   - **API restrictions:** Restrict key → check **PageSpeed Insights API** only.
+   - Save.
+5. Copy the key.
+6. Pass the key to `seo_page_audit` calls:
+
+   ```jsonc
+   {
+     "url": "https://example.com",
+     "check_cwv": true,
+     "psi_api_key": "AIzaSy...your-key"
+   }
+   ```
+
+   Or set the `PSI_API_KEY` env var in your MCP client config so you don't have to pass it every call (when supported — see `mcp/CONFIGURATION.md`).
+
+**Why this is required:** with an API key, PSI bills against your project at the documented 25k requests/day free tier. Without a key, the default per-project allocation is 0 — Google reserves "free unauthenticated" PSI for anonymous traffic with no GCP context, and once Google's edge identifies you as a gcloud user, you're routed to the per-project lane that has zero allocation by default.
+
+The tool's keyless throttle (`bottleneck` 1 req per 100s) still applies as a safety net, but it doesn't help when the per-day allocation itself is zero.
+
+---
+
 ### `gsc_traffic_compare` — periods overlap warning
 
 ```json

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -139,6 +139,22 @@ export async function fetchCwv(
 
   if (!response.ok) {
     const text = await response.text()
+
+    // Detect the "zero per-project daily quota" trap that hits unauthenticated
+    // PSI calls when Google attributes them to the caller's gcloud project.
+    // Free tier with API key has 25k/day; without key the project default is 0.
+    if (
+      response.status === 429 &&
+      (text.includes('"quota_limit_value": "0"') ||
+        text.includes('"quota_limit_value":"0"'))
+    ) {
+      throw new Error(
+        'PSI returned 429 with per-project daily quota = 0. ' +
+          'Create a free PSI API key (Cloud Console → Credentials → Create credentials → API key, restrict to PageSpeed Insights API) and pass it via the psi_api_key input. ' +
+          'See mcp/TROUBLESHOOTING.md → "PSI returns 429 quota_limit_value=0".',
+      )
+    }
+
     throw new Error(`PSI API error (HTTP ${response.status}): ${text}`)
   }
 


### PR DESCRIPTION
Closes #46.

## Problem

`seo_page_audit` with `check_cwv: true` returns HTTP 429 with `quota_limit_value: "0"` for any user who follows `scripts/setup.sh` exactly:

```json
{
  "error": {
    "code": 429,
    "status": "RESOURCE_EXHAUSTED",
    "metadata": {
      "consumer": "projects/<your-project-number>",
      "quota_metric": "pagespeedonline.googleapis.com/default",
      "quota_limit_value": "0",
      "quota_limit": "defaultPerDayPerProject"
    }
  }
}
```

Even though `fetchCwv` does **not** attach an `Authorization` header, Google's edge identifies gcloud-configured callers and routes them to their quota project's per-day PSI lane, which has a default allocation of **0**. The documented "25k/day free tier" only applies with an API key.

Result: the tool's spec'd "keyless mode with 1-per-100s throttle" is non-functional out of the box. Even the smoke test in `scripts/setup.sh` fails this way. Verified empirically against `portfolio-blog-479009`.

## Why this PR is docs+error-message rather than a code rewrite

The investigation in #46 (Option A vs B) hinged on whether `fetchCwv` was sending auth headers. It is not — the existing keyless path is correctly minimal. The problem is on Google's side: any gcloud-attributed request is treated as authenticated against the per-project zero quota. The cleanest fix is therefore to:

1. Tell users plainly that an API key is required in practice.
2. When the zero-quota trap fires, return an actionable error instead of dumping the raw 429 JSON into the warning.

## Changes

### `mcp/src/tools/seo-page-audit.ts`

In `fetchCwv`, detect `429 + "quota_limit_value": "0"` and throw a specific message:

```
PSI returned 429 with per-project daily quota = 0. Create a free PSI API key
(Cloud Console → Credentials → Create credentials → API key, restrict to
PageSpeed Insights API) and pass it via the psi_api_key input. See
mcp/TROUBLESHOOTING.md → "PSI returns 429 quota_limit_value=0".
```

Surfaces in the tool output as `warnings: ["psi_unavailable: ..."]` — `success` stays `true`, the HTML audit still completes.

### `mcp/PERMISSIONS.md` (PSI section rewritten)

- Removed the "Without an API key — no setup needed" claim. It is wrong.
- Made API key the recommended path with explicit Cloud Console steps.
- Kept the keyless option as "not recommended" with a clear explanation of why it doesn't work in practice.

### `mcp/TROUBLESHOOTING.md`

New entry: `seo_page_audit — PSI returns 429 with quota_limit_value: "0"`.

Includes verbatim error reproduction, step-by-step API key creation, and the underlying explanation of why Google routes the request to the per-project zero-allocation lane.

## Verification

- `npm run build` — clean
- `npm run test:run` — 1322 / 1322 passing
- `npm run lint` — clean

## What this PR does NOT do

- Does not change `fetchCwv` to bypass quota project (Google's design, not ours to override).
- Does not auto-provision an API key in `setup.sh` (would require billing prompts, scope too large for this fix).
- Does not change the keyless throttle behaviour for users who do somehow have keyless quota — that path remains, just with the new actionable error if the zero-quota trap fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PageSpeed Insights permissions guide to clarify that an API key is effectively required when checking Core Web Vitals, with instructions for key provisioning and configuration
  * Added troubleshooting section documenting HTTP 429 quota limit errors and remediation steps

* **Improvements**
  * Enhanced error handling for PageSpeed Insights quota failures with clearer, actionable error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->