### PR TITLE
fix(mcp): ga4_report parser correctness + gsc_analytics_run site echo (closes #48, #49)

### DIFF
--- a/mcp/src/tools/ga4-report.test.ts
+++ b/mcp/src/tools/ga4-report.test.ts
@@ -73,6 +73,10 @@ describe('ga4_report tool', () => {
 
   describe('parseReportOutput', () => {
     it('parses report with conversions table', () => {
+      // Format matches the real tablewriter output emitted by the Go binary:
+      // pipe-separated cells with `+---+---+` border lines. The previous
+      // fixture used whitespace-only alignment which never appears in
+      // production output.
       const output = `
 📊 GA4 Configuration Report
 ═══════════════════════════════════════════════
@@ -82,30 +86,34 @@ describe('ga4_report tool', () => {
 
 🎯 Conversions
 ───────────────────────────────────────────────
-   EVENT NAME             COUNTING METHOD
-   download_image         ONCE_PER_EVENT
-   compression_complete   ONCE_PER_SESSION
+       EVENT NAME       | COUNTING METHOD
+------------------------+-------------------
+  download_image        | ONCE_PER_EVENT
+  compression_complete  | ONCE_PER_SESSION
 
 📊 Custom Dimensions
 ───────────────────────────────────────────────
-   DISPLAY NAME       PARAMETER        SCOPE
-   User Type          user_type        USER
-   File Format        file_format      EVENT
+   DISPLAY NAME |   PARAMETER   | SCOPE
+----------------+---------------+--------
+  User Type     | user_type     | USER
+  File Format   | file_format   | EVENT
 
 📈 Custom Metrics
 ───────────────────────────────────────────────
-   DISPLAY NAME        PARAMETER          UNIT       SCOPE
-   Processing Time     processing_time    STANDARD   EVENT
+    DISPLAY NAME    |     PARAMETER     |   UNIT   | SCOPE
+--------------------+-------------------+----------+--------
+  Processing Time   | processing_time   | STANDARD | EVENT
 
 🧮 Recommended Calculated Metrics (create manually in GA4 UI)
 ───────────────────────────────────────────────
-   DISPLAY NAME   FORMULA   UNIT
+  DISPLAY NAME | FORMULA | UNIT
 
 👥 Configured Audiences
 ───────────────────────────────────────────────
 Total audiences configured: 0
 
-   NAME   CATEGORY   DURATION (DAYS)
+  NAME | CATEGORY | DURATION (DAYS)
+-------+----------+------------------
 
 Note: Audiences must be created manually in GA4 UI.
 
@@ -254,10 +262,11 @@ Enhanced Measurement enabled
 
 📈 Custom Metrics
 ───────────────────────────────────────────────
-   DISPLAY NAME        PARAMETER          UNIT       SCOPE
-   Processing Time     processing_time    STANDARD   EVENT
-   Product Price       product_price      CURRENCY   EVENT
-   Duration            duration_sec       SECONDS    EVENT
+   DISPLAY NAME    |     PARAMETER     |   UNIT   | SCOPE
+-------------------+-------------------+----------+--------
+  Processing Time  | processing_time   | STANDARD | EVENT
+  Product Price    | product_price     | CURRENCY | EVENT
+  Duration         | duration_sec      | SECONDS  | EVENT
 `;
 
       const result = parseReportOutput(output);

--- a/mcp/src/tools/ga4-report.ts
+++ b/mcp/src/tools/ga4-report.ts
@@ -403,65 +403,92 @@ function extractSection(output: string, startMarker: string, endMarker: string):
 /**
  * Parse table rows from a section
  *
- * Handles tablewriter output format (borderless tables with aligned columns)
+ * Handles tablewriter output format. Tables look like:
+ *
+ *               EVENT NAME           | COUNTING METHOD
+ *   ---------------------------------+-------------------
+ *     purchase                       | ONCE_PER_EVENT
+ *     contact_form_submit            | ONCE_PER_SESSION
+ *
+ * The previous implementation computed fixed column positions from the
+ * header line and used substring(start, end) to extract values. That broke
+ * because tablewriter centers headers (left-pads with spaces) but
+ * left-aligns data values, so the computed start position was inside a
+ * word for data rows — producing fragments like "rm_submit" instead of
+ * "contact_form_submit".
+ *
+ * This implementation splits each row on the `|` separator instead, which
+ * is robust against any horizontal alignment. It also skips border/
+ * separator lines that contain `+`, `|`, `-`, `=`, or unicode box-drawing
+ * characters — the previous regex missed `+` and `|`, causing rows like
+ * `+--------+----+` to be parsed as data.
  */
 function parseTableRows(section: string, expectedHeaders: string[]): Array<Record<string, string>> {
   const lines = section.split('\n').filter(line => line.trim().length > 0);
   const rows: Array<Record<string, string>> = [];
 
-  // Find header line
+  // Find the header line: the first line whose pipe-separated cells contain
+  // all of the expected header substrings.
   let headerLineIdx = -1;
-  let headerPositions: Array<{ name: string; start: number; end: number | undefined }> = [];
+  let columnNames: string[] = [];
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    // Check if this line contains all expected headers
-    const hasAllHeaders = expectedHeaders.every(h => line.toUpperCase().includes(h));
-    if (hasAllHeaders) {
+    const cells = splitPipes(lines[i]).map(c => c.trim().toUpperCase());
+    if (cells.length < expectedHeaders.length) continue;
+
+    const allHeadersPresent = expectedHeaders.every(h => cells.some(c => c.includes(h)));
+    if (allHeadersPresent) {
       headerLineIdx = i;
-      // Calculate column positions based on header positions
-      headerPositions = expectedHeaders.map((header, idx) => {
-        const start = line.toUpperCase().indexOf(header);
-        // End position is either the start of next header or undefined for last column
-        const nextHeaderStart = idx < expectedHeaders.length - 1
-          ? line.toUpperCase().indexOf(expectedHeaders[idx + 1])
-          : undefined;
-        return { name: header, start, end: nextHeaderStart };
-      });
+      columnNames = cells;
       break;
     }
   }
 
   if (headerLineIdx === -1) return rows;
 
-  // Parse data rows (lines after header)
+  // Border / separator regex — anything made entirely of border characters,
+  // including `+` (corner) and `|` (vertical) which tablewriter uses.
+  const borderRegex = /^[\s─\-═+|]+$/;
+
   for (let i = headerLineIdx + 1; i < lines.length; i++) {
     const line = lines[i];
+    if (borderRegex.test(line) || line.trim().length === 0) continue;
 
-    // Skip separator lines and empty lines
-    if (line.match(/^[\s─\-═]+$/) || line.trim().length === 0) {
-      continue;
-    }
+    const cells = splitPipes(line).map(c => c.trim());
+    if (cells.length < expectedHeaders.length) continue;
 
-    // Extract values based on column positions
     const row: Record<string, string> = {};
-    for (const { name, start, end } of headerPositions) {
-      // For last column (end is undefined), take rest of line
-      const value = end !== undefined
-        ? line.substring(start, end).trim()
-        : line.substring(start).trim();
-      if (value) {
-        row[name] = value;
-      }
+    for (let j = 0; j < columnNames.length && j < cells.length; j++) {
+      const value = cells[j];
+      if (value) row[columnNames[j]] = value;
     }
 
-    // Only add if we got at least one value
-    if (Object.keys(row).length > 0) {
-      rows.push(row);
-    }
+    if (Object.keys(row).length > 0) rows.push(row);
   }
 
   return rows;
+}
+
+/**
+ * Split a tablewriter row on `|` separators.
+ *
+ * Tablewriter typically renders rows as:
+ *   `  cell1  | cell2  | cell3 `
+ * with optional leading/trailing whitespace. We split on `|`, then drop
+ * empty leading/trailing cells produced by leading/trailing pipes in some
+ * tablewriter configurations.
+ */
+function splitPipes(line: string): string[] {
+  const cells = line.split('|');
+  // Drop a leading empty cell if the row starts with `|`.
+  if (cells.length > 0 && cells[0].trim() === '' && line.trimStart().startsWith('|')) {
+    cells.shift();
+  }
+  // Drop a trailing empty cell if the row ends with `|`.
+  if (cells.length > 0 && cells[cells.length - 1].trim() === '' && line.trimEnd().endsWith('|')) {
+    cells.pop();
+  }
+  return cells;
 }
 
 /**

--- a/mcp/src/tools/gsc-analytics.ts
+++ b/mcp/src/tools/gsc-analytics.ts
@@ -433,10 +433,15 @@ function parseTableOutput(output: string): AnalyticsRunOutput {
     return result;
   }
 
-  // Extract site from output
+  // Extract site from output. The CLI emits a progress line like
+  //   "Querying search analytics for sc-domain:wealthsim.app..."
+  // where the trailing "..." is purely cosmetic loading-indicator text, not
+  // part of the actual site identifier. Strip trailing dots so callers don't
+  // see "sc-domain:wealthsim.app..." in structured output (which would then
+  // 404 if used as input to a follow-up call). See issue #49.
   const siteMatch = output.match(/Querying search analytics for\s+(\S+)/);
   if (siteMatch) {
-    result.site = siteMatch[1].trim();
+    result.site = siteMatch[1].trim().replace(/\.+$/, '');
   }
 
   // Extract date range


### PR DESCRIPTION
Closes #48, closes #49.

## #48 — `ga4_report` returns mangled output

The MCP wrapper for `ga4_report` parses the Go binary's tablewriter stdout to extract structured fields. Two bugs in `parseTableRows`:

### Bug 1 — fixed-position substring extraction

Real CLI output:

```
      EVENT NAME       | COUNTING METHOD
----------------------+-------------------
  purchase            | ONCE_PER_EVENT
  contact_form_submit | ONCE_PER_SESSION
```

Headers are **centered** (left-padded with spaces). Data values are **left-aligned**. The parser computed column positions from the header line, then used `substring(start, end)` on every data row. Start position fell inside a word — producing fragments like `rm_submit` instead of `contact_form_submit`.

### Bug 2 — border lines parsed as data rows

The skip regex was `/^[\s─\-═]+$/` — missing the `+` (corner) and `|` (vertical) characters tablewriter uses. Border lines like `+--------+----+` were therefore treated as data rows, producing entries like `{ name: "----------------------+-", counting_method: "------------------" }`.

### Fix

Rewrote `parseTableRows` to split each row on `|` and trim cells. Header detection also splits on `|` and checks all expected headers appear in some cell. Border regex extended to include `+` and `|`.

### Test fixtures

The previous test fixtures used a whitespace-only-aligned column format that never appears in production output (no `|`, no `+----+` borders). They never caught this bug because they didn't exercise the real format. Updated both failing fixtures (`parses report with conversions table`, `handles multiple metrics with different units`) to use the real tablewriter format.

## #49 — `gsc_analytics_run` truncates `site` with trailing dots

The Go binary emits a progress line:

```
Querying search analytics for sc-domain:wealthsim.app...
```

The trailing `...` is cosmetic loading-indicator text, not part of the site URL. The parser regex `/Querying search analytics for\s+(\S+)/` greedily captured the dots, producing structured output like `site: "sc-domain:wealthsim.app..."`. A follow-up call using that echoed value would 404.

### Fix

Strip trailing dots after extraction: `.replace(/\.+$/, '')`. Single-line change.

## Verification

- `npm run build` — clean
- `npm run test:run` — 1322 / 1322 passing
- `npm run lint` — clean

The four previously-failing tests now pass against corrected real-format fixtures.

**Live MCP retest is blocked** until the user restarts Claude Desktop / their MCP client to pick up the rebuilt `dist/`. The unit tests prove the logic is correct against representative input.

## What this PR does NOT do

- Does not switch `ga4_report` to a structured-output mode of the binary (e.g. `--export json` if it streams to stdout). That would be a more robust fix but a larger change. This PR keeps the table-parsing approach but makes it correct.
- Does not audit other tools for similar table-parsing bugs. If `gsc_index_coverage` or `gsc_monitor_urls` also parse tablewriter output via fixed positions, they may have the same latent bug; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)