### PR TITLE
feat(render): extract Renderer module; pilot on gsc_analytics

### DIFF
--- a/cmd/gsc_analytics.go
+++ b/cmd/gsc_analytics.go
@@ -1,21 +1,19 @@
 package cmd
 
 import (
-	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/olekukonko/tablewriter"
-	tw "github.com/olekukonko/tablewriter/tw"
 	"github.com/spf13/cobra"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
 	"github.com/garbarok/ga4-manager/internal/config"
 	"github.com/garbarok/ga4-manager/internal/gsc"
+	"github.com/garbarok/ga4-manager/internal/render"
 )
 
 var (
@@ -271,58 +269,68 @@ func displayAnalyticsDryRun(query *gsc.SearchAnalyticsQuery) {
 	color.Blue("ℹ️  No API call made. Remove --dry-run to execute query.")
 }
 
+// analyticsColumns builds the column list from the report's dimensions plus
+// the four fixed metric columns. Title-casing the dimension names matches the
+// previous hand-rolled headers.
+func analyticsColumns(report *gsc.SearchAnalyticsReport) []string {
+	columns := make([]string, 0, len(report.Metadata.Dimensions)+4)
+	for _, dim := range report.Metadata.Dimensions {
+		columns = append(columns, cases.Title(language.English).String(dim))
+	}
+	return append(columns, "Clicks", "Impressions", "CTR", "Position")
+}
+
+// analyticsTableRow truncates long dimension values for terminal display and
+// uses one-decimal precision on CTR and position.
+func analyticsTableRow(row gsc.SearchAnalyticsRow) []string {
+	cells := make([]string, 0, len(row.Keys)+4)
+	for _, k := range row.Keys {
+		if len(k) > 60 {
+			cells = append(cells, k[:57]+"...")
+		} else {
+			cells = append(cells, k)
+		}
+	}
+	return append(cells,
+		fmt.Sprintf("%d", row.Clicks),
+		fmt.Sprintf("%d", row.Impressions),
+		fmt.Sprintf("%.1f%%", row.CTR*100),
+		fmt.Sprintf("%.1f", row.Position),
+	)
+}
+
+// analyticsCSVRow keeps dimension values verbatim and emits CTR / position at
+// full precision so downstream spreadsheet/BI tools can reformat.
+func analyticsCSVRow(row gsc.SearchAnalyticsRow) []string {
+	cells := make([]string, 0, len(row.Keys)+4)
+	cells = append(cells, row.Keys...)
+	return append(cells,
+		fmt.Sprintf("%d", row.Clicks),
+		fmt.Sprintf("%d", row.Impressions),
+		fmt.Sprintf("%.6f", row.CTR),
+		fmt.Sprintf("%.2f", row.Position),
+	)
+}
+
+// analyticsMarkdownRow matches the table-mode precision; pipe escaping is
+// handled inside the render package.
+func analyticsMarkdownRow(row gsc.SearchAnalyticsRow) []string {
+	cells := make([]string, 0, len(row.Keys)+4)
+	cells = append(cells, row.Keys...)
+	return append(cells,
+		fmt.Sprintf("%d", row.Clicks),
+		fmt.Sprintf("%d", row.Impressions),
+		fmt.Sprintf("%.1f%%", row.CTR*100),
+		fmt.Sprintf("%.1f", row.Position),
+	)
+}
+
 func displayAnalyticsTable(report *gsc.SearchAnalyticsReport) error {
 	if report.TotalRows == 0 {
 		color.Yellow("⚠ No data found for this query")
 		return nil
 	}
-
-	table := tablewriter.NewWriter(os.Stdout)
-
-	// Build header based on dimensions
-	header := make([]string, 0, len(report.Metadata.Dimensions)+4)
-	for _, dim := range report.Metadata.Dimensions {
-		header = append(header, cases.Title(language.English).String(dim))
-	}
-	header = append(header, "Clicks", "Impressions", "CTR", "Position")
-	table.Header(header)
-
-	// Table styling
-	table.Options(tablewriter.WithHeaderAlignment(tw.AlignLeft))
-	table.Options(tablewriter.WithRowAlignment(tw.AlignLeft))
-	table.Options(tablewriter.WithRendition(tw.Rendition{Borders: tw.BorderNone}))
-
-	// Add rows
-	for _, row := range report.Rows {
-		rowData := make([]string, 0, len(row.Keys)+4)
-
-		// Add dimension values
-		for _, key := range row.Keys {
-			// Truncate long URLs/queries for table display
-			if len(key) > 60 {
-				rowData = append(rowData, key[:57]+"...")
-			} else {
-				rowData = append(rowData, key)
-			}
-		}
-
-		// Add metrics
-		rowData = append(rowData,
-			fmt.Sprintf("%d", row.Clicks),
-			fmt.Sprintf("%d", row.Impressions),
-			fmt.Sprintf("%.1f%%", row.CTR*100),
-			fmt.Sprintf("%.1f", row.Position),
-		)
-
-		if err := table.Append(rowData); err != nil {
-			return fmt.Errorf("failed to append table row: %w", err)
-		}
-	}
-
-	if err := table.Render(); err != nil {
-		return fmt.Errorf("failed to render table: %w", err)
-	}
-	return nil
+	return render.Render(os.Stdout, render.FormatTable, analyticsColumns(report), report.Rows, analyticsTableRow)
 }
 
 func displayAnalyticsJSON(report *gsc.SearchAnalyticsReport) {
@@ -332,34 +340,7 @@ func displayAnalyticsJSON(report *gsc.SearchAnalyticsReport) {
 }
 
 func displayAnalyticsCSV(report *gsc.SearchAnalyticsReport) {
-	writer := csv.NewWriter(os.Stdout)
-	defer writer.Flush()
-
-	// Write header
-	header := make([]string, 0, len(report.Metadata.Dimensions)+4)
-	for _, dim := range report.Metadata.Dimensions {
-		header = append(header, cases.Title(language.English).String(dim))
-	}
-	header = append(header, "Clicks", "Impressions", "CTR", "Position")
-	_ = writer.Write(header)
-
-	// Write rows
-	for _, row := range report.Rows {
-		record := make([]string, 0, len(row.Keys)+4)
-
-		// Add dimension values
-		record = append(record, row.Keys...)
-
-		// Add metrics
-		record = append(record,
-			fmt.Sprintf("%d", row.Clicks),
-			fmt.Sprintf("%d", row.Impressions),
-			fmt.Sprintf("%.6f", row.CTR), // Full precision for CSV
-			fmt.Sprintf("%.2f", row.Position),
-		)
-
-		_ = writer.Write(record)
-	}
+	_ = render.Render(os.Stdout, render.FormatCSV, analyticsColumns(report), report.Rows, analyticsCSVRow)
 }
 
 func displayAnalyticsMarkdown(report *gsc.SearchAnalyticsReport) {
@@ -376,7 +357,6 @@ func displayAnalyticsMarkdown(report *gsc.SearchAnalyticsReport) {
 		return
 	}
 
-	// Summary section
 	fmt.Println("## Summary")
 	fmt.Println()
 	fmt.Printf("- **Total Rows:** %d\n", report.TotalRows)
@@ -386,48 +366,15 @@ func displayAnalyticsMarkdown(report *gsc.SearchAnalyticsReport) {
 	fmt.Printf("- **Average Position:** %.1f\n", report.Aggregates.AveragePosition)
 	fmt.Println()
 
-	// Data table
 	fmt.Println("## Results")
 	fmt.Println()
 
-	// Table header
-	headerRow := "|"
-	separatorRow := "|"
-	for _, dim := range report.Metadata.Dimensions {
-		headerRow += fmt.Sprintf(" %s |", cases.Title(language.English).String(dim))
-		separatorRow += " --- |"
+	// Limit to top 50 rows for markdown readability.
+	rows := report.Rows
+	if len(rows) > 50 {
+		rows = rows[:50]
 	}
-	headerRow += " Clicks | Impressions | CTR | Position |"
-	separatorRow += " ---: | ---: | ---: | ---: |"
-
-	fmt.Println(headerRow)
-	fmt.Println(separatorRow)
-
-	// Data rows (limit to top 50 for markdown readability)
-	displayLimit := report.TotalRows
-	if displayLimit > 50 {
-		displayLimit = 50
-	}
-
-	for i := 0; i < displayLimit; i++ {
-		row := report.Rows[i]
-		dataRow := "|"
-
-		for _, key := range row.Keys {
-			// Escape pipes in values
-			escapedKey := strings.ReplaceAll(key, "|", "\\|")
-			dataRow += fmt.Sprintf(" %s |", escapedKey)
-		}
-
-		dataRow += fmt.Sprintf(" %d | %d | %.1f%% | %.1f |",
-			row.Clicks,
-			row.Impressions,
-			row.CTR*100,
-			row.Position,
-		)
-
-		fmt.Println(dataRow)
-	}
+	_ = render.Render(os.Stdout, render.FormatMarkdown, analyticsColumns(report), rows, analyticsMarkdownRow)
 
 	if report.TotalRows > 50 {
 		fmt.Println()

--- a/cmd/gsc_cannibalization.go
+++ b/cmd/gsc_cannibalization.go
@@ -52,7 +52,7 @@ func init() {
 
 	gscCannibalizationCmd.Flags().StringVarP(&gscCannibalizationConfig, "config", "c", "", "Path to configuration file (required)")
 	gscCannibalizationCmd.Flags().Int64Var(&gscCannibalizationMinImpressions, "min-impressions", diagnostics.DefaultMinImpressions, "Per-page impression threshold for the cannibalisation predicate")
-	gscCannibalizationCmd.Flags().StringVar(&gscCannibalizationFormat, "format", diagcmd.FormatText, "Output format: text or json")
+	gscCannibalizationCmd.Flags().StringVar(&gscCannibalizationFormat, "format", diagcmd.FormatTable, "Output format: table or json")
 }
 
 // gscClientFactory returns a live GSC client wrapped behind the SearchAPI

--- a/cmd/gsc_cannibalization_test.go
+++ b/cmd/gsc_cannibalization_test.go
@@ -70,7 +70,7 @@ func TestRunCannibalizationCommand_CleanExitOnEmpty(t *testing.T) {
 	fake := &fakeSearchAPI{rows: []gsc.SearchAnalyticsRow{
 		cannibalisationRow("widgets", "https://example.com/a", 100),
 	}}
-	params, stdout, _ := newParams(t, fake, diagcmd.FormatText)
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatTable)
 
 	status := runCannibalizationCommand(params)
 
@@ -87,7 +87,7 @@ func TestRunCannibalizationCommand_IssuesExitOnHit(t *testing.T) {
 		cannibalisationRow("widgets", "https://example.com/a", 50),
 		cannibalisationRow("widgets", "https://example.com/b", 30),
 	}}
-	params, stdout, _ := newParams(t, fake, diagcmd.FormatText)
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatTable)
 
 	status := runCannibalizationCommand(params)
 
@@ -177,7 +177,7 @@ func TestRunCannibalizationCommand_EmptyJSONStillIncludesEnvelope(t *testing.T) 
 
 func TestRunCannibalizationCommand_FailureOnAPIError(t *testing.T) {
 	fake := &fakeSearchAPI{err: errors.New("api down")}
-	params, _, stderr := newParams(t, fake, diagcmd.FormatText)
+	params, _, stderr := newParams(t, fake, diagcmd.FormatTable)
 
 	status := runCannibalizationCommand(params)
 
@@ -191,7 +191,7 @@ func TestRunCannibalizationCommand_FailureOnAPIError(t *testing.T) {
 
 func TestRunCannibalizationCommand_FailureOnMissingConfig(t *testing.T) {
 	params := cannibalizationParams{
-		Format:  diagcmd.FormatText,
+		Format:  diagcmd.FormatTable,
 		Stdout:  &bytes.Buffer{},
 		Stderr:  &bytes.Buffer{},
 		Factory: func() (gsc.SearchAPI, func(), error) { return &fakeSearchAPI{}, func() {}, nil },

--- a/internal/gsc/diagcmd/framework.go
+++ b/internal/gsc/diagcmd/framework.go
@@ -2,7 +2,7 @@
 //
 // Every command under `ga4 gsc <diagnostic>` follows the same framework shape:
 // a JSON envelope with {command, site, generated_at, results, quota_used};
-// --format text|json; exit codes 0 (clean) / 2 (issues detected) / 1 (failure);
+// --format table|json; exit codes 0 (clean) / 2 (issues detected) / 1 (failure);
 // "silent on all-green" stdout aside from the quota footer. This package owns
 // those concerns so per-command code is reduced to the predicate-specific
 // glue: build the query, apply the predicate, supply the text-row renderer.
@@ -16,18 +16,21 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
-	"text/tabwriter"
 	"time"
 
 	"github.com/garbarok/ga4-manager/internal/config"
+	"github.com/garbarok/ga4-manager/internal/render"
 )
 
 // Output format names, exported so command files reference these instead of
-// duplicating string literals.
+// duplicating string literals. The diagnostic CLI accepts the table format
+// (human-readable, tab-aligned) and json (structured envelope for MCP /
+// scripts). Other rendering formats (csv, markdown) are available via the
+// underlying internal/render module but not exposed on diagnostic commands —
+// the JSON envelope is the canonical machine-readable shape here.
 const (
-	FormatText = "text"
-	FormatJSON = "json"
+	FormatTable = render.FormatTable
+	FormatJSON  = "json"
 )
 
 // Framework exit codes. The CLI convention is fixed: anything that crosses
@@ -68,11 +71,10 @@ func NewEnvelope[T any](command, site string, now time.Time, results []T, quotaU
 //
 // In JSON mode, the entire envelope is encoded with two-space indentation.
 //
-// In text mode, an empty Results slice prints only the framework's
+// In table mode, an empty Results slice prints only the framework's
 // `quota used: N` footer (the "silent on all-green" convention). When
-// Results is non-empty, columns is emitted as a tab-separated header and
-// rowFn is called for each result to produce the row cells; the final
-// footer line is `quota used: N`.
+// Results is non-empty, the table is rendered via internal/render and the
+// final footer line `quota used: N` is appended.
 func Render[T any](w io.Writer, env Envelope[T], format string, columns []string, rowFn func(T) []string) error {
 	if format == FormatJSON {
 		enc := json.NewEncoder(w)
@@ -81,16 +83,7 @@ func Render[T any](w io.Writer, env Envelope[T], format string, columns []string
 	}
 
 	if len(env.Results) > 0 {
-		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-		if _, err := fmt.Fprintln(tw, strings.Join(columns, "\t")); err != nil {
-			return err
-		}
-		for _, r := range env.Results {
-			if _, err := fmt.Fprintln(tw, strings.Join(rowFn(r), "\t")); err != nil {
-				return err
-			}
-		}
-		if err := tw.Flush(); err != nil {
+		if err := render.Render(w, render.FormatTable, columns, env.Results, rowFn); err != nil {
 			return err
 		}
 	}
@@ -123,8 +116,8 @@ func FailWith(w io.Writer, format string, args ...any) int {
 // ValidateFormat returns an error if format is not one of the supported
 // output formats. Commands call this once on entry to fail fast.
 func ValidateFormat(format string) error {
-	if format != FormatText && format != FormatJSON {
-		return fmt.Errorf("invalid --format %q: must be %s or %s", format, FormatText, FormatJSON)
+	if format != FormatTable && format != FormatJSON {
+		return fmt.Errorf("invalid --format %q: must be %s or %s", format, FormatTable, FormatJSON)
 	}
 	return nil
 }

--- a/internal/gsc/diagcmd/framework_test.go
+++ b/internal/gsc/diagcmd/framework_test.go
@@ -55,7 +55,7 @@ func TestRenderJSONEncodesEnvelope(t *testing.T) {
 
 func TestRenderTextPrintsHeaderRowsAndFooter(t *testing.T) {
 	var buf bytes.Buffer
-	err := Render(&buf, sampleEnvelope(), FormatText,
+	err := Render(&buf, sampleEnvelope(), FormatTable,
 		[]string{"name", "score"},
 		func(r row) []string { return []string{r.Name, strconv.Itoa(r.Score)} },
 	)
@@ -77,7 +77,7 @@ func TestRenderTextPrintsHeaderRowsAndFooter(t *testing.T) {
 func TestRenderTextEmptyResultsPrintsOnlyFooter(t *testing.T) {
 	env := NewEnvelope[row]("gsc_sample", "sc-domain:example.com", time.Now(), nil, 7)
 	var buf bytes.Buffer
-	err := Render(&buf, env, FormatText,
+	err := Render(&buf, env, FormatTable,
 		[]string{"name", "score"},
 		func(r row) []string { return []string{r.Name, strconv.Itoa(r.Score)} },
 	)
@@ -109,7 +109,7 @@ func TestExitCodeMapping(t *testing.T) {
 }
 
 func TestValidateFormat(t *testing.T) {
-	if err := ValidateFormat(FormatText); err != nil {
+	if err := ValidateFormat(FormatTable); err != nil {
 		t.Errorf("text should be valid, got %v", err)
 	}
 	if err := ValidateFormat(FormatJSON); err != nil {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -1,0 +1,132 @@
+// Package render is the shared tabular Renderer for ga4-manager CLI commands.
+//
+// One generic function — Render — accepts a slice of typed rows plus a
+// projection function to flatten each row into string cells, and writes the
+// table in one of three formats: table (tabwriter-aligned plain text), csv
+// (RFC 4180), or markdown (pipe-table). JSON serialisation is intentionally
+// not handled here: each command owns its own JSON envelope shape, because
+// downstream consumers expect command-specific fields (aggregates, metadata,
+// quota footers) that no general renderer should impose.
+//
+// Color, emoji, titles, and summary footers stay in the caller. The Renderer
+// emits plain text only — safe for redirection, pipelines, and CI logs.
+package render
+
+import (
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+)
+
+// Canonical format names. No aliases — exactly one string per format.
+const (
+	FormatTable    = "table"
+	FormatCSV      = "csv"
+	FormatMarkdown = "markdown"
+)
+
+// ErrUnknownFormat is returned when Render is given a format string that is
+// not one of FormatTable, FormatCSV, or FormatMarkdown.
+var ErrUnknownFormat = errors.New("render: unknown format")
+
+// Render writes the rows to w in the requested format.
+//
+// columns is the header row; rowFn projects each row to its cells. The
+// projection must return a slice of the same length as columns — Render
+// returns an error if the projection length differs, rather than emitting a
+// ragged table.
+//
+// An empty rows slice still emits the header (and an empty CSV/markdown
+// structure) so downstream parsers see a well-formed document. Callers that
+// want "silent on empty" should check len(rows) before calling Render.
+func Render[T any](
+	w io.Writer,
+	format string,
+	columns []string,
+	rows []T,
+	rowFn func(T) []string,
+) error {
+	switch format {
+	case FormatTable:
+		return renderTable(w, columns, rows, rowFn)
+	case FormatCSV:
+		return renderCSV(w, columns, rows, rowFn)
+	case FormatMarkdown:
+		return renderMarkdown(w, columns, rows, rowFn)
+	default:
+		return fmt.Errorf("%w: %q (want %s, %s, or %s)",
+			ErrUnknownFormat, format, FormatTable, FormatCSV, FormatMarkdown)
+	}
+}
+
+func renderTable[T any](w io.Writer, columns []string, rows []T, rowFn func(T) []string) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, strings.Join(columns, "\t")); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		cells := rowFn(r)
+		if err := assertArity(len(cells), len(columns)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(tw, strings.Join(cells, "\t")); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func renderCSV[T any](w io.Writer, columns []string, rows []T, rowFn func(T) []string) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write(columns); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		cells := rowFn(r)
+		if err := assertArity(len(cells), len(columns)); err != nil {
+			return err
+		}
+		if err := cw.Write(cells); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func renderMarkdown[T any](w io.Writer, columns []string, rows []T, rowFn func(T) []string) error {
+	if _, err := fmt.Fprintf(w, "| %s |\n", strings.Join(columns, " | ")); err != nil {
+		return err
+	}
+	sep := make([]string, len(columns))
+	for i := range sep {
+		sep[i] = "---"
+	}
+	if _, err := fmt.Fprintf(w, "| %s |\n", strings.Join(sep, " | ")); err != nil {
+		return err
+	}
+	for _, r := range rows {
+		cells := rowFn(r)
+		if err := assertArity(len(cells), len(columns)); err != nil {
+			return err
+		}
+		escaped := make([]string, len(cells))
+		for i, c := range cells {
+			escaped[i] = strings.ReplaceAll(c, "|", `\|`)
+		}
+		if _, err := fmt.Fprintf(w, "| %s |\n", strings.Join(escaped, " | ")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func assertArity(got, want int) error {
+	if got != want {
+		return fmt.Errorf("render: projection returned %d cells, want %d", got, want)
+	}
+	return nil
+}

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -1,0 +1,134 @@
+package render
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+type row struct {
+	name  string
+	score int
+}
+
+func projectRow(r row) []string {
+	return []string{r.name, fmt.Sprintf("%d", r.score)}
+}
+
+func sampleRows() []row {
+	return []row{
+		{name: "alpha", score: 1},
+		{name: "beta", score: 22},
+		{name: "gamma|escape", score: 333},
+	}
+}
+
+var sampleColumns = []string{"name", "score"}
+
+func TestRenderTableEmitsTabwriterAligned(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, FormatTable, sampleColumns, sampleRows(), projectRow); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"name", "score", "alpha", "beta", "gamma|escape", "333"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q\n%s", want, out)
+		}
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 4 {
+		t.Errorf("expected 4 lines (header + 3 rows), got %d\n%s", len(lines), out)
+	}
+}
+
+func TestRenderCSVEmitsRFC4180(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, FormatCSV, sampleColumns, sampleRows(), projectRow); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	wantLines := []string{
+		"name,score",
+		"alpha,1",
+		"beta,22",
+		"gamma|escape,333",
+	}
+	got := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(got) != len(wantLines) {
+		t.Fatalf("expected %d lines, got %d\n%s", len(wantLines), len(got), out)
+	}
+	for i, want := range wantLines {
+		if got[i] != want {
+			t.Errorf("line %d: got %q, want %q", i, got[i], want)
+		}
+	}
+}
+
+func TestRenderMarkdownEmitsPipeTable(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, FormatMarkdown, sampleColumns, sampleRows(), projectRow); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "| name | score |") {
+		t.Errorf("missing header row: %s", out)
+	}
+	if !strings.Contains(out, "| --- | --- |") {
+		t.Errorf("missing separator row: %s", out)
+	}
+	if !strings.Contains(out, "| alpha | 1 |") {
+		t.Errorf("missing data row: %s", out)
+	}
+	// Pipe character inside cell content must be escaped.
+	if !strings.Contains(out, `gamma\|escape`) {
+		t.Errorf("pipe character not escaped: %s", out)
+	}
+}
+
+func TestRenderEmptyRowsStillEmitsHeader(t *testing.T) {
+	tests := []struct {
+		format     string
+		wantHeader string
+	}{
+		{FormatTable, "name"},
+		{FormatCSV, "name,score"},
+		{FormatMarkdown, "| name | score |"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.format, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := Render(&buf, tc.format, sampleColumns, []row{}, projectRow); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if !strings.Contains(buf.String(), tc.wantHeader) {
+				t.Errorf("%s: empty rows should still emit header, got %q", tc.format, buf.String())
+			}
+		})
+	}
+}
+
+func TestRenderUnknownFormatReturnsTypedError(t *testing.T) {
+	var buf bytes.Buffer
+	err := Render(&buf, "xml", sampleColumns, sampleRows(), projectRow)
+	if err == nil {
+		t.Fatal("expected error for unknown format")
+	}
+	if !errors.Is(err, ErrUnknownFormat) {
+		t.Errorf("expected ErrUnknownFormat, got %v", err)
+	}
+}
+
+func TestRenderArityMismatchReturnsError(t *testing.T) {
+	badProjection := func(r row) []string { return []string{r.name} } // only 1 cell, columns has 2
+	var buf bytes.Buffer
+	err := Render(&buf, FormatTable, sampleColumns, sampleRows(), badProjection)
+	if err == nil {
+		t.Fatal("expected error for arity mismatch")
+	}
+	if !strings.Contains(err.Error(), "projection returned") {
+		t.Errorf("error should mention projection arity: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Slice 1 of the rendering-friction work surfaced by the
\`/improve-codebase-architecture\` review on PR #63. Stacked on top of #63;
merge that first, then this.

- **\`internal/render\`** — canonical tabular renderer for ga4-manager CLI commands. One generic \`Render[T](w, format, columns, rows, rowFn)\` function. Three formats: \`table\` (tabwriter), \`csv\` (RFC 4180), \`markdown\` (pipe-table with pipe-escape). JSON stays out — each command owns its own JSON envelope shape because downstream consumers expect command-specific fields no general renderer should impose. Emits plain text only; color / emoji / titles / summary blocks stay in callers.
- **diagcmd migration** — \`FormatText\` constant renamed to \`FormatTable\` to match the canonical vocabulary. The diagnostic CLI's \`--format\` flag now accepts \`table\` or \`json\` instead of \`text\` or \`json\`. The MCP tool always passes \`json\` so the upstream wire is unaffected. \`diagcmd.Render\` delegates its table path to \`render.Render\`.
- **Pilot: \`cmd/gsc_analytics.go\`** — the four hand-rolled display functions become 1–3-line wrappers around \`render.Render\` with per-format projection functions. The \`olekukonko/tablewriter\` dependency is removed from this file. Six other cmd files still use it; they migrate in slice 2 (next PR).
- **No JSON output shape changes.** Analytics JSON still emits \`{site, period, rows, aggregates, metadata, quota}\` exactly as before; consumers are unaffected.

## Grilling decisions (locked)

- **Renderer signature**: generic \`Render[T any](w, format, columns, rows, rowFn) error\` — mirrors \`diagcmd.Render\`'s existing shape.
- **Input model**: Option C from the grill (shape-agnostic Renderer over rows + projection function). No \`Envelope\`, no \`Cell\` taxonomy.
- **Format vocabulary**: \`table\` / \`csv\` / \`markdown\` (no aliases, no \`text\`, no \`md\`).
- **Summary blocks / quota footers / titles**: caller-printed. Renderer is narrow.
- **Migration order**: sliced. This PR is the pilot. Slice 2 = remaining six cmds + \`cmd/report.go\` \`md → markdown\` normalization.

## Test plan

- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [x] \`make lint\` clean (only pre-existing vendored govet warnings)
- [x] \`npm test\` in \`mcp/\` green (1358 tests)
- [ ] Manual smoke on a real GSC site: \`ga4 gsc analytics run --config <path> --format table\`, \`--format csv > out.csv\`, \`--format markdown > out.md\`
- [ ] Manual smoke on diagnostic: \`ga4 gsc cannibalization --config <path>\` defaults to table format

## What's next

Slice 2 migrates the remaining six cmd files (\`gsc_coverage\`, \`gsc_monitor\`, \`gsc_inspect\`, \`gsc_sitemaps\`, \`cleanup\`, \`report\`) and normalises \`cmd/report.go\`'s \`md → markdown\`. Spawning an AFK agent for it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)