### PR TITLE
fix(mcp): treat exit 2 as success; fail fast on missing ga4 binary

### DIFF
--- a/mcp/src/cli/executor.ts
+++ b/mcp/src/cli/executor.ts
@@ -1,9 +1,15 @@
 import { spawn } from 'child_process';
+import { accessSync, constants } from 'fs';
 import type { CLIResult, CLIExecuteParams } from '../types/cli.js';
 import { stripANSI } from '../utils/ansi-strip.js';
 
 /**
- * Executes CLI commands and captures output
+ * Executes CLI commands and captures output.
+ *
+ * The binary path is validated at construction time. If the binary does
+ * not exist or is not executable, an Error with a remediation hint is
+ * thrown immediately — the previous behaviour surfaced an opaque
+ * `spawn .../ga4 ENOENT` on the first tool call instead.
  */
 export class CLIExecutor {
   private binaryPath: string;
@@ -11,6 +17,20 @@ export class CLIExecutor {
 
   constructor(binaryPath: string) {
     this.binaryPath = binaryPath;
+    this.assertBinaryUsable();
+  }
+
+  private assertBinaryUsable(): void {
+    try {
+      accessSync(this.binaryPath, constants.X_OK);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `ga4 CLI binary not found or not executable at ${this.binaryPath} (${reason}).\n` +
+          `Build it first: 'make build' or 'go build -o ga4 .' from the repo root.\n` +
+          `Override the path with the GA4_BINARY_PATH environment variable.`,
+      );
+    }
   }
 
   /**

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -132,6 +132,17 @@ const __dirname = dirname(__filename)
 const binaryPath = process.env.GA4_BINARY_PATH || join(__dirname, '../../ga4')
 const executor = new CLIExecutor(binaryPath)
 
+// Framework convention (see CONTEXT.md, docs/BACKLOG.md "Implementation notes"):
+//   exit 0 — clean run, no findings
+//   exit 1 — command failed (API error, malformed config, etc.)
+//   exit 2 — success with findings (e.g. cannibalising queries detected)
+//
+// Both 0 and 2 are success at the MCP dispatch layer; the parsed JSON
+// envelope tells the caller whether findings exist. Treating 2 as failure
+// would swallow stdout — the very report the tool exists to surface.
+const SUCCESS_EXIT_CODES = new Set([0, 2])
+const isSuccessExit = (code: number): boolean => SUCCESS_EXIT_CODES.has(code)
+
 // ============================================================================
 // Tool registry
 // ============================================================================
@@ -304,7 +315,7 @@ const SPECS: ToolSpec[] = [
         command: 'gsc',
         args: buildMonitorUrlsArgs(input),
       })
-      if (result.exitCode !== 0) {
+      if (!isSuccessExit(result.exitCode)) {
         return { output: mapCLIError(result, 'gsc_monitor_urls'), isError: true }
       }
       return { output: parseMonitorUrlsOutput(result.stdout, input), isError: false }
@@ -383,7 +394,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       command: spec.command,
       args: spec.buildArgs(input),
     })
-    if (result.exitCode !== 0) {
+    if (!isSuccessExit(result.exitCode)) {
       return jsonContent(mapCLIError(result, name), true)
     }
     return jsonContent(spec.parse(result.stdout, input))


### PR DESCRIPTION
## Summary

Two MCP-layer bugs surfaced by Operator feedback after running BO-04 (cannibalisation) end-to-end.

**1. Exit code 2 swallowed stdout.** Framework convention is \`0\` clean, \`1\` failed, \`2\` success-with-findings. The MCP dispatch treated any non-zero exit as \`CLI_EXECUTION_FAILED\`, returning only stderr. The actual JSON envelope — the findings report — never reached the model. Now \`{0, 2}\` are both treated as success; only \`1\` and unexpected codes route to \`mapCLIError\`. This restores the CLI+MCP parity contract for every diagnostic command (cannibalisation today, all BO-* commands going forward).

**2. Opaque \`spawn .../ga4 ENOENT\` on missing binary.** First MCP call after a fresh clone surfaced a confusing libuv error with no remediation hint. \`CLIExecutor\` now validates the binary at construction (synchronous \`accessSync\` with \`X_OK\`) and throws with a clear message pointing at \`make build\`, \`go build -o ga4 .\`, and the \`GA4_BINARY_PATH\` env override. The MCP server fails to start rather than producing a confusing first-tool-call error.

## Test plan

- [x] \`npm test\` in \`mcp/\` — 46 files, 1358 tests, all green
- [x] \`npm run build\` clean
- [ ] Manual smoke: invoke \`gsc_cannibalization\` MCP tool with findings → verify stdout JSON envelope reaches the client (no longer collapsed to \`CLI_EXECUTION_FAILED\`)
- [ ] Manual smoke: delete \`ga4\` binary → start MCP server → verify clear error message