### PR TITLE
feat(cannibalization): --days, --with-coverage-state, canonical_candidate docs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,6 +110,11 @@ Two or more pages on the same site ranking for the same query, splitting authori
 cannibalisation ≔ ≥2 pages on the same query with impressions ≥ 10
 ```
 
+The `canonical_candidate` field on a cannibalisation result is a heuristic: it is the page with the highest current impressions on the query, **not** Google's chosen canonical. For migrating sites GSC may still attribute impressions to a legacy URL inside its 28-day window, so the impression leader can be the page the Operator intends to redirect away from. When precision matters, callers can request a per-page coverage_state lookup which annotates each finding with a severity tier:
+
+- `actionable` — every page in the result is in a non-redirect coverage state.
+- `consolidating` — at least one page is `Page with redirect`; the migration is mid-flight and the finding will decay out of the GSC attribution window on its own.
+
 Avoid: "duplicate ranking", "query overlap".
 
 ---

--- a/cmd/gsc_cannibalization.go
+++ b/cmd/gsc_cannibalization.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strconv"
 	"time"
 
@@ -15,15 +16,37 @@ import (
 )
 
 const (
-	cannibalizationDays        = 30
+	cannibalizationDaysDefault = 28
+	cannibalizationDaysMin     = 1
+	cannibalizationDaysMax     = 485 // GSC retains roughly 16 months of search-analytics data
 	cannibalizationRowLimit    = 5000
 	cannibalizationCommandName = "gsc_cannibalization"
+
+	// CoverageStatePageWithRedirect is the URL Inspection coverage_state
+	// string GSC returns for a page that is being redirected away. A
+	// cannibalisation pair where either side is in this state is
+	// "consolidating" rather than "actionable" — the impressions are still
+	// being attributed under GSC's 28-day window but the migration is
+	// already in flight.
+	CoverageStatePageWithRedirect = "Page with redirect"
+
+	// SeverityActionable indicates every page in the result is in a
+	// non-redirect coverage state — the Operator can act on this pair
+	// today.
+	SeverityActionable = "actionable"
+
+	// SeverityConsolidating indicates at least one page in the result is
+	// a "Page with redirect" — the migration is mid-flight and the finding
+	// will decay out of the GSC attribution window on its own.
+	SeverityConsolidating = "consolidating"
 )
 
 var (
-	gscCannibalizationConfig         string
-	gscCannibalizationMinImpressions int64
-	gscCannibalizationFormat         string
+	gscCannibalizationConfig            string
+	gscCannibalizationMinImpressions    int64
+	gscCannibalizationFormat            string
+	gscCannibalizationDays              int
+	gscCannibalizationWithCoverageState bool
 )
 
 var gscCannibalizationCmd = &cobra.Command{
@@ -35,6 +58,22 @@ indicating duplicate-ranking content to consolidate.
 
 Stateless: one Search Analytics API call per run. No state files written.
 
+The canonical_candidate field is a heuristic: it is the page with the most
+impressions on the query, NOT Google's chosen canonical. For migrating
+sites GSC may still attribute impressions to the legacy URL under its
+28-day window, so the impression leader can be the page you intend to
+redirect AWAY from. Use --with-coverage-state to surface the underlying
+coverage_state on each page and let the severity tier guide you.
+
+Pass --with-coverage-state to additionally inspect each unique candidate
+page via the URL Inspection API. Each result then carries a severity:
+  actionable     — every page is in a non-redirect coverage state
+  consolidating  — at least one page is "Page with redirect"; the
+                   migration is mid-flight and the finding will decay
+                   out of the GSC attribution window on its own.
+Quota cost: one URL Inspection request per unique candidate page; off
+by default because URL Inspection has a 2000/day budget.
+
 Exit codes:
   0  no cannibalising queries detected
   2  at least one cannibalising query detected
@@ -43,7 +82,9 @@ Exit codes:
 Examples:
   ga4 gsc cannibalization --config configs/mysite.yaml
   ga4 gsc cannibalization --config configs/mysite.yaml --format json
-  ga4 gsc cannibalization --config configs/mysite.yaml --min-impressions 25`,
+  ga4 gsc cannibalization --config configs/mysite.yaml --min-impressions 25
+  ga4 gsc cannibalization --config configs/mysite.yaml --days 90
+  ga4 gsc cannibalization --config configs/mysite.yaml --with-coverage-state`,
 	RunE: cannibalizationRunE,
 }
 
@@ -53,11 +94,20 @@ func init() {
 	gscCannibalizationCmd.Flags().StringVarP(&gscCannibalizationConfig, "config", "c", "", "Path to configuration file (required)")
 	gscCannibalizationCmd.Flags().Int64Var(&gscCannibalizationMinImpressions, "min-impressions", diagnostics.DefaultMinImpressions, "Per-page impression threshold for the cannibalisation predicate")
 	gscCannibalizationCmd.Flags().StringVar(&gscCannibalizationFormat, "format", diagcmd.FormatTable, "Output format: table or json")
+	gscCannibalizationCmd.Flags().IntVar(&gscCannibalizationDays, "days", cannibalizationDaysDefault, "Lookback window in days (1–485)")
+	gscCannibalizationCmd.Flags().BoolVar(&gscCannibalizationWithCoverageState, "with-coverage-state", false, "Inspect each candidate page via URL Inspection and emit a severity tier per finding")
 }
 
-// gscClientFactory returns a live GSC client wrapped behind the SearchAPI
-// interface. Tests substitute a fake.
-var gscClientFactory = func() (gsc.SearchAPI, func(), error) {
+// cannibalizationClient is the union of GSC capabilities this command can
+// use. The InspectAPI half is exercised only when --with-coverage-state is
+// set; without the flag the command never calls InspectURL.
+type cannibalizationClient interface {
+	gsc.SearchAPI
+	gsc.InspectAPI
+}
+
+// gscClientFactory returns a live GSC client. Tests substitute a fake.
+var gscClientFactory = func() (cannibalizationClient, func(), error) {
 	client, err := gsc.NewClient()
 	if err != nil {
 		return nil, func() {}, err
@@ -69,6 +119,9 @@ var gscClientFactory = func() (gsc.SearchAPI, func(), error) {
 type CannibalizationPage struct {
 	Page        string `json:"page"`
 	Impressions int64  `json:"impressions"`
+	// CoverageState is populated only when --with-coverage-state is set;
+	// otherwise the field is omitted from JSON output.
+	CoverageState string `json:"coverage_state,omitempty"`
 }
 
 // CannibalizationResultRow is one row of the JSON results array.
@@ -77,6 +130,9 @@ type CannibalizationResultRow struct {
 	Pages              []CannibalizationPage `json:"pages"`
 	TotalImpressions   int64                 `json:"total_impressions"`
 	CanonicalCandidate string                `json:"canonical_candidate"`
+	// Severity is populated only when --with-coverage-state is set;
+	// otherwise the field is omitted from JSON output.
+	Severity string `json:"severity,omitempty"`
 }
 
 // CannibalizationOutput is the JSON envelope emitted under --format json.
@@ -84,30 +140,37 @@ type CannibalizationOutput = diagcmd.Envelope[CannibalizationResultRow]
 
 func cannibalizationRunE(_ *cobra.Command, _ []string) error {
 	status := runCannibalizationCommand(cannibalizationParams{
-		ConfigPath:     gscCannibalizationConfig,
-		MinImpressions: gscCannibalizationMinImpressions,
-		Format:         gscCannibalizationFormat,
-		Factory:        gscClientFactory,
-		Stdout:         os.Stdout,
-		Stderr:         os.Stderr,
-		Now:            time.Now().UTC(),
+		ConfigPath:         gscCannibalizationConfig,
+		MinImpressions:     gscCannibalizationMinImpressions,
+		Format:             gscCannibalizationFormat,
+		Days:               gscCannibalizationDays,
+		WithCoverageState:  gscCannibalizationWithCoverageState,
+		Factory:            gscClientFactory,
+		Stdout:             os.Stdout,
+		Stderr:             os.Stderr,
+		Now:                time.Now().UTC(),
 	})
 	os.Exit(status)
 	return nil
 }
 
 type cannibalizationParams struct {
-	ConfigPath     string
-	MinImpressions int64
-	Format         string
-	Factory        func() (gsc.SearchAPI, func(), error)
-	Stdout         io.Writer
-	Stderr         io.Writer
-	Now            time.Time
+	ConfigPath        string
+	MinImpressions    int64
+	Format            string
+	Days              int
+	WithCoverageState bool
+	Factory           func() (cannibalizationClient, func(), error)
+	Stdout            io.Writer
+	Stderr            io.Writer
+	Now               time.Time
 }
 
 func runCannibalizationCommand(p cannibalizationParams) int {
 	if err := diagcmd.ValidateFormat(p.Format); err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+	if err := validateCannibalizationDays(p.Days); err != nil {
 		return diagcmd.FailWith(p.Stderr, "%v", err)
 	}
 	site, _, err := diagcmd.LoadSite(p.ConfigPath)
@@ -121,20 +184,27 @@ func runCannibalizationCommand(p cannibalizationParams) int {
 	}
 	defer cleanup()
 
-	env, err := buildCannibalizationEnvelope(client, site, p.MinImpressions, p.Now)
+	env, err := buildCannibalizationEnvelope(client, site, p.MinImpressions, p.Days, p.WithCoverageState, p.Now)
 	if err != nil {
 		return diagcmd.FailWith(p.Stderr, "%v", err)
 	}
 
-	if err := diagcmd.Render(p.Stdout, env, p.Format, cannibalizationColumns, cannibalizationTextRow); err != nil {
+	if err := diagcmd.Render(p.Stdout, env, p.Format, cannibalizationColumnsFor(p.WithCoverageState), cannibalizationTextRowFor(p.WithCoverageState)); err != nil {
 		return diagcmd.FailWith(p.Stderr, "failed to render output: %v", err)
 	}
 
 	return diagcmd.ExitCode(nil, len(env.Results) > 0)
 }
 
-func buildCannibalizationEnvelope(client gsc.SearchAPI, site string, minImpressions int64, now time.Time) (CannibalizationOutput, error) {
-	startDate, endDate := gsc.BuildDateRange(cannibalizationDays)
+func validateCannibalizationDays(days int) error {
+	if days < cannibalizationDaysMin || days > cannibalizationDaysMax {
+		return fmt.Errorf("invalid --days %d: must be in [%d, %d]", days, cannibalizationDaysMin, cannibalizationDaysMax)
+	}
+	return nil
+}
+
+func buildCannibalizationEnvelope(client cannibalizationClient, site string, minImpressions int64, days int, withCoverageState bool, now time.Time) (CannibalizationOutput, error) {
+	startDate, endDate := gsc.BuildDateRange(days)
 	report, err := client.QuerySearchAnalytics(&gsc.SearchAnalyticsQuery{
 		SiteURL:    site,
 		StartDate:  startDate,
@@ -162,16 +232,83 @@ func buildCannibalizationEnvelope(client gsc.SearchAPI, site string, minImpressi
 		})
 	}
 
-	return diagcmd.NewEnvelope(cannibalizationCommandName, site, now, rows, report.QuotaUsed), nil
+	quota := report.QuotaUsed
+	if withCoverageState {
+		inspections, err := annotateWithCoverageState(client, site, rows)
+		if err != nil {
+			return CannibalizationOutput{}, fmt.Errorf("coverage-state inspection failed: %w", err)
+		}
+		quota = report.QuotaUsed + inspections
+	}
+
+	return diagcmd.NewEnvelope(cannibalizationCommandName, site, now, rows, quota), nil
 }
 
-var cannibalizationColumns = []string{"query", "pages", "total_impressions", "canonical_candidate"}
+// annotateWithCoverageState inspects each unique candidate page once and
+// fills in CoverageState on every page entry plus a Severity tier on every
+// result. Returns the number of URL Inspection calls made so the caller can
+// add it to the quota footer.
+func annotateWithCoverageState(client gsc.InspectAPI, site string, rows []CannibalizationResultRow) (int, error) {
+	uniquePages := make(map[string]struct{})
+	for _, r := range rows {
+		for _, p := range r.Pages {
+			uniquePages[p.Page] = struct{}{}
+		}
+	}
 
-func cannibalizationTextRow(r CannibalizationResultRow) []string {
-	return []string{
-		r.Query,
-		strconv.Itoa(len(r.Pages)),
-		strconv.FormatInt(r.TotalImpressions, 10),
-		r.CanonicalCandidate,
+	pageList := make([]string, 0, len(uniquePages))
+	for p := range uniquePages {
+		pageList = append(pageList, p)
+	}
+	sort.Strings(pageList) // deterministic call order for tests + logs
+
+	state := make(map[string]string, len(pageList))
+	for _, page := range pageList {
+		result, err := client.InspectURL(site, page)
+		if err != nil {
+			return 0, fmt.Errorf("inspect %s: %w", page, err)
+		}
+		state[page] = result.CoverageState
+	}
+
+	for i := range rows {
+		hasRedirect := false
+		for j := range rows[i].Pages {
+			cov := state[rows[i].Pages[j].Page]
+			rows[i].Pages[j].CoverageState = cov
+			if cov == CoverageStatePageWithRedirect {
+				hasRedirect = true
+			}
+		}
+		if hasRedirect {
+			rows[i].Severity = SeverityConsolidating
+		} else {
+			rows[i].Severity = SeverityActionable
+		}
+	}
+
+	return len(pageList), nil
+}
+
+func cannibalizationColumnsFor(withCoverageState bool) []string {
+	cols := []string{"query", "pages", "total_impressions", "canonical_candidate"}
+	if withCoverageState {
+		cols = append(cols, "severity")
+	}
+	return cols
+}
+
+func cannibalizationTextRowFor(withCoverageState bool) func(CannibalizationResultRow) []string {
+	return func(r CannibalizationResultRow) []string {
+		cells := []string{
+			r.Query,
+			strconv.Itoa(len(r.Pages)),
+			strconv.FormatInt(r.TotalImpressions, 10),
+			r.CanonicalCandidate,
+		}
+		if withCoverageState {
+			cells = append(cells, r.Severity)
+		}
+		return cells
 	}
 }

--- a/cmd/gsc_cannibalization_test.go
+++ b/cmd/gsc_cannibalization_test.go
@@ -14,25 +14,38 @@ import (
 	"github.com/garbarok/ga4-manager/internal/gsc/diagcmd"
 )
 
-// fakeSearchAPI is a local SearchAPI for the cannibalisation tests. It
-// satisfies the slimmed interface (QuerySearchAnalytics only) and reports
-// quota by counting calls. Lives in this _test.go file to mirror
-// internal/ga4's fakeAdminAPI pattern.
-type fakeSearchAPI struct {
-	rows  []gsc.SearchAnalyticsRow
-	err   error
-	calls int
+// fakeCannibalizationClient implements cannibalizationClient (the union of
+// gsc.SearchAPI and gsc.InspectAPI) for the cannibalisation tests. Lives in
+// this _test.go file to mirror internal/ga4's fakeAdminAPI pattern.
+type fakeCannibalizationClient struct {
+	rows           []gsc.SearchAnalyticsRow
+	searchErr      error
+	searchCalls    int
+	coverageByPage map[string]string
+	inspectErr     error
+	inspectCalls   int
 }
 
-func (f *fakeSearchAPI) QuerySearchAnalytics(_ *gsc.SearchAnalyticsQuery) (*gsc.SearchAnalyticsReport, error) {
-	f.calls++
-	if f.err != nil {
-		return nil, f.err
+func (f *fakeCannibalizationClient) QuerySearchAnalytics(_ *gsc.SearchAnalyticsQuery) (*gsc.SearchAnalyticsReport, error) {
+	f.searchCalls++
+	if f.searchErr != nil {
+		return nil, f.searchErr
 	}
 	return &gsc.SearchAnalyticsReport{
 		Rows:      f.rows,
 		TotalRows: len(f.rows),
-		QuotaUsed: f.calls,
+		QuotaUsed: f.searchCalls,
+	}, nil
+}
+
+func (f *fakeCannibalizationClient) InspectURL(_, page string) (*gsc.URLInspectionResult, error) {
+	f.inspectCalls++
+	if f.inspectErr != nil {
+		return nil, f.inspectErr
+	}
+	return &gsc.URLInspectionResult{
+		URL:           page,
+		CoverageState: f.coverageByPage[page],
 	}, nil
 }
 
@@ -51,7 +64,7 @@ func cannibalisationRow(query, page string, impressions int64) gsc.SearchAnalyti
 	return gsc.SearchAnalyticsRow{Keys: []string{query, page}, Impressions: impressions}
 }
 
-func newParams(t *testing.T, fake *fakeSearchAPI, format string) (cannibalizationParams, *bytes.Buffer, *bytes.Buffer) {
+func newParams(t *testing.T, fake *fakeCannibalizationClient, format string) (cannibalizationParams, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
@@ -59,7 +72,8 @@ func newParams(t *testing.T, fake *fakeSearchAPI, format string) (cannibalizatio
 		ConfigPath:     writeConfig(t, "sc-domain:example.com"),
 		MinImpressions: 10,
 		Format:         format,
-		Factory:        func() (gsc.SearchAPI, func(), error) { return fake, func() {}, nil },
+		Days:           cannibalizationDaysDefault,
+		Factory:        func() (cannibalizationClient, func(), error) { return fake, func() {}, nil },
 		Stdout:         stdout,
 		Stderr:         stderr,
 		Now:            time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC),
@@ -67,7 +81,7 @@ func newParams(t *testing.T, fake *fakeSearchAPI, format string) (cannibalizatio
 }
 
 func TestRunCannibalizationCommand_CleanExitOnEmpty(t *testing.T) {
-	fake := &fakeSearchAPI{rows: []gsc.SearchAnalyticsRow{
+	fake := &fakeCannibalizationClient{rows: []gsc.SearchAnalyticsRow{
 		cannibalisationRow("widgets", "https://example.com/a", 100),
 	}}
 	params, stdout, _ := newParams(t, fake, diagcmd.FormatTable)
@@ -83,7 +97,7 @@ func TestRunCannibalizationCommand_CleanExitOnEmpty(t *testing.T) {
 }
 
 func TestRunCannibalizationCommand_IssuesExitOnHit(t *testing.T) {
-	fake := &fakeSearchAPI{rows: []gsc.SearchAnalyticsRow{
+	fake := &fakeCannibalizationClient{rows: []gsc.SearchAnalyticsRow{
 		cannibalisationRow("widgets", "https://example.com/a", 50),
 		cannibalisationRow("widgets", "https://example.com/b", 30),
 	}}
@@ -106,7 +120,7 @@ func TestRunCannibalizationCommand_IssuesExitOnHit(t *testing.T) {
 }
 
 func TestRunCannibalizationCommand_JSONShape(t *testing.T) {
-	fake := &fakeSearchAPI{rows: []gsc.SearchAnalyticsRow{
+	fake := &fakeCannibalizationClient{rows: []gsc.SearchAnalyticsRow{
 		cannibalisationRow("widgets", "https://example.com/a", 50),
 		cannibalisationRow("widgets", "https://example.com/b", 30),
 		cannibalisationRow("gadgets", "https://example.com/c", 200),
@@ -148,13 +162,16 @@ func TestRunCannibalizationCommand_JSONShape(t *testing.T) {
 	if got.Results[0].CanonicalCandidate != "https://example.com/c" {
 		t.Errorf("results[0].canonical_candidate = %q", got.Results[0].CanonicalCandidate)
 	}
-	if len(got.Results[0].Pages) != 2 {
-		t.Errorf("results[0].pages len = %d, want 2", len(got.Results[0].Pages))
+	if got.Results[0].Severity != "" {
+		t.Errorf("severity should be empty when --with-coverage-state is off, got %q", got.Results[0].Severity)
+	}
+	if got.Results[0].Pages[0].CoverageState != "" {
+		t.Errorf("coverage_state should be empty when --with-coverage-state is off, got %q", got.Results[0].Pages[0].CoverageState)
 	}
 }
 
 func TestRunCannibalizationCommand_EmptyJSONStillIncludesEnvelope(t *testing.T) {
-	fake := &fakeSearchAPI{rows: nil}
+	fake := &fakeCannibalizationClient{rows: nil}
 	params, stdout, _ := newParams(t, fake, diagcmd.FormatJSON)
 
 	status := runCannibalizationCommand(params)
@@ -176,7 +193,7 @@ func TestRunCannibalizationCommand_EmptyJSONStillIncludesEnvelope(t *testing.T) 
 }
 
 func TestRunCannibalizationCommand_FailureOnAPIError(t *testing.T) {
-	fake := &fakeSearchAPI{err: errors.New("api down")}
+	fake := &fakeCannibalizationClient{searchErr: errors.New("api down")}
 	params, _, stderr := newParams(t, fake, diagcmd.FormatTable)
 
 	status := runCannibalizationCommand(params)
@@ -192,9 +209,10 @@ func TestRunCannibalizationCommand_FailureOnAPIError(t *testing.T) {
 func TestRunCannibalizationCommand_FailureOnMissingConfig(t *testing.T) {
 	params := cannibalizationParams{
 		Format:  diagcmd.FormatTable,
+		Days:    cannibalizationDaysDefault,
 		Stdout:  &bytes.Buffer{},
 		Stderr:  &bytes.Buffer{},
-		Factory: func() (gsc.SearchAPI, func(), error) { return &fakeSearchAPI{}, func() {}, nil },
+		Factory: func() (cannibalizationClient, func(), error) { return &fakeCannibalizationClient{}, func() {}, nil },
 		Now:     time.Now(),
 	}
 	if status := runCannibalizationCommand(params); status != diagcmd.ExitFailure {
@@ -203,12 +221,140 @@ func TestRunCannibalizationCommand_FailureOnMissingConfig(t *testing.T) {
 }
 
 func TestRunCannibalizationCommand_FailureOnInvalidFormat(t *testing.T) {
-	fake := &fakeSearchAPI{rows: nil}
+	fake := &fakeCannibalizationClient{rows: nil}
 	params, _, stderr := newParams(t, fake, "xml")
 	if status := runCannibalizationCommand(params); status != diagcmd.ExitFailure {
 		t.Fatalf("status = %d, want %d", status, diagcmd.ExitFailure)
 	}
 	if !strings.Contains(stderr.String(), "invalid --format") {
 		t.Errorf("stderr does not explain invalid format: %q", stderr.String())
+	}
+}
+
+func TestRunCannibalizationCommand_FailureOnInvalidDays(t *testing.T) {
+	fake := &fakeCannibalizationClient{}
+	params, _, stderr := newParams(t, fake, diagcmd.FormatTable)
+	params.Days = 0
+	if status := runCannibalizationCommand(params); status != diagcmd.ExitFailure {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitFailure)
+	}
+	if !strings.Contains(stderr.String(), "invalid --days") {
+		t.Errorf("stderr does not explain invalid days: %q", stderr.String())
+	}
+
+	params.Days = cannibalizationDaysMax + 1
+	stderr.Reset()
+	if status := runCannibalizationCommand(params); status != diagcmd.ExitFailure {
+		t.Fatalf("status above max = %d, want %d", status, diagcmd.ExitFailure)
+	}
+}
+
+func TestRunCannibalizationCommand_WithCoverageStateAddsSeverityAndDedupesInspect(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("widgets", "https://example.com/a", 50),
+			cannibalisationRow("widgets", "https://example.com/b", 30),
+			cannibalisationRow("gadgets", "https://example.com/a", 40), // page A reused across queries
+			cannibalisationRow("gadgets", "https://example.com/c", 25),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/a": "Page with redirect", // legacy, redirected
+			"https://example.com/b": "Submitted and indexed",
+			"https://example.com/c": "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatJSON)
+	params.WithCoverageState = true
+
+	status := runCannibalizationCommand(params)
+	if status != diagcmd.ExitIssues {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitIssues)
+	}
+
+	var got CannibalizationOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+
+	// Deduplication: pages {a, b, c} → 3 unique → 3 Inspect calls, NOT 4.
+	if fake.inspectCalls != 3 {
+		t.Errorf("inspect calls = %d, want 3 (dedup across queries)", fake.inspectCalls)
+	}
+	// Quota footer: 1 search + 3 inspect = 4.
+	if got.QuotaUsed != 4 {
+		t.Errorf("quota_used = %d, want 4", got.QuotaUsed)
+	}
+
+	// Every result has severity populated, every page has coverage_state.
+	for i, r := range got.Results {
+		if r.Severity == "" {
+			t.Errorf("results[%d].severity is empty", i)
+		}
+		for j, p := range r.Pages {
+			if p.CoverageState == "" {
+				t.Errorf("results[%d].pages[%d].coverage_state is empty", i, j)
+			}
+		}
+	}
+
+	// Both queries should be "consolidating" because both share page A (redirect).
+	for i, r := range got.Results {
+		if r.Severity != SeverityConsolidating {
+			t.Errorf("results[%d].severity = %q, want %q (page A redirects in both)", i, r.Severity, SeverityConsolidating)
+		}
+	}
+}
+
+func TestRunCannibalizationCommand_WithCoverageStateActionableWhenNoRedirect(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("widgets", "https://example.com/x", 50),
+			cannibalisationRow("widgets", "https://example.com/y", 30),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/x": "Submitted and indexed",
+			"https://example.com/y": "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatJSON)
+	params.WithCoverageState = true
+
+	if status := runCannibalizationCommand(params); status != diagcmd.ExitIssues {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitIssues)
+	}
+
+	var got CannibalizationOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got.Results))
+	}
+	if got.Results[0].Severity != SeverityActionable {
+		t.Errorf("severity = %q, want %q", got.Results[0].Severity, SeverityActionable)
+	}
+}
+
+func TestRunCannibalizationCommand_WithCoverageStateAddsTableColumn(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("widgets", "https://example.com/x", 50),
+			cannibalisationRow("widgets", "https://example.com/y", 30),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/x": "Submitted and indexed",
+			"https://example.com/y": "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatTable)
+	params.WithCoverageState = true
+
+	runCannibalizationCommand(params)
+	out := stdout.String()
+	if !strings.Contains(out, "severity") {
+		t.Errorf("table header missing severity column: %q", out)
+	}
+	if !strings.Contains(out, SeverityActionable) {
+		t.Errorf("table missing actionable severity: %q", out)
 	}
 }

--- a/internal/gsc/searchapi.go
+++ b/internal/gsc/searchapi.go
@@ -13,5 +13,19 @@ type SearchAPI interface {
 	QuerySearchAnalytics(query *SearchAnalyticsQuery) (*SearchAnalyticsReport, error)
 }
 
-// Compile-time guarantee that *Client satisfies SearchAPI.
-var _ SearchAPI = (*Client)(nil)
+// InspectAPI is the consumer interface for URL Inspection. Diagnostic
+// commands that need per-URL coverage data (e.g. cannibalisation severity
+// tiering, hreflang validation, schema audits) depend on this seam in
+// addition to SearchAPI. Each call charges one inspection against the daily
+// quota; callers are expected to deduplicate URLs they care about before
+// invoking InspectURL.
+type InspectAPI interface {
+	InspectURL(siteURL, inspectURL string) (*URLInspectionResult, error)
+}
+
+// Compile-time guarantee that *Client satisfies both diagnostic-side
+// interfaces.
+var (
+	_ SearchAPI  = (*Client)(nil)
+	_ InspectAPI = (*Client)(nil)
+)

--- a/mcp/src/tools/gsc-cannibalization.test.ts
+++ b/mcp/src/tools/gsc-cannibalization.test.ts
@@ -8,14 +8,25 @@ import {
 } from './gsc-cannibalization.js'
 
 describe('gscCannibalizationInputSchema', () => {
-  it('accepts a config path with default min_impressions', () => {
+  it('accepts a config path with default min_impressions, days, and with_coverage_state', () => {
     const parsed = gscCannibalizationInputSchema.safeParse({
       config: 'configs/mysite.yaml',
     })
     expect(parsed.success).toBe(true)
     if (parsed.success) {
       expect(parsed.data.min_impressions).toBe(10)
+      expect(parsed.data.days).toBe(28)
+      expect(parsed.data.with_coverage_state).toBe(false)
     }
+  })
+
+  it('rejects days below 1 or above 485', () => {
+    expect(
+      gscCannibalizationInputSchema.safeParse({ config: 'x', days: 0 }).success,
+    ).toBe(false)
+    expect(
+      gscCannibalizationInputSchema.safeParse({ config: 'x', days: 486 }).success,
+    ).toBe(false)
   })
 
   it('accepts a custom min_impressions', () => {
@@ -57,10 +68,12 @@ describe('gscCannibalizationInputSchema', () => {
 })
 
 describe('buildCannibalizationArgs', () => {
-  it('always passes config, json format, and min-impressions', () => {
+  it('always passes config, json format, min-impressions, and days', () => {
     const args = buildCannibalizationArgs({
       config: 'configs/mysite.yaml',
       min_impressions: 10,
+      days: 28,
+      with_coverage_state: false,
     } as GscCannibalizationInput)
     expect(args).toEqual([
       'cannibalization',
@@ -70,6 +83,8 @@ describe('buildCannibalizationArgs', () => {
       'json',
       '--min-impressions',
       '10',
+      '--days',
+      '28',
     ])
   })
 
@@ -77,9 +92,40 @@ describe('buildCannibalizationArgs', () => {
     const args = buildCannibalizationArgs({
       config: 'configs/mysite.yaml',
       min_impressions: 25,
+      days: 28,
+      with_coverage_state: false,
     } as GscCannibalizationInput)
     expect(args).toContain('--min-impressions')
     expect(args).toContain('25')
+  })
+
+  it('passes a non-default days verbatim', () => {
+    const args = buildCannibalizationArgs({
+      config: 'configs/mysite.yaml',
+      min_impressions: 10,
+      days: 90,
+      with_coverage_state: false,
+    } as GscCannibalizationInput)
+    expect(args).toContain('--days')
+    expect(args).toContain('90')
+  })
+
+  it('appends --with-coverage-state when true; omits when false', () => {
+    const on = buildCannibalizationArgs({
+      config: 'configs/mysite.yaml',
+      min_impressions: 10,
+      days: 28,
+      with_coverage_state: true,
+    } as GscCannibalizationInput)
+    expect(on).toContain('--with-coverage-state')
+
+    const off = buildCannibalizationArgs({
+      config: 'configs/mysite.yaml',
+      min_impressions: 10,
+      days: 28,
+      with_coverage_state: false,
+    } as GscCannibalizationInput)
+    expect(off).not.toContain('--with-coverage-state')
   })
 })
 

--- a/mcp/src/tools/gsc-cannibalization.ts
+++ b/mcp/src/tools/gsc-cannibalization.ts
@@ -18,6 +18,21 @@ export const gscCannibalizationInputSchema = z.object({
     .describe(
       'Per-page impression threshold for the cannibalisation predicate (default: 10, matching CONTEXT.md)',
     ),
+  days: z
+    .number()
+    .int()
+    .min(1)
+    .max(485)
+    .optional()
+    .default(28)
+    .describe('Lookback window in days (default: 28, max: 485 — GSC retains ~16 months)'),
+  with_coverage_state: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true, inspect each unique candidate page via URL Inspection and emit a severity tier (actionable | consolidating) per result. Costs one inspection request per unique page; off by default because URL Inspection has a 2000/day budget.',
+    ),
 })
 
 export type GscCannibalizationInput = z.infer<typeof gscCannibalizationInputSchema>
@@ -29,13 +44,25 @@ export type GscCannibalizationInput = z.infer<typeof gscCannibalizationInputSche
 export interface CannibalizationPage {
   page: string
   impressions: number
+  /** Populated only when with_coverage_state is true. */
+  coverage_state?: string
 }
 
 export interface CannibalizationResultRow {
   query: string
   pages: CannibalizationPage[]
   total_impressions: number
+  /**
+   * The page with the highest impressions on this query — a heuristic,
+   * NOT Google's chosen canonical. For migrating sites GSC may still
+   * attribute impressions to the legacy URL inside its 28-day window, so
+   * the impression leader can be the page you intend to redirect AWAY
+   * from. Use with_coverage_state to surface the underlying coverage_state
+   * and let the severity tier guide you.
+   */
   canonical_candidate: string
+  /** Populated only when with_coverage_state is true. */
+  severity?: 'actionable' | 'consolidating'
 }
 
 export interface CannibalizationOutput {
@@ -51,7 +78,7 @@ export interface CannibalizationOutput {
 // ============================================================================
 
 export function buildCannibalizationArgs(input: GscCannibalizationInput): string[] {
-  return [
+  const args = [
     'cannibalization',
     '--config',
     input.config,
@@ -59,7 +86,13 @@ export function buildCannibalizationArgs(input: GscCannibalizationInput): string
     'json',
     '--min-impressions',
     String(input.min_impressions),
+    '--days',
+    String(input.days),
   ]
+  if (input.with_coverage_state) {
+    args.push('--with-coverage-state')
+  }
+  return args
 }
 
 // parseCannibalizationOutput parses the CLI's JSON envelope. The framework
@@ -89,7 +122,7 @@ export function parseCannibalizationOutput(stdout: string): CannibalizationOutpu
 export const gscCannibalizationTool = {
   name: 'gsc_cannibalization',
   description:
-    'Detect Google Search Console queries where two or more pages on the same site each receive at least the configured impression threshold, splitting authority. Returns queries ranked by total impressions across cannibalising pages and the canonical-page candidate (highest impressions). Stateless: one Search Analytics API call per run.',
+    'Detect Google Search Console queries where two or more pages on the same site each receive at least the configured impression threshold, splitting authority. Returns queries ranked by total impressions across cannibalising pages and the canonical-page candidate. The canonical_candidate is a heuristic — the page with the highest current impressions on the query, NOT Google\'s chosen canonical — so for migrating sites it may point at a legacy URL still inside the GSC 28-day attribution window. Pass with_coverage_state to additionally inspect each unique candidate page via URL Inspection and surface a severity tier (actionable | consolidating) that distinguishes in-flight consolidations from real cannibalisation. Stateless: one Search Analytics call plus optional URL Inspection calls per unique candidate page.',
   inputSchema: {
     type: 'object',
     required: ['config'],
@@ -104,6 +137,20 @@ export const gscCannibalizationTool = {
           'Per-page impression threshold for the cannibalisation predicate. Default: 10.',
         default: 10,
         minimum: 1,
+      },
+      days: {
+        type: 'number',
+        description:
+          'Lookback window in days. Default: 28. Maximum: 485 (GSC retains roughly 16 months of search-analytics data).',
+        default: 28,
+        minimum: 1,
+        maximum: 485,
+      },
+      with_coverage_state: {
+        type: 'boolean',
+        description:
+          'When true, inspect each unique candidate page via URL Inspection and emit a severity tier per result (actionable | consolidating). Costs one inspection request per unique page; off by default because URL Inspection has a 2000/day budget.',
+        default: false,
       },
     },
   },


### PR DESCRIPTION
Implements the three BO-04 operator-feedback follow-ups (#67, #68, #69) in one PR — all narrowly scoped to \`gsc_cannibalization\` and the shared GSC client interfaces.

## What's in the box

### #67 — \`--with-coverage-state\` flag + severity tier

- New \`gsc.InspectAPI\` interface alongside \`SearchAPI\` (URL Inspection seam, mirrors the adminAPI/fakeAdminAPI pattern).
- When the flag is set: unique candidate pages are deduplicated across all findings, inspected once each, and the result envelope gains:
  - \`coverage_state\` per page
  - \`severity: "actionable" | "consolidating"\` per result
- \`consolidating\` fires when any page in the result is \`Page with redirect\` — the in-flight-migration case from the operator's BO-04 audit.
- Off by default (URL Inspection has a 2000/day budget).
- \`quota_used\` correctly sums search-analytics + inspection calls.
- Text mode adds a \`severity\` column; JSON fields use \`omitempty\` so unset output is byte-identical to today.

### #69 — \`--days\` flag

- Lookback window is now \`--days N\`, default **28** (was hardcoded 30; corrected to match GSC's standard reporting window), range **1..485** matching GSC's ~16-month retention floor.
- MCP tool accepts a matching \`days\` arg with same default + validation.

### #68 — \`canonical_candidate\` heuristic docs

- CLI \`--help\` block explicitly states \"page with most impressions, NOT Google's chosen canonical\".
- MCP tool description carries the same language so AI clients see the caveat upfront.
- \`CONTEXT.md\` \"SEO Diagnostics → Cannibalisation\" gets a new paragraph documenting the heuristic and the two severity tiers, graduating them from implementation detail to vocabulary.

## Tests

- [x] \`go test ./...\` — all green (new test cases: --days validation, --with-coverage-state on/off, dedup across queries, severity computation, table column injection)
- [x] \`go vet ./...\` clean
- [x] \`make lint\` clean (only pre-existing vendored \`node_modules/flatted\` govet warnings)
- [x] MCP \`npm test\` — **1361 green** (was 1358 + 3 new)
- [x] \`npm run build\` clean

## Doesn't touch

- The state store (BO-04 is stateless, still is).
- Any other BO-* command (the InspectAPI seam is reusable but no other consumer added yet).
- The framework conventions (exit codes, format vocabulary, envelope shape) — unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)