### PR TITLE
feat(cannibalization): polish — redirect-aware canonical, --only-actionable, summary footer

### DIFF
--- a/cmd/gsc_cannibalization.go
+++ b/cmd/gsc_cannibalization.go
@@ -47,6 +47,7 @@ var (
 	gscCannibalizationFormat            string
 	gscCannibalizationDays              int
 	gscCannibalizationWithCoverageState bool
+	gscCannibalizationOnlyActionable    bool
 )
 
 var gscCannibalizationCmd = &cobra.Command{
@@ -74,9 +75,19 @@ page via the URL Inspection API. Each result then carries a severity:
 Quota cost: one URL Inspection request per unique candidate page; off
 by default because URL Inspection has a 2000/day budget.
 
+With --with-coverage-state set, canonical_candidate is sharpened: for
+consolidating findings the impression leader among NON-redirect pages
+is returned instead of the raw impression leader (which can itself be
+a redirected page during in-flight migrations).
+
+Pass --only-actionable to drop consolidating findings from the result
+set after coverage-state annotation. Useful for cron wrappers that want
+"silent on all-green" semantics when every finding is an in-flight
+migration. Implies --with-coverage-state.
+
 Exit codes:
-  0  no cannibalising queries detected
-  2  at least one cannibalising query detected
+  0  no actionable cannibalising queries (after --only-actionable filter)
+  2  at least one cannibalising query in the result set
   1  command failed (API error, malformed config, etc.)
 
 Examples:
@@ -84,7 +95,8 @@ Examples:
   ga4 gsc cannibalization --config configs/mysite.yaml --format json
   ga4 gsc cannibalization --config configs/mysite.yaml --min-impressions 25
   ga4 gsc cannibalization --config configs/mysite.yaml --days 90
-  ga4 gsc cannibalization --config configs/mysite.yaml --with-coverage-state`,
+  ga4 gsc cannibalization --config configs/mysite.yaml --with-coverage-state
+  ga4 gsc cannibalization --config configs/mysite.yaml --only-actionable`,
 	RunE: cannibalizationRunE,
 }
 
@@ -96,6 +108,7 @@ func init() {
 	gscCannibalizationCmd.Flags().StringVar(&gscCannibalizationFormat, "format", diagcmd.FormatTable, "Output format: table or json")
 	gscCannibalizationCmd.Flags().IntVar(&gscCannibalizationDays, "days", cannibalizationDaysDefault, "Lookback window in days (1–485)")
 	gscCannibalizationCmd.Flags().BoolVar(&gscCannibalizationWithCoverageState, "with-coverage-state", false, "Inspect each candidate page via URL Inspection and emit a severity tier per finding")
+	gscCannibalizationCmd.Flags().BoolVar(&gscCannibalizationOnlyActionable, "only-actionable", false, "Drop consolidating findings from the result set (implies --with-coverage-state)")
 }
 
 // cannibalizationClient is the union of GSC capabilities this command can
@@ -140,15 +153,16 @@ type CannibalizationOutput = diagcmd.Envelope[CannibalizationResultRow]
 
 func cannibalizationRunE(_ *cobra.Command, _ []string) error {
 	status := runCannibalizationCommand(cannibalizationParams{
-		ConfigPath:         gscCannibalizationConfig,
-		MinImpressions:     gscCannibalizationMinImpressions,
-		Format:             gscCannibalizationFormat,
-		Days:               gscCannibalizationDays,
-		WithCoverageState:  gscCannibalizationWithCoverageState,
-		Factory:            gscClientFactory,
-		Stdout:             os.Stdout,
-		Stderr:             os.Stderr,
-		Now:                time.Now().UTC(),
+		ConfigPath:        gscCannibalizationConfig,
+		MinImpressions:    gscCannibalizationMinImpressions,
+		Format:            gscCannibalizationFormat,
+		Days:              gscCannibalizationDays,
+		WithCoverageState: gscCannibalizationWithCoverageState,
+		OnlyActionable:    gscCannibalizationOnlyActionable,
+		Factory:           gscClientFactory,
+		Stdout:            os.Stdout,
+		Stderr:            os.Stderr,
+		Now:               time.Now().UTC(),
 	})
 	os.Exit(status)
 	return nil
@@ -160,6 +174,7 @@ type cannibalizationParams struct {
 	Format            string
 	Days              int
 	WithCoverageState bool
+	OnlyActionable    bool
 	Factory           func() (cannibalizationClient, func(), error)
 	Stdout            io.Writer
 	Stderr            io.Writer
@@ -173,6 +188,12 @@ func runCannibalizationCommand(p cannibalizationParams) int {
 	if err := validateCannibalizationDays(p.Days); err != nil {
 		return diagcmd.FailWith(p.Stderr, "%v", err)
 	}
+
+	// --only-actionable implies --with-coverage-state because severity is the
+	// field the filter operates on. Auto-enabling avoids a confusing "you set
+	// --only-actionable but never asked for severity, so nothing was dropped".
+	withCoverageState := p.WithCoverageState || p.OnlyActionable
+
 	site, _, err := diagcmd.LoadSite(p.ConfigPath)
 	if err != nil {
 		return diagcmd.FailWith(p.Stderr, "%v", err)
@@ -184,13 +205,20 @@ func runCannibalizationCommand(p cannibalizationParams) int {
 	}
 	defer cleanup()
 
-	env, err := buildCannibalizationEnvelope(client, site, p.MinImpressions, p.Days, p.WithCoverageState, p.Now)
+	env, severityCounts, err := buildCannibalizationEnvelope(client, site, p.MinImpressions, p.Days, withCoverageState, p.OnlyActionable, p.Now)
 	if err != nil {
 		return diagcmd.FailWith(p.Stderr, "%v", err)
 	}
 
-	if err := diagcmd.Render(p.Stdout, env, p.Format, cannibalizationColumnsFor(p.WithCoverageState), cannibalizationTextRowFor(p.WithCoverageState)); err != nil {
+	if err := diagcmd.Render(p.Stdout, env, p.Format, cannibalizationColumnsFor(withCoverageState), cannibalizationTextRowFor(withCoverageState)); err != nil {
 		return diagcmd.FailWith(p.Stderr, "failed to render output: %v", err)
+	}
+
+	// Text-mode summary footer: appended only when coverage-state annotation
+	// happened (otherwise there is no severity to summarise). JSON output is
+	// unchanged — consumers compute their own breakdown from results[].severity.
+	if p.Format == diagcmd.FormatTable && withCoverageState {
+		writeCannibalizationSummary(p.Stdout, len(env.Results), severityCounts, p.OnlyActionable)
 	}
 
 	return diagcmd.ExitCode(nil, len(env.Results) > 0)
@@ -203,7 +231,21 @@ func validateCannibalizationDays(days int) error {
 	return nil
 }
 
-func buildCannibalizationEnvelope(client cannibalizationClient, site string, minImpressions int64, days int, withCoverageState bool, now time.Time) (CannibalizationOutput, error) {
+// cannibalizationSeverityCounts captures the breakdown computed during a
+// --with-coverage-state run. The pre-filter values are surfaced to the
+// text-mode summary footer so the Operator can see "10 findings: 0
+// actionable, 10 consolidating; --only-actionable dropped 10" even when
+// the filter empties the result set.
+type cannibalizationSeverityCounts struct {
+	Actionable    int
+	Consolidating int
+	HadFilter     bool
+	DroppedByOnly int
+}
+
+func buildCannibalizationEnvelope(client cannibalizationClient, site string, minImpressions int64, days int, withCoverageState, onlyActionable bool, now time.Time) (CannibalizationOutput, cannibalizationSeverityCounts, error) {
+	var counts cannibalizationSeverityCounts
+
 	startDate, endDate := gsc.BuildDateRange(days)
 	report, err := client.QuerySearchAnalytics(&gsc.SearchAnalyticsQuery{
 		SiteURL:    site,
@@ -214,7 +256,7 @@ func buildCannibalizationEnvelope(client cannibalizationClient, site string, min
 		DataState:  "final",
 	})
 	if err != nil {
-		return CannibalizationOutput{}, fmt.Errorf("search analytics query failed: %w", err)
+		return CannibalizationOutput{}, counts, fmt.Errorf("search analytics query failed: %w", err)
 	}
 
 	diag := diagnostics.Cannibalisation(report.Rows, minImpressions)
@@ -236,12 +278,33 @@ func buildCannibalizationEnvelope(client cannibalizationClient, site string, min
 	if withCoverageState {
 		inspections, err := annotateWithCoverageState(client, site, rows)
 		if err != nil {
-			return CannibalizationOutput{}, fmt.Errorf("coverage-state inspection failed: %w", err)
+			return CannibalizationOutput{}, counts, fmt.Errorf("coverage-state inspection failed: %w", err)
 		}
 		quota = report.QuotaUsed + inspections
+
+		for _, r := range rows {
+			switch r.Severity {
+			case SeverityActionable:
+				counts.Actionable++
+			case SeverityConsolidating:
+				counts.Consolidating++
+			}
+		}
+
+		if onlyActionable {
+			counts.HadFilter = true
+			counts.DroppedByOnly = counts.Consolidating
+			filtered := make([]CannibalizationResultRow, 0, counts.Actionable)
+			for _, r := range rows {
+				if r.Severity == SeverityActionable {
+					filtered = append(filtered, r)
+				}
+			}
+			rows = filtered
+		}
 	}
 
-	return diagcmd.NewEnvelope(cannibalizationCommandName, site, now, rows, quota), nil
+	return diagcmd.NewEnvelope(cannibalizationCommandName, site, now, rows, quota), counts, nil
 }
 
 // annotateWithCoverageState inspects each unique candidate page once and
@@ -282,12 +345,43 @@ func annotateWithCoverageState(client gsc.InspectAPI, site string, rows []Cannib
 		}
 		if hasRedirect {
 			rows[i].Severity = SeverityConsolidating
+			// Replace canonical_candidate with the impression leader among
+			// non-redirect pages. Pages are already sorted impressions
+			// descending by the diagnostics package, so the first
+			// non-redirect entry IS the highest-impression non-redirect
+			// page. Falls back to the original heuristic value when every
+			// page redirects — that case yields no sensible recommendation,
+			// so the impression-leader heuristic is the least-wrong choice.
+			for _, p := range rows[i].Pages {
+				if p.CoverageState != CoverageStatePageWithRedirect {
+					rows[i].CanonicalCandidate = p.Page
+					break
+				}
+			}
 		} else {
 			rows[i].Severity = SeverityActionable
 		}
 	}
 
 	return len(pageList), nil
+}
+
+// writeCannibalizationSummary appends a one-line summary footer to text-mode
+// output, so cron tails read "→ 10 findings: 0 actionable, 10 consolidating"
+// without needing to scan the severity column.
+func writeCannibalizationSummary(w io.Writer, shownCount int, counts cannibalizationSeverityCounts, onlyActionable bool) {
+	switch {
+	case counts.HadFilter && counts.Actionable == 0:
+		fmt.Fprintf(w, "→ 0 actionable findings (filtered out %d consolidating). No action required.\n", counts.DroppedByOnly)
+	case onlyActionable:
+		fmt.Fprintf(w, "→ %d actionable findings (filtered out %d consolidating).\n", shownCount, counts.DroppedByOnly)
+	case counts.Actionable == 0 && counts.Consolidating > 0:
+		fmt.Fprintf(w, "→ %d findings: 0 actionable, %d consolidating. No action required.\n",
+			shownCount, counts.Consolidating)
+	default:
+		fmt.Fprintf(w, "→ %d findings: %d actionable, %d consolidating.\n",
+			shownCount, counts.Actionable, counts.Consolidating)
+	}
 }
 
 func cannibalizationColumnsFor(withCoverageState bool) []string {

--- a/cmd/gsc_cannibalization_test.go
+++ b/cmd/gsc_cannibalization_test.go
@@ -358,3 +358,200 @@ func TestRunCannibalizationCommand_WithCoverageStateAddsTableColumn(t *testing.T
 		t.Errorf("table missing actionable severity: %q", out)
 	}
 }
+
+// Regression test for the operator's BO-04 finding: when a consolidating
+// result's impression leader IS the redirected page, canonical_candidate
+// must be replaced with the impression leader among NON-redirect pages so
+// the Operator never sees "canonicalise to this redirect target" advice.
+func TestRunCannibalizationCommand_WithCoverageStateRedirectAwareCanonical(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			// Legacy URL has MORE impressions than the canonical target.
+			cannibalisationRow("uk-query", "https://example.com/legacy", 27),
+			cannibalisationRow("uk-query", "https://example.com/canonical", 13),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/legacy":    "Page with redirect",
+			"https://example.com/canonical": "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatJSON)
+	params.WithCoverageState = true
+
+	runCannibalizationCommand(params)
+
+	var got CannibalizationOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got.Results))
+	}
+	if got.Results[0].Severity != SeverityConsolidating {
+		t.Fatalf("severity = %q, want consolidating", got.Results[0].Severity)
+	}
+	if got.Results[0].CanonicalCandidate != "https://example.com/canonical" {
+		t.Errorf("canonical_candidate = %q, want %q (impression-leader among non-redirect pages)",
+			got.Results[0].CanonicalCandidate, "https://example.com/canonical")
+	}
+}
+
+func TestRunCannibalizationCommand_OnlyActionableFiltersConsolidating(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			// Consolidating finding (one side redirects).
+			cannibalisationRow("legacy-query", "https://example.com/legacy", 50),
+			cannibalisationRow("legacy-query", "https://example.com/new", 30),
+			// Actionable finding (both sides indexed).
+			cannibalisationRow("hot-query", "https://example.com/a", 40),
+			cannibalisationRow("hot-query", "https://example.com/b", 35),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/legacy": "Page with redirect",
+			"https://example.com/new":    "Submitted and indexed",
+			"https://example.com/a":      "Submitted and indexed",
+			"https://example.com/b":      "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatJSON)
+	params.OnlyActionable = true
+
+	status := runCannibalizationCommand(params)
+
+	var got CannibalizationOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1 (the actionable one)", len(got.Results))
+	}
+	if got.Results[0].Query != "hot-query" {
+		t.Errorf("kept the wrong finding: %q", got.Results[0].Query)
+	}
+	if got.Results[0].Severity != SeverityActionable {
+		t.Errorf("severity = %q, want actionable", got.Results[0].Severity)
+	}
+	if status != diagcmd.ExitIssues {
+		t.Errorf("status = %d, want %d (still issues — one actionable left)", status, diagcmd.ExitIssues)
+	}
+}
+
+func TestRunCannibalizationCommand_OnlyActionableExitsCleanWhenAllConsolidating(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("q", "https://example.com/legacy", 50),
+			cannibalisationRow("q", "https://example.com/new", 30),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/legacy": "Page with redirect",
+			"https://example.com/new":    "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatJSON)
+	params.OnlyActionable = true
+
+	status := runCannibalizationCommand(params)
+
+	if status != diagcmd.ExitClean {
+		t.Errorf("status = %d, want %d (everything filtered out → exit clean for cron-friendliness)",
+			status, diagcmd.ExitClean)
+	}
+
+	var got CannibalizationOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(got.Results) != 0 {
+		t.Errorf("results should be empty after --only-actionable filter, got %d", len(got.Results))
+	}
+}
+
+func TestRunCannibalizationCommand_OnlyActionableImpliesWithCoverageState(t *testing.T) {
+	// No coverageByPage map needed — setting --only-actionable alone should
+	// still cause Inspect calls because the flag implies --with-coverage-state.
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("q", "https://example.com/a", 50),
+			cannibalisationRow("q", "https://example.com/b", 30),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/a": "Submitted and indexed",
+			"https://example.com/b": "Submitted and indexed",
+		},
+	}
+	params, _, _ := newParams(t, fake, diagcmd.FormatJSON)
+	params.OnlyActionable = true
+	// Intentionally leaving params.WithCoverageState = false.
+
+	runCannibalizationCommand(params)
+
+	if fake.inspectCalls == 0 {
+		t.Error("expected --only-actionable to imply --with-coverage-state (Inspect should fire)")
+	}
+}
+
+func TestRunCannibalizationCommand_TextSummaryFooter(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("q1", "https://example.com/legacy", 50),
+			cannibalisationRow("q1", "https://example.com/new", 30),
+			cannibalisationRow("q2", "https://example.com/a", 40),
+			cannibalisationRow("q2", "https://example.com/b", 35),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/legacy": "Page with redirect",
+			"https://example.com/new":    "Submitted and indexed",
+			"https://example.com/a":      "Submitted and indexed",
+			"https://example.com/b":      "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatTable)
+	params.WithCoverageState = true
+
+	runCannibalizationCommand(params)
+	out := stdout.String()
+
+	if !strings.Contains(out, "→ 2 findings: 1 actionable, 1 consolidating.") {
+		t.Errorf("summary footer missing or wrong:\n%s", out)
+	}
+}
+
+func TestRunCannibalizationCommand_TextSummaryFooterNoActionRequired(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("q", "https://example.com/legacy", 50),
+			cannibalisationRow("q", "https://example.com/new", 30),
+		},
+		coverageByPage: map[string]string{
+			"https://example.com/legacy": "Page with redirect",
+			"https://example.com/new":    "Submitted and indexed",
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatTable)
+	params.WithCoverageState = true
+
+	runCannibalizationCommand(params)
+	out := stdout.String()
+
+	if !strings.Contains(out, "No action required") {
+		t.Errorf("expected 'No action required' phrasing when all consolidating:\n%s", out)
+	}
+}
+
+func TestRunCannibalizationCommand_TextSummaryFooterOmittedWithoutCoverageState(t *testing.T) {
+	fake := &fakeCannibalizationClient{
+		rows: []gsc.SearchAnalyticsRow{
+			cannibalisationRow("q", "https://example.com/a", 50),
+			cannibalisationRow("q", "https://example.com/b", 30),
+		},
+	}
+	params, stdout, _ := newParams(t, fake, diagcmd.FormatTable)
+	// withCoverageState off — no severity, no summary footer.
+
+	runCannibalizationCommand(params)
+	out := stdout.String()
+
+	if strings.Contains(out, "→") || strings.Contains(out, "actionable") {
+		t.Errorf("summary footer should not appear without --with-coverage-state:\n%s", out)
+	}
+}

--- a/mcp/src/tools/gsc-cannibalization.test.ts
+++ b/mcp/src/tools/gsc-cannibalization.test.ts
@@ -8,7 +8,7 @@ import {
 } from './gsc-cannibalization.js'
 
 describe('gscCannibalizationInputSchema', () => {
-  it('accepts a config path with default min_impressions, days, and with_coverage_state', () => {
+  it('accepts a config path with default min_impressions, days, with_coverage_state, and only_actionable', () => {
     const parsed = gscCannibalizationInputSchema.safeParse({
       config: 'configs/mysite.yaml',
     })
@@ -17,6 +17,7 @@ describe('gscCannibalizationInputSchema', () => {
       expect(parsed.data.min_impressions).toBe(10)
       expect(parsed.data.days).toBe(28)
       expect(parsed.data.with_coverage_state).toBe(false)
+      expect(parsed.data.only_actionable).toBe(false)
     }
   })
 
@@ -74,6 +75,7 @@ describe('buildCannibalizationArgs', () => {
       min_impressions: 10,
       days: 28,
       with_coverage_state: false,
+      only_actionable: false,
     } as GscCannibalizationInput)
     expect(args).toEqual([
       'cannibalization',
@@ -94,6 +96,7 @@ describe('buildCannibalizationArgs', () => {
       min_impressions: 25,
       days: 28,
       with_coverage_state: false,
+      only_actionable: false,
     } as GscCannibalizationInput)
     expect(args).toContain('--min-impressions')
     expect(args).toContain('25')
@@ -105,6 +108,7 @@ describe('buildCannibalizationArgs', () => {
       min_impressions: 10,
       days: 90,
       with_coverage_state: false,
+      only_actionable: false,
     } as GscCannibalizationInput)
     expect(args).toContain('--days')
     expect(args).toContain('90')
@@ -116,6 +120,7 @@ describe('buildCannibalizationArgs', () => {
       min_impressions: 10,
       days: 28,
       with_coverage_state: true,
+      only_actionable: false,
     } as GscCannibalizationInput)
     expect(on).toContain('--with-coverage-state')
 
@@ -124,8 +129,29 @@ describe('buildCannibalizationArgs', () => {
       min_impressions: 10,
       days: 28,
       with_coverage_state: false,
+      only_actionable: false,
     } as GscCannibalizationInput)
     expect(off).not.toContain('--with-coverage-state')
+  })
+
+  it('appends --only-actionable when true; omits when false', () => {
+    const on = buildCannibalizationArgs({
+      config: 'configs/mysite.yaml',
+      min_impressions: 10,
+      days: 28,
+      with_coverage_state: false,
+      only_actionable: true,
+    } as GscCannibalizationInput)
+    expect(on).toContain('--only-actionable')
+
+    const off = buildCannibalizationArgs({
+      config: 'configs/mysite.yaml',
+      min_impressions: 10,
+      days: 28,
+      with_coverage_state: false,
+      only_actionable: false,
+    } as GscCannibalizationInput)
+    expect(off).not.toContain('--only-actionable')
   })
 })
 

--- a/mcp/src/tools/gsc-cannibalization.ts
+++ b/mcp/src/tools/gsc-cannibalization.ts
@@ -33,6 +33,13 @@ export const gscCannibalizationInputSchema = z.object({
     .describe(
       'When true, inspect each unique candidate page via URL Inspection and emit a severity tier (actionable | consolidating) per result. Costs one inspection request per unique page; off by default because URL Inspection has a 2000/day budget.',
     ),
+  only_actionable: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe(
+      'When true, drop consolidating findings from the result set. Implies with_coverage_state. Useful for cron wrappers that want "silent on all-green" semantics when every finding is an in-flight migration.',
+    ),
 })
 
 export type GscCannibalizationInput = z.infer<typeof gscCannibalizationInputSchema>
@@ -92,6 +99,9 @@ export function buildCannibalizationArgs(input: GscCannibalizationInput): string
   if (input.with_coverage_state) {
     args.push('--with-coverage-state')
   }
+  if (input.only_actionable) {
+    args.push('--only-actionable')
+  }
   return args
 }
 
@@ -150,6 +160,12 @@ export const gscCannibalizationTool = {
         type: 'boolean',
         description:
           'When true, inspect each unique candidate page via URL Inspection and emit a severity tier per result (actionable | consolidating). Costs one inspection request per unique page; off by default because URL Inspection has a 2000/day budget.',
+        default: false,
+      },
+      only_actionable: {
+        type: 'boolean',
+        description:
+          'When true, drop consolidating findings from the result set. Implies with_coverage_state.',
         default: false,
       },
     },


### PR DESCRIPTION
Three polish items from a live end-to-end re-test against sc-domain:wealthsim.app.

## 1. canonical_candidate respects coverage_state

When \`--with-coverage-state\` is set and a finding is consolidating, \`canonical_candidate\` becomes the impression leader among **non-redirect** pages. Replaces the impression-leader-overall heuristic silently. Live wealthsim run confirmed the fix: 2 UK queries that previously pointed at the redirect target now correctly point at the consolidation destination.

Falls back to the original heuristic when every page in a result redirects (structurally impossible today but documented).

## 2. \`--only-actionable\` filter

Drops consolidating findings post-annotation. Exit code follows the filtered count — \`0\` when everything's an in-flight migration, matching the framework's silent-on-all-green convention. Implies \`--with-coverage-state\`.

Live verification:
\`\`\`
$ ga4 gsc cannibalization --config configs/site.yaml --only-actionable
quota used: 3
→ 0 actionable findings (filtered out 10 consolidating). No action required.
$ echo \$?
0
\`\`\`

## 3. Text-mode summary footer

One-line summary appended after the table when coverage-state annotation has happened. Variants:
- \`→ N findings: A actionable, C consolidating.\` (mixed)
- \`→ N findings: 0 actionable, N consolidating. No action required.\` (all consolidating)
- \`→ N actionable findings (filtered out C consolidating).\` (under --only-actionable)
- \`→ 0 actionable findings (filtered out C consolidating). No action required.\` (empty after filter)

JSON output unchanged — consumers compute breakdowns from \`results[].severity\` themselves.

## Tests

- [x] Go suite green
- [x] MCP \`npm test\`: 1362 tests (+1 new)
- [x] \`go vet\` clean, \`make lint\` clean
- [x] Live re-test against sc-domain:wealthsim.app verifying all three behaviours

🤖 Generated with [Claude Code](https://claude.com/claude-code)