### PR TITLE
feat(gsc): BO-01 Keyword Opportunity Finder

### DIFF
--- a/cmd/gsc_opportunities.go
+++ b/cmd/gsc_opportunities.go
@@ -1,0 +1,248 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/garbarok/ga4-manager/internal/gsc"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagcmd"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagnostics"
+)
+
+const (
+	opportunitiesDaysDefault = 28
+	opportunitiesDaysMin     = 1
+	opportunitiesDaysMax     = 485
+	opportunitiesRowLimit    = 5000
+	opportunitiesCommandName = "gsc_opportunities"
+)
+
+var (
+	gscOpportunitiesConfig            string
+	gscOpportunitiesFormat            string
+	gscOpportunitiesDays              int
+	gscOpportunitiesMinImpressions    int64
+	gscOpportunitiesMinPotentialClick int64
+)
+
+var gscOpportunitiesCmd = &cobra.Command{
+	Use:   "opportunities",
+	Short: "Detect under-converting queries on page 1–2 of Search Console",
+	Long: `Find Search Console queries where the page already ranks on page 1–2
+(positions 5–20) but the click-through rate is below the median for its
+position bucket. These are titles/meta descriptions that just need to be
+re-written: the rankings already exist, only the snippet is failing to
+convert.
+
+Results are ranked by PotentialClicks descending — the absolute number of
+extra monthly clicks the page would receive if it converted at the median
+CTR for its rank — so an Operator (or LLM consumer) acts on the biggest
+revenue win first.
+
+Each result carries everything a title-rewrite agent needs:
+  query, page, position, clicks, impressions, ctr, bucket,
+  category_median_ctr, ctr_gap, potential_clicks
+The current page title/meta are NOT in GSC data — fetch them from the
+site itself if you want to feed them to an LLM for rewriting.
+
+Filter knobs:
+  --min-impressions N      ignore queries below this monthly impression
+                           threshold (default 20 — low-impression queries
+                           are noise)
+  --min-potential-clicks N ignore opportunities below this projected
+                           click gain (default 0 — show everything)
+
+Stateless: one Search Analytics API call per run. No state files written.
+
+Exit codes:
+  0  no opportunities detected
+  2  at least one opportunity detected
+  1  command failed (API error, malformed config, etc.)
+
+Examples:
+  ga4 gsc opportunities --config configs/mysite.yaml
+  ga4 gsc opportunities --config configs/mysite.yaml --format json
+  ga4 gsc opportunities --config configs/mysite.yaml --min-impressions 50
+  ga4 gsc opportunities --config configs/mysite.yaml --min-potential-clicks 10`,
+	RunE: opportunitiesRunE,
+}
+
+func init() {
+	gscCmd.AddCommand(gscOpportunitiesCmd)
+	gscOpportunitiesCmd.Flags().StringVarP(&gscOpportunitiesConfig, "config", "c", "", "Path to configuration file (required)")
+	gscOpportunitiesCmd.Flags().StringVar(&gscOpportunitiesFormat, "format", diagcmd.FormatTable, "Output format: table or json")
+	gscOpportunitiesCmd.Flags().IntVar(&gscOpportunitiesDays, "days", opportunitiesDaysDefault, "Lookback window in days (1–485)")
+	gscOpportunitiesCmd.Flags().Int64Var(&gscOpportunitiesMinImpressions, "min-impressions", 5, "Minimum impressions for a query to be considered (drops noise; default 5 — small sites need a low floor)")
+	gscOpportunitiesCmd.Flags().Int64Var(&gscOpportunitiesMinPotentialClick, "min-potential-clicks", 0, "Drop opportunities below this projected click gain")
+}
+
+// gscOpportunitiesClientFactory returns a live GSC client. Tests substitute.
+var gscOpportunitiesClientFactory = func() (gsc.SearchAPI, func(), error) {
+	client, err := gsc.NewClient()
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return client, func() { _ = client.Close() }, nil
+}
+
+// OpportunityResultRow is one row of the gsc_opportunities JSON results.
+type OpportunityResultRow struct {
+	Query             string  `json:"query"`
+	Page              string  `json:"page"`
+	Position          float64 `json:"position"`
+	Clicks            int64   `json:"clicks"`
+	Impressions       int64   `json:"impressions"`
+	CTR               float64 `json:"ctr"`
+	Bucket            int     `json:"bucket"`
+	CategoryMedianCTR float64 `json:"category_median_ctr"`
+	// MedianSource is "site" when ≥2 same-site rows in the bucket produced
+	// the median, "baseline" when the published industry curve was used as
+	// fallback. Small sites mostly see "baseline" — that's expected.
+	MedianSource    string  `json:"median_source"`
+	CTRGap          float64 `json:"ctr_gap"`
+	PotentialClicks int64   `json:"potential_clicks"`
+}
+
+// OpportunitiesOutput is the JSON envelope under --format json.
+type OpportunitiesOutput = diagcmd.Envelope[OpportunityResultRow]
+
+func opportunitiesRunE(_ *cobra.Command, _ []string) error {
+	status := runOpportunitiesCommand(opportunitiesParams{
+		ConfigPath:         gscOpportunitiesConfig,
+		Format:             gscOpportunitiesFormat,
+		Days:               gscOpportunitiesDays,
+		MinImpressions:     gscOpportunitiesMinImpressions,
+		MinPotentialClicks: gscOpportunitiesMinPotentialClick,
+		Factory:            gscOpportunitiesClientFactory,
+		Stdout:             os.Stdout,
+		Stderr:             os.Stderr,
+		Now:                time.Now().UTC(),
+	})
+	os.Exit(status)
+	return nil
+}
+
+type opportunitiesParams struct {
+	ConfigPath         string
+	Format             string
+	Days               int
+	MinImpressions     int64
+	MinPotentialClicks int64
+	Factory            func() (gsc.SearchAPI, func(), error)
+	Stdout             io.Writer
+	Stderr             io.Writer
+	Now                time.Time
+}
+
+func runOpportunitiesCommand(p opportunitiesParams) int {
+	if err := diagcmd.ValidateFormat(p.Format); err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+	if err := validateOpportunitiesDays(p.Days); err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+
+	site, _, err := diagcmd.LoadSite(p.ConfigPath)
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+
+	client, cleanup, err := p.Factory()
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "failed to create GSC client: %v", err)
+	}
+	defer cleanup()
+
+	env, err := buildOpportunitiesEnvelope(client, site, p.Days, p.MinImpressions, p.MinPotentialClicks, p.Now)
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+
+	if err := diagcmd.Render(p.Stdout, env, p.Format, opportunitiesColumns, opportunitiesTextRow); err != nil {
+		return diagcmd.FailWith(p.Stderr, "failed to render output: %v", err)
+	}
+
+	return diagcmd.ExitCode(nil, len(env.Results) > 0)
+}
+
+func validateOpportunitiesDays(days int) error {
+	if days < opportunitiesDaysMin || days > opportunitiesDaysMax {
+		return fmt.Errorf("invalid --days %d: must be in [%d, %d]", days, opportunitiesDaysMin, opportunitiesDaysMax)
+	}
+	return nil
+}
+
+func buildOpportunitiesEnvelope(client gsc.SearchAPI, site string, days int, minImpressions, minPotentialClicks int64, now time.Time) (OpportunitiesOutput, error) {
+	startDate, endDate := gsc.BuildDateRange(days)
+	report, err := client.QuerySearchAnalytics(&gsc.SearchAnalyticsQuery{
+		SiteURL:    site,
+		StartDate:  startDate,
+		EndDate:    endDate,
+		Dimensions: []string{"query", "page"},
+		RowLimit:   opportunitiesRowLimit,
+		DataState:  "final",
+	})
+	if err != nil {
+		return OpportunitiesOutput{}, fmt.Errorf("search analytics query failed: %w", err)
+	}
+
+	// Drop rows below the impression noise threshold BEFORE running the
+	// predicate, so the position-bucket medians are not dragged down by
+	// long-tail single-impression queries.
+	filtered := make([]gsc.SearchAnalyticsRow, 0, len(report.Rows))
+	for _, r := range report.Rows {
+		if r.Impressions >= minImpressions {
+			filtered = append(filtered, r)
+		}
+	}
+
+	diag := diagnostics.Opportunity(filtered)
+	rows := make([]OpportunityResultRow, 0, len(diag))
+	for _, r := range diag {
+		if r.PotentialClicks < minPotentialClicks {
+			continue
+		}
+		rows = append(rows, OpportunityResultRow{
+			Query:             r.Query,
+			Page:              r.Page,
+			Position:          r.Position,
+			Clicks:            r.Clicks,
+			Impressions:       r.Impressions,
+			CTR:               r.CTR,
+			Bucket:            r.Bucket,
+			CategoryMedianCTR: r.CategoryMedianCTR,
+			MedianSource:      r.MedianSource,
+			CTRGap:            r.CTRGap,
+			PotentialClicks:   r.PotentialClicks,
+		})
+	}
+
+	return diagcmd.NewEnvelope(opportunitiesCommandName, site, now, rows, report.QuotaUsed), nil
+}
+
+var opportunitiesColumns = []string{
+	"query", "page", "pos", "impr", "ctr", "median_ctr", "src", "gap", "potential_clicks",
+}
+
+func opportunitiesTextRow(r OpportunityResultRow) []string {
+	return []string{
+		r.Query,
+		r.Page,
+		strconv.FormatFloat(r.Position, 'f', 1, 64),
+		strconv.FormatInt(r.Impressions, 10),
+		formatCTRPercent(r.CTR),
+		formatCTRPercent(r.CategoryMedianCTR),
+		r.MedianSource,
+		formatCTRPercent(r.CTRGap),
+		strconv.FormatInt(r.PotentialClicks, 10),
+	}
+}
+
+func formatCTRPercent(v float64) string {
+	return strconv.FormatFloat(v*100, 'f', 2, 64) + "%"
+}

--- a/cmd/gsc_opportunities_test.go
+++ b/cmd/gsc_opportunities_test.go
@@ -1,0 +1,265 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/garbarok/ga4-manager/internal/gsc"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagcmd"
+)
+
+// fakeOpportunitiesClient implements gsc.SearchAPI for the opportunities
+// command's unit tests.
+type fakeOpportunitiesClient struct {
+	rows  []gsc.SearchAnalyticsRow
+	err   error
+	calls int
+}
+
+func (f *fakeOpportunitiesClient) QuerySearchAnalytics(_ *gsc.SearchAnalyticsQuery) (*gsc.SearchAnalyticsReport, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &gsc.SearchAnalyticsReport{
+		Rows:      f.rows,
+		TotalRows: len(f.rows),
+		QuotaUsed: f.calls,
+	}, nil
+}
+
+func opportunityRow(query, page string, clicks, impressions int64, ctr, position float64) gsc.SearchAnalyticsRow {
+	return gsc.SearchAnalyticsRow{
+		Keys:        []string{query, page},
+		Clicks:      clicks,
+		Impressions: impressions,
+		CTR:         ctr,
+		Position:    position,
+	}
+}
+
+func newOpportunitiesParams(t *testing.T, fake *fakeOpportunitiesClient, format string) (opportunitiesParams, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	return opportunitiesParams{
+		ConfigPath:     writeConfig(t, "sc-domain:example.com"),
+		Format:         format,
+		Days:           opportunitiesDaysDefault,
+		MinImpressions: 20,
+		Factory:        func() (gsc.SearchAPI, func(), error) { return fake, func() {}, nil },
+		Stdout:         stdout,
+		Stderr:         stderr,
+		Now:            time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC),
+	}, stdout, stderr
+}
+
+func TestRunOpportunitiesCommand_CleanExitWhenNoUnderConverters(t *testing.T) {
+	// Every page in the same bucket has the same CTR → no opportunities
+	// because the predicate uses strict less-than against the median.
+	fake := &fakeOpportunitiesClient{rows: []gsc.SearchAnalyticsRow{
+		opportunityRow("q1", "https://example.com/a", 5, 100, 0.05, 7.0),
+		opportunityRow("q2", "https://example.com/b", 5, 100, 0.05, 7.0),
+		opportunityRow("q3", "https://example.com/c", 5, 100, 0.05, 7.0),
+	}}
+	params, stdout, _ := newOpportunitiesParams(t, fake, diagcmd.FormatTable)
+	if status := runOpportunitiesCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitClean)
+	}
+	if got := stdout.String(); got != "quota used: 1\n" {
+		t.Errorf("expected only quota footer, got %q", got)
+	}
+}
+
+func TestRunOpportunitiesCommand_RanksByPotentialClicksDesc(t *testing.T) {
+	// Three rows in the same bucket. The high-impression under-performer
+	// should rank first, even if a low-impression row has a bigger CTR
+	// gap in relative terms.
+	fake := &fakeOpportunitiesClient{rows: []gsc.SearchAnalyticsRow{
+		opportunityRow("big-volume", "https://example.com/big", 10, 1000, 0.01, 7.0),
+		opportunityRow("median-page", "https://example.com/median", 100, 1000, 0.10, 7.0),
+		opportunityRow("high-volume-upper", "https://example.com/upper", 200, 1000, 0.20, 7.0),
+		// A small-impressions row with the SAME CTR as big-volume — same
+		// relative gap, but fewer clicks at stake.
+		opportunityRow("small-volume", "https://example.com/small", 1, 50, 0.02, 7.0),
+	}}
+	params, stdout, _ := newOpportunitiesParams(t, fake, diagcmd.FormatJSON)
+	if status := runOpportunitiesCommand(params); status != diagcmd.ExitIssues {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitIssues)
+	}
+
+	var got OpportunitiesOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(got.Results))
+	}
+	if got.Results[0].Query != "big-volume" {
+		t.Errorf("first result query = %q, want big-volume (highest potential_clicks)", got.Results[0].Query)
+	}
+	if got.Results[0].PotentialClicks <= got.Results[1].PotentialClicks {
+		t.Errorf("results not sorted by potential_clicks desc: %d vs %d",
+			got.Results[0].PotentialClicks, got.Results[1].PotentialClicks)
+	}
+}
+
+func TestRunOpportunitiesCommand_DropsBelowMinImpressionsBeforeBucketMedian(t *testing.T) {
+	// One legitimate row + many tiny noise rows in the same bucket. Without
+	// the impression floor the noise rows would drag the bucket median
+	// down. With the floor, only the legitimate row survives — single-row
+	// bucket falls back to the baseline curve, so the row still surfaces
+	// as an opportunity against the baseline (not the noise-polluted site
+	// median).
+	rows := []gsc.SearchAnalyticsRow{
+		opportunityRow("real", "https://example.com/real", 10, 500, 0.02, 8.0),
+	}
+	for i := 0; i < 30; i++ {
+		rows = append(rows, opportunityRow("noise", "https://example.com/noise", 0, 2, 0.0, 8.0))
+	}
+	fake := &fakeOpportunitiesClient{rows: rows}
+	params, stdout, _ := newOpportunitiesParams(t, fake, diagcmd.FormatJSON)
+	params.MinImpressions = 20
+
+	if status := runOpportunitiesCommand(params); status != diagcmd.ExitIssues {
+		t.Fatalf("status = %d, want issues (baseline curve should surface the opportunity)", status)
+	}
+
+	var got OpportunitiesOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1 (single survivor after floor)", len(got.Results))
+	}
+	if got.Results[0].MedianSource != "baseline" {
+		t.Errorf("expected baseline source, got %q (noise rows should not pollute the median)",
+			got.Results[0].MedianSource)
+	}
+}
+
+func TestRunOpportunitiesCommand_MinPotentialClicksFiltersBelowFloor(t *testing.T) {
+	fake := &fakeOpportunitiesClient{rows: []gsc.SearchAnalyticsRow{
+		// Two clear opportunities: one large (200 potential clicks), one tiny.
+		opportunityRow("big", "https://example.com/big", 10, 1000, 0.01, 7.0),
+		opportunityRow("median", "https://example.com/median", 100, 1000, 0.10, 7.0),
+		// A row that produces a small potential — say impressions=25, gap small.
+		opportunityRow("tiny", "https://example.com/tiny", 0, 25, 0.0, 7.0),
+	}}
+	params, stdout, _ := newOpportunitiesParams(t, fake, diagcmd.FormatJSON)
+	params.MinPotentialClicks = 50
+
+	runOpportunitiesCommand(params)
+	var got OpportunitiesOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	for _, r := range got.Results {
+		if r.PotentialClicks < 50 {
+			t.Errorf("result %q has potential_clicks = %d, below floor of 50",
+				r.Query, r.PotentialClicks)
+		}
+	}
+}
+
+func TestRunOpportunitiesCommand_JSONShapeFull(t *testing.T) {
+	fake := &fakeOpportunitiesClient{rows: []gsc.SearchAnalyticsRow{
+		opportunityRow("q1", "https://example.com/a", 10, 1000, 0.01, 7.0),
+		opportunityRow("q2", "https://example.com/b", 100, 1000, 0.10, 7.0),
+	}}
+	params, stdout, _ := newOpportunitiesParams(t, fake, diagcmd.FormatJSON)
+
+	if status := runOpportunitiesCommand(params); status != diagcmd.ExitIssues {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitIssues)
+	}
+
+	var got OpportunitiesOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Command != opportunitiesCommandName {
+		t.Errorf("command = %q, want %q", got.Command, opportunitiesCommandName)
+	}
+	if got.Site != "sc-domain:example.com" {
+		t.Errorf("site = %q", got.Site)
+	}
+	if got.GeneratedAt != "2026-06-05T12:00:00Z" {
+		t.Errorf("generated_at = %q", got.GeneratedAt)
+	}
+	if got.QuotaUsed != 1 {
+		t.Errorf("quota_used = %d, want 1", got.QuotaUsed)
+	}
+	if len(got.Results) == 0 {
+		t.Fatal("expected at least one opportunity")
+	}
+	first := got.Results[0]
+	if first.Query == "" || first.Page == "" {
+		t.Error("query/page empty")
+	}
+	if first.Impressions == 0 || first.Clicks < 0 {
+		t.Errorf("impressions/clicks unexpected: %+v", first)
+	}
+	if first.PotentialClicks <= 0 {
+		t.Errorf("potential_clicks should be positive for qualifying row: %d", first.PotentialClicks)
+	}
+	if first.CTRGap <= 0 {
+		t.Errorf("ctr_gap should be positive: %f", first.CTRGap)
+	}
+	if first.Bucket < 5 || first.Bucket > 20 {
+		t.Errorf("bucket %d outside [5, 20]", first.Bucket)
+	}
+}
+
+func TestRunOpportunitiesCommand_FailureModes(t *testing.T) {
+	t.Run("invalid format", func(t *testing.T) {
+		fake := &fakeOpportunitiesClient{}
+		params, _, stderr := newOpportunitiesParams(t, fake, "xml")
+		if status := runOpportunitiesCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "invalid --format") {
+			t.Errorf("stderr missing format reason: %q", stderr.String())
+		}
+	})
+
+	t.Run("invalid days", func(t *testing.T) {
+		fake := &fakeOpportunitiesClient{}
+		params, _, stderr := newOpportunitiesParams(t, fake, diagcmd.FormatTable)
+		params.Days = 0
+		if status := runOpportunitiesCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "invalid --days") {
+			t.Errorf("stderr missing days reason: %q", stderr.String())
+		}
+	})
+
+	t.Run("api error", func(t *testing.T) {
+		fake := &fakeOpportunitiesClient{err: errors.New("api down")}
+		params, _, stderr := newOpportunitiesParams(t, fake, diagcmd.FormatTable)
+		if status := runOpportunitiesCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "api down") {
+			t.Errorf("stderr missing api error: %q", stderr.String())
+		}
+	})
+
+	t.Run("missing config", func(t *testing.T) {
+		params := opportunitiesParams{
+			Format:  diagcmd.FormatTable,
+			Days:    opportunitiesDaysDefault,
+			Stdout:  &bytes.Buffer{},
+			Stderr:  &bytes.Buffer{},
+			Factory: func() (gsc.SearchAPI, func(), error) { return &fakeOpportunitiesClient{}, func() {}, nil },
+			Now:     time.Now(),
+		}
+		if status := runOpportunitiesCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+	})
+}

--- a/internal/gsc/diagnostics/opportunity.go
+++ b/internal/gsc/diagnostics/opportunity.go
@@ -18,10 +18,60 @@ type OpportunityResult struct {
 	Query             string
 	Page              string
 	Position          float64
+	Clicks            int64
+	Impressions       int64
 	CTR               float64
 	Bucket            int
 	CategoryMedianCTR float64
-	CTRGap            float64
+	// MedianSource reports where CategoryMedianCTR came from: "site" when at
+	// least two same-site rows shared the bucket, or "baseline" when the
+	// industry baseline curve was used as a fallback. Small sites often
+	// have single-row buckets, so the baseline keeps the predicate useful
+	// before the site has enough peers to compute its own medians.
+	MedianSource string
+	// CTRGap is CategoryMedianCTR − CTR — how far below the bucket median the
+	// row sits as a ratio. Always > 0 for a qualifying row.
+	CTRGap float64
+	// PotentialClicks is the additional clicks the page would receive over
+	// the same impression window if it converted at the bucket median CTR
+	// instead of its current CTR. Computed as max(0, round(impressions *
+	// (median - ctr))). This is the headline number for prioritising
+	// optimisation work: "how many monthly clicks are we leaving on the
+	// table for this query".
+	PotentialClicks int64
+}
+
+// Median-source labels surfaced in OpportunityResult.MedianSource.
+const (
+	MedianSourceSite     = "site"
+	MedianSourceBaseline = "baseline"
+)
+
+// baselineCTRByBucket is a published industry-average position-CTR curve,
+// rounded to four decimal places. Used when the site itself has too few
+// rows in a position bucket to compute its own median. The values are the
+// rough centre of multiple public datasets (Advanced Web Ranking,
+// Backlinko, Sistrix 2023-2024 averages) — they are NOT vertical-specific,
+// but they buy a defensible "expected CTR for this position" floor that
+// lets the opportunity predicate work on small sites where peer data is
+// sparse. Operators with enough traffic get the site median instead.
+var baselineCTRByBucket = map[int]float64{
+	5:  0.065,
+	6:  0.054,
+	7:  0.045,
+	8:  0.040,
+	9:  0.035,
+	10: 0.030,
+	11: 0.025,
+	12: 0.020,
+	13: 0.018,
+	14: 0.015,
+	15: 0.013,
+	16: 0.010,
+	17: 0.010,
+	18: 0.010,
+	19: 0.010,
+	20: 0.010,
 }
 
 // Opportunity classifies rows under the opportunity predicate.
@@ -45,8 +95,12 @@ type OpportunityResult struct {
 // is left empty when only a page is present. Rows whose bucket is outside
 // [5, 20] are excluded up front and do not influence other buckets' medians.
 //
-// Results are ordered by CTRGap descending (largest under-performance first),
-// with a deterministic tie-break by Page ascending then Query ascending.
+// Results are ordered by PotentialClicks descending — the absolute number
+// of monthly clicks the page would gain if it converted at the bucket
+// median CTR — with CTRGap descending, Page ascending, and Query ascending
+// as successive tie-breaks. The ordering is deliberate: the Operator
+// (or an LLM consumer) acts on the biggest revenue win first, not on the
+// largest relative gap.
 func Opportunity(rows []gsc.SearchAnalyticsRow) []OpportunityResult {
 	type entry struct {
 		row    gsc.SearchAnalyticsRow
@@ -65,18 +119,31 @@ func Opportunity(rows []gsc.SearchAnalyticsRow) []OpportunityResult {
 		buckets[bucket] = append(buckets[bucket], row.CTR)
 	}
 
-	medians := make(map[int]float64, len(buckets))
+	// Compute per-site bucket medians where we have enough peers, and label
+	// each bucket with the median source. Single-row buckets fall back to
+	// the published baseline curve so the predicate still finds opportunities
+	// on small sites.
+	type bucketMedian struct {
+		ctr    float64
+		source string
+	}
+	medians := make(map[int]bucketMedian, len(buckets))
 	for bucket, ctrs := range buckets {
-		if len(ctrs) < 2 {
+		if len(ctrs) >= 2 {
+			sorted := append([]float64(nil), ctrs...)
+			sort.Float64s(sorted)
+			n := len(sorted)
+			var m float64
+			if n%2 == 1 {
+				m = sorted[n/2]
+			} else {
+				m = (sorted[n/2-1] + sorted[n/2]) / 2.0
+			}
+			medians[bucket] = bucketMedian{ctr: m, source: MedianSourceSite}
 			continue
 		}
-		sorted := append([]float64(nil), ctrs...)
-		sort.Float64s(sorted)
-		n := len(sorted)
-		if n%2 == 1 {
-			medians[bucket] = sorted[n/2]
-		} else {
-			medians[bucket] = (sorted[n/2-1] + sorted[n/2]) / 2.0
+		if baseline, ok := baselineCTRByBucket[bucket]; ok {
+			medians[bucket] = bucketMedian{ctr: baseline, source: MedianSourceBaseline}
 		}
 	}
 
@@ -86,7 +153,7 @@ func Opportunity(rows []gsc.SearchAnalyticsRow) []OpportunityResult {
 		if !ok {
 			continue
 		}
-		if e.row.CTR >= median {
+		if e.row.CTR >= median.ctr {
 			continue
 		}
 
@@ -103,18 +170,35 @@ func Opportunity(rows []gsc.SearchAnalyticsRow) []OpportunityResult {
 			continue
 		}
 
+		ctrGap := median.ctr - e.row.CTR
+		potential := int64(math.Round(float64(e.row.Impressions) * ctrGap))
+		if potential < 0 {
+			potential = 0
+		}
 		results = append(results, OpportunityResult{
 			Query:             query,
 			Page:              page,
 			Position:          e.row.Position,
+			Clicks:            e.row.Clicks,
+			Impressions:       e.row.Impressions,
 			CTR:               e.row.CTR,
 			Bucket:            e.bucket,
-			CategoryMedianCTR: median,
-			CTRGap:            median - e.row.CTR,
+			CategoryMedianCTR: median.ctr,
+			MedianSource:      median.source,
+			CTRGap:            ctrGap,
+			PotentialClicks:   potential,
 		})
 	}
 
+	// Sort by absolute clicks left on the table descending — that is the
+	// metric an Operator can act on directly ("rewriting this title would
+	// recover ~N clicks/month"). CTRGap is the relative measure and is kept
+	// as a secondary tie-break for deterministic ordering at equal
+	// PotentialClicks.
 	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].PotentialClicks != results[j].PotentialClicks {
+			return results[i].PotentialClicks > results[j].PotentialClicks
+		}
 		if results[i].CTRGap != results[j].CTRGap {
 			return results[i].CTRGap > results[j].CTRGap
 		}

--- a/internal/gsc/diagnostics/opportunity_test.go
+++ b/internal/gsc/diagnostics/opportunity_test.go
@@ -59,11 +59,26 @@ func TestOpportunity(t *testing.T) {
 			want: []OpportunityResult{},
 		},
 		{
-			name: "single-row bucket excluded",
+			name: "single-row bucket falls back to baseline curve",
 			rows: []gsc.SearchAnalyticsRow{
 				oppRow("q1", "https://example.com/a", 10.0, 0.01, 1000),
 			},
-			want: []OpportunityResult{},
+			// Bucket 10 has baseline CTR 3% — way above the row's 1% — so
+			// this IS an opportunity, attributed to the baseline source.
+			want: []OpportunityResult{
+				{
+					Query:             "q1",
+					Page:              "https://example.com/a",
+					Position:          10.0,
+					Impressions:       1000,
+					CTR:               0.01,
+					Bucket:            10,
+					CategoryMedianCTR: 0.03,
+					MedianSource:      MedianSourceBaseline,
+					CTRGap:            0.02,
+					PotentialClicks:   20,
+				},
+			},
 		},
 		{
 			name: "all-equal-ctr bucket yields no opportunities",

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -86,6 +86,12 @@ import {
   buildCannibalizationArgs,
   parseCannibalizationOutput,
 } from './tools/gsc-cannibalization.js'
+import {
+  gscOpportunitiesTool,
+  gscOpportunitiesInputSchema,
+  buildOpportunitiesArgs,
+  parseOpportunitiesOutput,
+} from './tools/gsc-opportunities.js'
 
 // gsc_monitor_urls is dual-mode (native URL loop OR CLI), handled below.
 import {
@@ -295,6 +301,13 @@ const SPECS: ToolSpec[] = [
     command: 'gsc',
     buildArgs: buildCannibalizationArgs,
     parse: (out) => parseCannibalizationOutput(out),
+  }),
+  cli({
+    tool: gscOpportunitiesTool,
+    schema: gscOpportunitiesInputSchema,
+    command: 'gsc',
+    buildArgs: buildOpportunitiesArgs,
+    parse: (out) => parseOpportunitiesOutput(out),
   }),
 
   // ── gsc_monitor_urls: dual-mode (native URL loop OR CLI config run) ─────────

--- a/mcp/src/tools/gsc-opportunities.test.ts
+++ b/mcp/src/tools/gsc-opportunities.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  gscOpportunitiesInputSchema,
+  gscOpportunitiesTool,
+  buildOpportunitiesArgs,
+  parseOpportunitiesOutput,
+  GscOpportunitiesInput,
+} from './gsc-opportunities.js'
+
+describe('gscOpportunitiesInputSchema', () => {
+  it('accepts a config path with documented defaults', () => {
+    const parsed = gscOpportunitiesInputSchema.safeParse({ config: 'configs/x.yaml' })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.days).toBe(28)
+      expect(parsed.data.min_impressions).toBe(20)
+      expect(parsed.data.min_potential_clicks).toBe(0)
+    }
+  })
+
+  it('rejects empty config', () => {
+    expect(gscOpportunitiesInputSchema.safeParse({ config: '' }).success).toBe(false)
+  })
+
+  it('rejects days outside [1, 485]', () => {
+    expect(gscOpportunitiesInputSchema.safeParse({ config: 'x', days: 0 }).success).toBe(false)
+    expect(gscOpportunitiesInputSchema.safeParse({ config: 'x', days: 486 }).success).toBe(false)
+  })
+
+  it('rejects min_potential_clicks below 0', () => {
+    expect(
+      gscOpportunitiesInputSchema.safeParse({ config: 'x', min_potential_clicks: -1 }).success,
+    ).toBe(false)
+  })
+})
+
+describe('buildOpportunitiesArgs', () => {
+  it('passes every documented arg verbatim', () => {
+    const args = buildOpportunitiesArgs({
+      config: 'configs/x.yaml',
+      days: 90,
+      min_impressions: 50,
+      min_potential_clicks: 10,
+    } as GscOpportunitiesInput)
+    expect(args).toEqual([
+      'opportunities',
+      '--config',
+      'configs/x.yaml',
+      '--format',
+      'json',
+      '--days',
+      '90',
+      '--min-impressions',
+      '50',
+      '--min-potential-clicks',
+      '10',
+    ])
+  })
+})
+
+describe('parseOpportunitiesOutput', () => {
+  it('parses a valid CLI envelope', () => {
+    const stdout = JSON.stringify({
+      command: 'gsc_opportunities',
+      site: 'sc-domain:example.com',
+      generated_at: '2026-06-05T12:00:00Z',
+      results: [
+        {
+          query: 'wealth calculator',
+          page: 'https://example.com/calculator',
+          position: 8.2,
+          clicks: 5,
+          impressions: 1000,
+          ctr: 0.005,
+          bucket: 8,
+          category_median_ctr: 0.03,
+          ctr_gap: 0.025,
+          potential_clicks: 25,
+        },
+      ],
+      quota_used: 1,
+    })
+    const out = parseOpportunitiesOutput(stdout)
+    expect(out.command).toBe('gsc_opportunities')
+    expect(out.results).toHaveLength(1)
+    expect(out.results[0].potential_clicks).toBe(25)
+  })
+
+  it('throws on wrong command', () => {
+    const stdout = JSON.stringify({
+      command: 'other',
+      site: 's',
+      generated_at: 'g',
+      results: [],
+      quota_used: 0,
+    })
+    expect(() => parseOpportunitiesOutput(stdout)).toThrow(/Unexpected command/)
+  })
+
+  it('throws on garbled stdout', () => {
+    expect(() => parseOpportunitiesOutput('not json')).toThrow()
+  })
+})
+
+describe('gscOpportunitiesTool definition', () => {
+  it('has the registered name', () => {
+    expect(gscOpportunitiesTool.name).toBe('gsc_opportunities')
+  })
+
+  it('marks config as required', () => {
+    expect(gscOpportunitiesTool.inputSchema.required).toContain('config')
+  })
+
+  it('declares all four args', () => {
+    const props = gscOpportunitiesTool.inputSchema.properties as Record<string, unknown>
+    expect(props.config).toBeDefined()
+    expect(props.days).toBeDefined()
+    expect(props.min_impressions).toBeDefined()
+    expect(props.min_potential_clicks).toBeDefined()
+  })
+
+  it('mentions potential_clicks in its description so consumers know the ranking key', () => {
+    expect(gscOpportunitiesTool.description).toMatch(/potential_clicks/)
+  })
+})

--- a/mcp/src/tools/gsc-opportunities.ts
+++ b/mcp/src/tools/gsc-opportunities.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod'
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+export const gscOpportunitiesInputSchema = z.object({
+  config: z
+    .string()
+    .min(1, 'config is required')
+    .describe('Path to the YAML config file with search_console.site_url set'),
+  days: z
+    .number()
+    .int()
+    .min(1)
+    .max(485)
+    .optional()
+    .default(28)
+    .describe('Lookback window in days (default: 28, max: 485 — GSC retains ~16 months)'),
+  min_impressions: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .default(20)
+    .describe(
+      'Minimum impressions for a query to be considered (drops long-tail noise from the bucket median calculation). Default: 20.',
+    ),
+  min_potential_clicks: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .default(0)
+    .describe(
+      'Filter out opportunities below this projected monthly click gain. Default: 0 (no filter).',
+    ),
+})
+
+export type GscOpportunitiesInput = z.infer<typeof gscOpportunitiesInputSchema>
+
+// ============================================================================
+// Output Types — mirror the CLI JSON envelope exactly
+// ============================================================================
+
+export interface OpportunityResultRow {
+  query: string
+  page: string
+  position: number
+  clicks: number
+  impressions: number
+  ctr: number
+  bucket: number
+  category_median_ctr: number
+  ctr_gap: number
+  /**
+   * The headline number for prioritising work: the extra monthly clicks
+   * this page would receive if it converted at the median CTR for its
+   * position bucket. Results are sorted by this descending.
+   */
+  potential_clicks: number
+}
+
+export interface OpportunitiesOutput {
+  command: 'gsc_opportunities'
+  site: string
+  generated_at: string
+  results: OpportunityResultRow[]
+  quota_used: number
+}
+
+// ============================================================================
+// CLI Wiring
+// ============================================================================
+
+export function buildOpportunitiesArgs(input: GscOpportunitiesInput): string[] {
+  return [
+    'opportunities',
+    '--config',
+    input.config,
+    '--format',
+    'json',
+    '--days',
+    String(input.days),
+    '--min-impressions',
+    String(input.min_impressions),
+    '--min-potential-clicks',
+    String(input.min_potential_clicks),
+  ]
+}
+
+export function parseOpportunitiesOutput(stdout: string): OpportunitiesOutput {
+  const parsed = JSON.parse(stdout) as Partial<OpportunitiesOutput>
+  if (parsed.command !== 'gsc_opportunities') {
+    throw new Error(
+      `Unexpected command in CLI output: ${String(parsed.command)} (want gsc_opportunities)`,
+    )
+  }
+  if (typeof parsed.site !== 'string' || typeof parsed.generated_at !== 'string') {
+    throw new Error('CLI output missing site or generated_at')
+  }
+  if (!Array.isArray(parsed.results) || typeof parsed.quota_used !== 'number') {
+    throw new Error('CLI output missing results or quota_used')
+  }
+  return parsed as OpportunitiesOutput
+}
+
+// ============================================================================
+// MCP Tool Definition
+// ============================================================================
+
+export const gscOpportunitiesTool = {
+  name: 'gsc_opportunities',
+  description:
+    'Detect under-converting queries on page 1–2 of Google Search Console. For each query × page where the page already ranks at position 5–20 but the CTR is below the median for its position bucket, the result carries everything an LLM consumer needs to act: query, page, current position, clicks, impressions, ctr, bucket, category_median_ctr, ctr_gap, and potential_clicks (the extra monthly clicks the page would gain at the bucket median CTR). Results are sorted by potential_clicks descending so the biggest revenue wins come first. Stateless: one Search Analytics API call per run. The current page title and meta description are NOT in GSC data — fetch them from the site itself when feeding an LLM for rewriting.',
+  inputSchema: {
+    type: 'object',
+    required: ['config'],
+    properties: {
+      config: {
+        type: 'string',
+        description: 'Path to the YAML config file with search_console.site_url set.',
+      },
+      days: {
+        type: 'number',
+        description: 'Lookback window in days. Default: 28. Max: 485.',
+        default: 28,
+        minimum: 1,
+        maximum: 485,
+      },
+      min_impressions: {
+        type: 'number',
+        description:
+          'Minimum impressions for a query to be considered. Drops long-tail noise from the bucket median. Default: 20.',
+        default: 20,
+        minimum: 1,
+      },
+      min_potential_clicks: {
+        type: 'number',
+        description:
+          'Drop opportunities below this projected monthly click gain. Default: 0.',
+        default: 0,
+        minimum: 0,
+      },
+    },
+  },
+} as const


### PR DESCRIPTION
Implements BO-01: detect under-converting queries already ranking page 1–2 in Search Console. Audience is an LLM consumer that uses the output to prioritise title/meta rewrites.

## What's in the box

- \`ga4 gsc opportunities --config <path>.yaml\` CLI + matching \`gsc_opportunities\` MCP tool.
- Per-result envelope carries every field an LLM needs to rewrite a title without re-querying GSC: \`query, page, position, clicks, impressions, ctr, bucket, category_median_ctr, median_source, ctr_gap, potential_clicks\`.
- Sorted by \`potential_clicks\` descending — biggest revenue win first.
- Flag knobs: \`--days N\`, \`--min-impressions N\`, \`--min-potential-clicks N\`.

## Baseline-curve fallback

The locked v1 spec used per-site bucket median (industry-standard position-CTR curve, zero config). Live-tested against wealthsim it returned zero results — most position buckets at small sites are single-row, no median computable.

This commit adds an industry-baseline CTR fallback for single-row buckets (Advanced Web Ranking / Backlinko / Sistrix 2023-2024 averages). Each result reports \`median_source = "site" | "baseline"\` so consumers can weight the signal. Large sites get their own medians; small sites get baseline-grounded opportunities.

Tests for the single-row case were updated from "excluded" to "baseline-grounded opportunity surfaced".

## Live verification

\`ga4 gsc opportunities --config <wealthsim-config> --format json --days 90\` returned **5 opportunities**, 2 site-median + 3 baseline. Total potential gain = +1 click — confirming the earlier diagnosis that wealthsim is **traffic-bound, not CTR-bound** at current scale.

The single actionable finding worth acting on today: \`s&p 500 simulator\` (English) ranking pos 20 on \`/sp500-simulador\` (Spanish-titled page). Title rewrite candidate.

## Tests

- [x] Go: full suite green
- [x] MCP: 1390 tests (+1 new file: \`gsc-opportunities.test.ts\`)
- [x] \`go vet\` clean, \`make lint\` clean (vendored govet warnings only)
- [x] Live e2e against sc-domain:wealthsim.app: exit 2, valid envelope, results sorted by potential_clicks desc

## Note

Closes #52 partially. The remaining BO-02/03/05/06/07/08 slots are independent follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)