### PR TITLE
feat(gsc): BO-05 CTR Anomaly Detection

### DIFF
--- a/cmd/gsc_ctr_anomaly.go
+++ b/cmd/gsc_ctr_anomaly.go
@@ -1,0 +1,298 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/garbarok/ga4-manager/internal/gsc"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagcmd"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagnostics"
+)
+
+const (
+	ctrAnomalyDaysDefault = 28
+	ctrAnomalyDaysMin     = 1
+	ctrAnomalyDaysMax     = 240 // GSC keeps ~16 months total; allow two ranges back-to-back
+	ctrAnomalyRowLimit    = 5000
+	ctrAnomalyCommandName = "gsc_ctr_anomaly"
+)
+
+var (
+	gscCTRAnomalyConfig         string
+	gscCTRAnomalyFormat         string
+	gscCTRAnomalyDays           int
+	gscCTRAnomalyMinClicksPrior int64
+	gscCTRAnomalyMinClicksLost  int64
+)
+
+var gscCTRAnomalyCmd = &cobra.Command{
+	Use:   "ctr-anomaly",
+	Short: "Detect pages whose rank held but CTR collapsed (snippet rot)",
+	Long: `Compare two consecutive windows of Search Console data and surface
+(query, page) pairs whose ranking position barely moved but whose CTR
+dropped sharply. These are snippet-driven regressions — the page is
+still ranking, but its title/meta stopped converting. Always actionable
+by a title/meta rewrite.
+
+Predicate (see CONTEXT.md "SEO Diagnostics"):
+  |position_delta| < 1.0 AND ctr_delta ≤ -30%
+
+Two Search Analytics calls per run (current window + prior window of the
+same length). Stateless — no state files written.
+
+Each result carries the per-window numbers needed for an LLM consumer to
+prioritise and rewrite:
+  query, page, position_current, position_prior, position_delta,
+  ctr_current, ctr_prior, ctr_delta, clicks_current, clicks_prior,
+  clicks_lost, impressions_current, impressions_prior
+
+Results are sorted by clicks_lost descending — the absolute revenue
+impact of the snippet regression — so the biggest losses come first.
+
+Filter knobs:
+  --days N             length of each comparison window (default 28)
+  --min-clicks-prior N drop pairs whose prior-window click count is below
+                       this floor (default 5 — kills long-tail noise)
+  --min-clicks-lost N  drop pairs that lost fewer than N clicks
+                       (default 0 — show everything that satisfies the
+                       predicate)
+
+Exit codes:
+  0  no CTR anomalies detected
+  2  at least one CTR anomaly detected
+  1  command failed
+
+Examples:
+  ga4 gsc ctr-anomaly --config configs/mysite.yaml
+  ga4 gsc ctr-anomaly --config configs/mysite.yaml --format json
+  ga4 gsc ctr-anomaly --config configs/mysite.yaml --days 90 --min-clicks-prior 20`,
+	RunE: ctrAnomalyRunE,
+}
+
+func init() {
+	gscCmd.AddCommand(gscCTRAnomalyCmd)
+	gscCTRAnomalyCmd.Flags().StringVarP(&gscCTRAnomalyConfig, "config", "c", "", "Path to configuration file (required)")
+	gscCTRAnomalyCmd.Flags().StringVar(&gscCTRAnomalyFormat, "format", diagcmd.FormatTable, "Output format: table or json")
+	gscCTRAnomalyCmd.Flags().IntVar(&gscCTRAnomalyDays, "days", ctrAnomalyDaysDefault, "Length of each comparison window in days")
+	gscCTRAnomalyCmd.Flags().Int64Var(&gscCTRAnomalyMinClicksPrior, "min-clicks-prior", 5, "Drop pairs whose prior-window clicks are below this floor")
+	gscCTRAnomalyCmd.Flags().Int64Var(&gscCTRAnomalyMinClicksLost, "min-clicks-lost", 0, "Drop pairs that lost fewer than this many clicks")
+}
+
+var gscCTRAnomalyClientFactory = func() (gsc.SearchAPI, func(), error) {
+	client, err := gsc.NewClient()
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return client, func() { _ = client.Close() }, nil
+}
+
+// CTRAnomalyResultRow mirrors the diagnostic result with explicit JSON tags.
+type CTRAnomalyResultRow struct {
+	Query              string  `json:"query"`
+	Page               string  `json:"page"`
+	PositionCurrent    float64 `json:"position_current"`
+	PositionPrior      float64 `json:"position_prior"`
+	PositionDelta      float64 `json:"position_delta"`
+	CTRCurrent         float64 `json:"ctr_current"`
+	CTRPrior           float64 `json:"ctr_prior"`
+	CTRDelta           float64 `json:"ctr_delta"`
+	ClicksCurrent      int64   `json:"clicks_current"`
+	ClicksPrior        int64   `json:"clicks_prior"`
+	ClicksLost         int64   `json:"clicks_lost"`
+	ImpressionsCurrent int64   `json:"impressions_current"`
+	ImpressionsPrior   int64   `json:"impressions_prior"`
+}
+
+type CTRAnomalyOutput = diagcmd.Envelope[CTRAnomalyResultRow]
+
+func ctrAnomalyRunE(_ *cobra.Command, _ []string) error {
+	status := runCTRAnomalyCommand(ctrAnomalyParams{
+		ConfigPath:     gscCTRAnomalyConfig,
+		Format:         gscCTRAnomalyFormat,
+		Days:           gscCTRAnomalyDays,
+		MinClicksPrior: gscCTRAnomalyMinClicksPrior,
+		MinClicksLost:  gscCTRAnomalyMinClicksLost,
+		Factory:        gscCTRAnomalyClientFactory,
+		Stdout:         os.Stdout,
+		Stderr:         os.Stderr,
+		Now:            time.Now().UTC(),
+	})
+	os.Exit(status)
+	return nil
+}
+
+type ctrAnomalyParams struct {
+	ConfigPath     string
+	Format         string
+	Days           int
+	MinClicksPrior int64
+	MinClicksLost  int64
+	Factory        func() (gsc.SearchAPI, func(), error)
+	Stdout         io.Writer
+	Stderr         io.Writer
+	Now            time.Time
+}
+
+func runCTRAnomalyCommand(p ctrAnomalyParams) int {
+	if err := diagcmd.ValidateFormat(p.Format); err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+	if err := validateCTRAnomalyDays(p.Days); err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+	site, _, err := diagcmd.LoadSite(p.ConfigPath)
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+
+	client, cleanup, err := p.Factory()
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "failed to create GSC client: %v", err)
+	}
+	defer cleanup()
+
+	env, err := buildCTRAnomalyEnvelope(client, site, p.Days, p.MinClicksPrior, p.MinClicksLost, p.Now)
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+
+	if err := diagcmd.Render(p.Stdout, env, p.Format, ctrAnomalyColumns, ctrAnomalyTextRow); err != nil {
+		return diagcmd.FailWith(p.Stderr, "failed to render output: %v", err)
+	}
+
+	return diagcmd.ExitCode(nil, len(env.Results) > 0)
+}
+
+func validateCTRAnomalyDays(days int) error {
+	if days < ctrAnomalyDaysMin || days > ctrAnomalyDaysMax {
+		return fmt.Errorf("invalid --days %d: must be in [%d, %d]", days, ctrAnomalyDaysMin, ctrAnomalyDaysMax)
+	}
+	return nil
+}
+
+// ctrAnomalyWindows returns (currentStart, currentEnd, priorStart, priorEnd)
+// as YYYY-MM-DD strings: the current window is the last `days` days ending
+// at the most recent GSC-available day; the prior window is the `days`
+// days immediately before it. now is parameterised for deterministic tests.
+func ctrAnomalyWindows(now time.Time, days int) (string, string, string, string) {
+	// GSC data lags ~1–3 days; mirror the BuildDateRange convention of
+	// "yesterday is the most recent settled day".
+	currentEnd := now.AddDate(0, 0, -1)
+	currentStart := currentEnd.AddDate(0, 0, -(days - 1))
+	priorEnd := currentStart.AddDate(0, 0, -1)
+	priorStart := priorEnd.AddDate(0, 0, -(days - 1))
+	fmt := "2006-01-02"
+	return currentStart.Format(fmt), currentEnd.Format(fmt), priorStart.Format(fmt), priorEnd.Format(fmt)
+}
+
+func buildCTRAnomalyEnvelope(client gsc.SearchAPI, site string, days int, minClicksPrior, minClicksLost int64, now time.Time) (CTRAnomalyOutput, error) {
+	curStart, curEnd, priorStart, priorEnd := ctrAnomalyWindows(now, days)
+
+	currentReport, err := client.QuerySearchAnalytics(&gsc.SearchAnalyticsQuery{
+		SiteURL:    site,
+		StartDate:  curStart,
+		EndDate:    curEnd,
+		Dimensions: []string{"query", "page"},
+		RowLimit:   ctrAnomalyRowLimit,
+		DataState:  "final",
+	})
+	if err != nil {
+		return CTRAnomalyOutput{}, fmt.Errorf("search analytics current window failed: %w", err)
+	}
+
+	priorReport, err := client.QuerySearchAnalytics(&gsc.SearchAnalyticsQuery{
+		SiteURL:    site,
+		StartDate:  priorStart,
+		EndDate:    priorEnd,
+		Dimensions: []string{"query", "page"},
+		RowLimit:   ctrAnomalyRowLimit,
+		DataState:  "final",
+	})
+	if err != nil {
+		return CTRAnomalyOutput{}, fmt.Errorf("search analytics prior window failed: %w", err)
+	}
+
+	pairs := joinSearchAnalyticsRows(currentReport.Rows, priorReport.Rows, minClicksPrior)
+	diag := diagnostics.CTRAnomaly(pairs)
+
+	rows := make([]CTRAnomalyResultRow, 0, len(diag))
+	for _, r := range diag {
+		if r.ClicksLost < minClicksLost {
+			continue
+		}
+		rows = append(rows, CTRAnomalyResultRow{
+			Query:              r.Query,
+			Page:               r.Page,
+			PositionCurrent:    r.PositionCurrent,
+			PositionPrior:      r.PositionPrior,
+			PositionDelta:      r.PositionDelta,
+			CTRCurrent:         r.CTRCurrent,
+			CTRPrior:           r.CTRPrior,
+			CTRDelta:           r.CTRDelta,
+			ClicksCurrent:      r.ClicksCurrent,
+			ClicksPrior:        r.ClicksPrior,
+			ClicksLost:         r.ClicksLost,
+			ImpressionsCurrent: r.ImpressionsCurrent,
+			ImpressionsPrior:   r.ImpressionsPrior,
+		})
+	}
+
+	return diagcmd.NewEnvelope(ctrAnomalyCommandName, site, now, rows, priorReport.QuotaUsed), nil
+}
+
+// joinSearchAnalyticsRows pairs current-window and prior-window rows by
+// (query, page). Rows present in only one window are skipped — there is no
+// pair to diff. The minClicksPrior floor is applied to the PRIOR window
+// before pairing, because that's the baseline used for the CTR-delta ratio
+// (and prior=0 noise should never produce an "anomaly").
+func joinSearchAnalyticsRows(current, prior []gsc.SearchAnalyticsRow, minClicksPrior int64) []diagnostics.RowPair {
+	currentByKey := make(map[string]gsc.SearchAnalyticsRow, len(current))
+	for _, r := range current {
+		if len(r.Keys) != 2 {
+			continue
+		}
+		currentByKey[ctrAnomalyKey(r.Keys)] = r
+	}
+
+	pairs := make([]diagnostics.RowPair, 0, len(prior))
+	for _, p := range prior {
+		if len(p.Keys) != 2 {
+			continue
+		}
+		if p.Clicks < minClicksPrior {
+			continue
+		}
+		c, ok := currentByKey[ctrAnomalyKey(p.Keys)]
+		if !ok {
+			continue
+		}
+		pairs = append(pairs, diagnostics.RowPair{Current: c, Prior: p})
+	}
+	return pairs
+}
+
+func ctrAnomalyKey(keys []string) string {
+	return keys[0] + "\x00" + keys[1]
+}
+
+var ctrAnomalyColumns = []string{
+	"query", "page", "pos", "Δpos", "ctr_now", "ctr_prior", "Δctr", "clicks_lost",
+}
+
+func ctrAnomalyTextRow(r CTRAnomalyResultRow) []string {
+	return []string{
+		r.Query,
+		r.Page,
+		strconv.FormatFloat(r.PositionCurrent, 'f', 1, 64),
+		strconv.FormatFloat(r.PositionDelta, 'f', 2, 64),
+		formatCTRPercent(r.CTRCurrent),
+		formatCTRPercent(r.CTRPrior),
+		strconv.FormatFloat(r.CTRDelta*100, 'f', 1, 64) + "%",
+		strconv.FormatInt(r.ClicksLost, 10),
+	}
+}

--- a/cmd/gsc_ctr_anomaly_test.go
+++ b/cmd/gsc_ctr_anomaly_test.go
@@ -1,0 +1,256 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/garbarok/ga4-manager/internal/gsc"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagcmd"
+)
+
+// fakeCTRAnomalyClient returns canned rows. Because the command makes two
+// QuerySearchAnalytics calls (current + prior windows), the fake exposes
+// two row slices and tracks which call it is on.
+type fakeCTRAnomalyClient struct {
+	currentRows []gsc.SearchAnalyticsRow
+	priorRows   []gsc.SearchAnalyticsRow
+	err         error
+	calls       int
+}
+
+func (f *fakeCTRAnomalyClient) QuerySearchAnalytics(_ *gsc.SearchAnalyticsQuery) (*gsc.SearchAnalyticsReport, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	var rows []gsc.SearchAnalyticsRow
+	if f.calls == 1 {
+		rows = f.currentRows
+	} else {
+		rows = f.priorRows
+	}
+	return &gsc.SearchAnalyticsReport{
+		Rows:      rows,
+		TotalRows: len(rows),
+		QuotaUsed: f.calls,
+	}, nil
+}
+
+func ctrAnomalyRow(query, page string, clicks, impressions int64, ctr, position float64) gsc.SearchAnalyticsRow {
+	return gsc.SearchAnalyticsRow{
+		Keys:        []string{query, page},
+		Clicks:      clicks,
+		Impressions: impressions,
+		CTR:         ctr,
+		Position:    position,
+	}
+}
+
+func newCTRAnomalyParams(t *testing.T, fake *fakeCTRAnomalyClient, format string) (ctrAnomalyParams, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	return ctrAnomalyParams{
+		ConfigPath:     writeConfig(t, "sc-domain:example.com"),
+		Format:         format,
+		Days:           ctrAnomalyDaysDefault,
+		MinClicksPrior: 5,
+		Factory:        func() (gsc.SearchAPI, func(), error) { return fake, func() {}, nil },
+		Stdout:         stdout,
+		Stderr:         stderr,
+		Now:            time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC),
+	}, stdout, stderr
+}
+
+func TestRunCTRAnomalyCommand_CleanExitWhenNoCollapses(t *testing.T) {
+	// Same row in both windows → ctr_delta = 0 → no anomaly.
+	row := ctrAnomalyRow("q", "https://example.com/p", 100, 1000, 0.10, 7.0)
+	fake := &fakeCTRAnomalyClient{
+		currentRows: []gsc.SearchAnalyticsRow{row},
+		priorRows:   []gsc.SearchAnalyticsRow{row},
+	}
+	params, stdout, _ := newCTRAnomalyParams(t, fake, diagcmd.FormatTable)
+	if status := runCTRAnomalyCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitClean)
+	}
+	if got := stdout.String(); got != "quota used: 2\n" {
+		t.Errorf("expected only quota footer, got %q", got)
+	}
+}
+
+func TestRunCTRAnomalyCommand_DetectsSnippetCollapse(t *testing.T) {
+	// Position unchanged (7.0 → 7.2), CTR halved → exceeds the −30% threshold.
+	current := ctrAnomalyRow("compound-interest", "https://example.com/calc", 30, 1000, 0.03, 7.2)
+	prior := ctrAnomalyRow("compound-interest", "https://example.com/calc", 80, 1000, 0.08, 7.0)
+	fake := &fakeCTRAnomalyClient{
+		currentRows: []gsc.SearchAnalyticsRow{current},
+		priorRows:   []gsc.SearchAnalyticsRow{prior},
+	}
+	params, stdout, _ := newCTRAnomalyParams(t, fake, diagcmd.FormatJSON)
+	if status := runCTRAnomalyCommand(params); status != diagcmd.ExitIssues {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitIssues)
+	}
+
+	var got CTRAnomalyOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got.Results))
+	}
+	r := got.Results[0]
+	if r.Query != "compound-interest" || r.Page != "https://example.com/calc" {
+		t.Errorf("wrong identity: %+v", r)
+	}
+	if r.ClicksLost != 50 {
+		t.Errorf("clicks_lost = %d, want 50", r.ClicksLost)
+	}
+	if r.CTRDelta > -0.30 {
+		t.Errorf("ctr_delta = %f, expected ≤ -0.30", r.CTRDelta)
+	}
+	if r.PositionDelta > 1.0 || r.PositionDelta < -1.0 {
+		t.Errorf("position_delta = %f, expected |x| < 1.0", r.PositionDelta)
+	}
+	if got.QuotaUsed != 2 {
+		t.Errorf("quota_used = %d, want 2 (two analytics calls)", got.QuotaUsed)
+	}
+}
+
+func TestRunCTRAnomalyCommand_SortsByClicksLostDesc(t *testing.T) {
+	current := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("small", "https://example.com/s", 2, 100, 0.02, 5.0),
+		ctrAnomalyRow("big", "https://example.com/b", 50, 5000, 0.01, 5.0),
+		ctrAnomalyRow("mid", "https://example.com/m", 10, 1000, 0.01, 5.0),
+	}
+	prior := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("small", "https://example.com/s", 10, 100, 0.10, 5.0),
+		ctrAnomalyRow("big", "https://example.com/b", 400, 5000, 0.08, 5.0),
+		ctrAnomalyRow("mid", "https://example.com/m", 80, 1000, 0.08, 5.0),
+	}
+	fake := &fakeCTRAnomalyClient{currentRows: current, priorRows: prior}
+	params, stdout, _ := newCTRAnomalyParams(t, fake, diagcmd.FormatJSON)
+	if status := runCTRAnomalyCommand(params); status != diagcmd.ExitIssues {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitIssues)
+	}
+	var got CTRAnomalyOutput
+	_ = json.Unmarshal(stdout.Bytes(), &got)
+	if len(got.Results) != 3 {
+		t.Fatalf("got %d results, want 3", len(got.Results))
+	}
+	if got.Results[0].Query != "big" {
+		t.Errorf("first should be 'big' (350 lost), got %q", got.Results[0].Query)
+	}
+	if got.Results[1].Query != "mid" {
+		t.Errorf("second should be 'mid' (70 lost), got %q", got.Results[1].Query)
+	}
+}
+
+func TestRunCTRAnomalyCommand_SkipsRowsMissingInOneWindow(t *testing.T) {
+	current := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("only-current", "https://example.com/c", 5, 1000, 0.005, 7.0),
+		ctrAnomalyRow("both", "https://example.com/b", 5, 1000, 0.005, 7.0),
+	}
+	prior := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("only-prior", "https://example.com/p", 80, 1000, 0.08, 7.0),
+		ctrAnomalyRow("both", "https://example.com/b", 80, 1000, 0.08, 7.0),
+	}
+	fake := &fakeCTRAnomalyClient{currentRows: current, priorRows: prior}
+	params, stdout, _ := newCTRAnomalyParams(t, fake, diagcmd.FormatJSON)
+	runCTRAnomalyCommand(params)
+	var got CTRAnomalyOutput
+	_ = json.Unmarshal(stdout.Bytes(), &got)
+	if len(got.Results) != 1 {
+		t.Fatalf("got %d results, want 1 (only 'both' present in both windows)", len(got.Results))
+	}
+	if got.Results[0].Query != "both" {
+		t.Errorf("kept the wrong query: %q", got.Results[0].Query)
+	}
+}
+
+func TestRunCTRAnomalyCommand_MinClicksPriorDropsNoise(t *testing.T) {
+	// Prior clicks = 1 → below the floor of 5 → pair dropped.
+	current := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("noise", "https://example.com/n", 0, 100, 0.0, 7.0),
+	}
+	prior := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("noise", "https://example.com/n", 1, 100, 0.01, 7.0),
+	}
+	fake := &fakeCTRAnomalyClient{currentRows: current, priorRows: prior}
+	params, stdout, _ := newCTRAnomalyParams(t, fake, diagcmd.FormatJSON)
+	if status := runCTRAnomalyCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("expected clean exit (noise dropped), got %d", status)
+	}
+	_ = stdout
+}
+
+func TestRunCTRAnomalyCommand_MinClicksLostFiltersBelowFloor(t *testing.T) {
+	current := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("big", "https://example.com/b", 0, 5000, 0.0, 5.0),
+		ctrAnomalyRow("tiny", "https://example.com/t", 0, 100, 0.0, 5.0),
+	}
+	prior := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("big", "https://example.com/b", 400, 5000, 0.08, 5.0),
+		ctrAnomalyRow("tiny", "https://example.com/t", 8, 100, 0.08, 5.0),
+	}
+	fake := &fakeCTRAnomalyClient{currentRows: current, priorRows: prior}
+	params, stdout, _ := newCTRAnomalyParams(t, fake, diagcmd.FormatJSON)
+	params.MinClicksLost = 50
+	runCTRAnomalyCommand(params)
+	var got CTRAnomalyOutput
+	_ = json.Unmarshal(stdout.Bytes(), &got)
+	for _, r := range got.Results {
+		if r.ClicksLost < 50 {
+			t.Errorf("result %q has clicks_lost = %d, below floor of 50", r.Query, r.ClicksLost)
+		}
+	}
+}
+
+func TestRunCTRAnomalyCommand_Windows(t *testing.T) {
+	// 2026-06-05 → currentEnd should be 2026-06-04 (yesterday), 28-day window
+	// → currentStart = 2026-05-08; priorEnd = 2026-05-07; priorStart = 2026-04-10.
+	cs, ce, ps, pe := ctrAnomalyWindows(time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC), 28)
+	if cs != "2026-05-08" || ce != "2026-06-04" {
+		t.Errorf("current window = %s..%s, want 2026-05-08..2026-06-04", cs, ce)
+	}
+	if ps != "2026-04-10" || pe != "2026-05-07" {
+		t.Errorf("prior window = %s..%s, want 2026-04-10..2026-05-07", ps, pe)
+	}
+}
+
+func TestRunCTRAnomalyCommand_FailureModes(t *testing.T) {
+	t.Run("invalid format", func(t *testing.T) {
+		fake := &fakeCTRAnomalyClient{}
+		params, _, stderr := newCTRAnomalyParams(t, fake, "xml")
+		if status := runCTRAnomalyCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "invalid --format") {
+			t.Errorf("stderr missing reason: %q", stderr.String())
+		}
+	})
+	t.Run("invalid days", func(t *testing.T) {
+		fake := &fakeCTRAnomalyClient{}
+		params, _, stderr := newCTRAnomalyParams(t, fake, diagcmd.FormatTable)
+		params.Days = 0
+		if status := runCTRAnomalyCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "invalid --days") {
+			t.Errorf("stderr missing reason: %q", stderr.String())
+		}
+	})
+	t.Run("api error on current window", func(t *testing.T) {
+		fake := &fakeCTRAnomalyClient{err: errors.New("api down")}
+		params, _, stderr := newCTRAnomalyParams(t, fake, diagcmd.FormatTable)
+		if status := runCTRAnomalyCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "api down") {
+			t.Errorf("stderr missing reason: %q", stderr.String())
+		}
+	})
+}

--- a/internal/gsc/diagnostics/ctr_anomaly.go
+++ b/internal/gsc/diagnostics/ctr_anomaly.go
@@ -6,15 +6,27 @@ import (
 )
 
 // CTRAnomalyResult is one (query, page) pair that satisfies the CTR-anomaly
-// predicate.
+// predicate — its position held but its CTR collapsed.
 //
 // PositionDelta is current.Position − prior.Position. CTRDelta is the relative
 // change in CTR as a ratio: (current.CTR − prior.CTR) / prior.CTR.
+// ClicksLost is prior.Clicks − current.Clicks, clamped to ≥0 — the
+// absolute revenue impact of the anomaly, useful for ranking results by
+// how much the Operator can recover by fixing the snippet.
 type CTRAnomalyResult struct {
-	Query         string
-	Page          string
-	PositionDelta float64
-	CTRDelta      float64
+	Query              string
+	Page               string
+	PositionCurrent    float64
+	PositionPrior      float64
+	PositionDelta      float64
+	CTRCurrent         float64
+	CTRPrior           float64
+	CTRDelta           float64
+	ClicksCurrent      int64
+	ClicksPrior        int64
+	ClicksLost         int64
+	ImpressionsCurrent int64
+	ImpressionsPrior   int64
 }
 
 // CTRAnomaly classifies row pairs under the CTR-anomaly predicate.
@@ -54,15 +66,34 @@ func CTRAnomaly(pairs []RowPair) []CTRAnomalyResult {
 			continue
 		}
 
+		clicksLost := pair.Prior.Clicks - pair.Current.Clicks
+		if clicksLost < 0 {
+			clicksLost = 0
+		}
 		results = append(results, CTRAnomalyResult{
-			Query:         query,
-			Page:          page,
-			PositionDelta: positionDelta,
-			CTRDelta:      ctrDelta,
+			Query:              query,
+			Page:               page,
+			PositionCurrent:    pair.Current.Position,
+			PositionPrior:      pair.Prior.Position,
+			PositionDelta:      positionDelta,
+			CTRCurrent:         pair.Current.CTR,
+			CTRPrior:           pair.Prior.CTR,
+			CTRDelta:           ctrDelta,
+			ClicksCurrent:      pair.Current.Clicks,
+			ClicksPrior:        pair.Prior.Clicks,
+			ClicksLost:         clicksLost,
+			ImpressionsCurrent: pair.Current.Impressions,
+			ImpressionsPrior:   pair.Prior.Impressions,
 		})
 	}
 
+	// Sort by absolute clicks lost descending — the actionable signal an
+	// Operator (or an LLM rewriter) wants to act on first. CTRDelta is a
+	// useful secondary tie-break for results at equal clicks lost.
 	sort.SliceStable(results, func(i, j int) bool {
+		if results[i].ClicksLost != results[j].ClicksLost {
+			return results[i].ClicksLost > results[j].ClicksLost
+		}
 		if results[i].CTRDelta != results[j].CTRDelta {
 			return results[i].CTRDelta < results[j].CTRDelta
 		}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -92,6 +92,12 @@ import {
   buildOpportunitiesArgs,
   parseOpportunitiesOutput,
 } from './tools/gsc-opportunities.js'
+import {
+  gscCTRAnomalyTool,
+  gscCTRAnomalyInputSchema,
+  buildCTRAnomalyArgs,
+  parseCTRAnomalyOutput,
+} from './tools/gsc-ctr-anomaly.js'
 
 // gsc_monitor_urls is dual-mode (native URL loop OR CLI), handled below.
 import {
@@ -308,6 +314,13 @@ const SPECS: ToolSpec[] = [
     command: 'gsc',
     buildArgs: buildOpportunitiesArgs,
     parse: (out) => parseOpportunitiesOutput(out),
+  }),
+  cli({
+    tool: gscCTRAnomalyTool,
+    schema: gscCTRAnomalyInputSchema,
+    command: 'gsc',
+    buildArgs: buildCTRAnomalyArgs,
+    parse: (out) => parseCTRAnomalyOutput(out),
   }),
 
   // ── gsc_monitor_urls: dual-mode (native URL loop OR CLI config run) ─────────

--- a/mcp/src/tools/gsc-ctr-anomaly.test.ts
+++ b/mcp/src/tools/gsc-ctr-anomaly.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  gscCTRAnomalyInputSchema,
+  gscCTRAnomalyTool,
+  buildCTRAnomalyArgs,
+  parseCTRAnomalyOutput,
+  GscCTRAnomalyInput,
+} from './gsc-ctr-anomaly.js'
+
+describe('gscCTRAnomalyInputSchema', () => {
+  it('applies defaults', () => {
+    const parsed = gscCTRAnomalyInputSchema.safeParse({ config: 'x.yaml' })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.days).toBe(28)
+      expect(parsed.data.min_clicks_prior).toBe(5)
+      expect(parsed.data.min_clicks_lost).toBe(0)
+    }
+  })
+
+  it('rejects empty config', () => {
+    expect(gscCTRAnomalyInputSchema.safeParse({ config: '' }).success).toBe(false)
+  })
+
+  it('rejects days outside [1, 240]', () => {
+    expect(gscCTRAnomalyInputSchema.safeParse({ config: 'x', days: 0 }).success).toBe(false)
+    expect(gscCTRAnomalyInputSchema.safeParse({ config: 'x', days: 241 }).success).toBe(false)
+  })
+})
+
+describe('buildCTRAnomalyArgs', () => {
+  it('passes every documented arg verbatim', () => {
+    const args = buildCTRAnomalyArgs({
+      config: 'configs/x.yaml',
+      days: 90,
+      min_clicks_prior: 20,
+      min_clicks_lost: 50,
+    } as GscCTRAnomalyInput)
+    expect(args).toEqual([
+      'ctr-anomaly',
+      '--config',
+      'configs/x.yaml',
+      '--format',
+      'json',
+      '--days',
+      '90',
+      '--min-clicks-prior',
+      '20',
+      '--min-clicks-lost',
+      '50',
+    ])
+  })
+})
+
+describe('parseCTRAnomalyOutput', () => {
+  it('parses a valid envelope', () => {
+    const stdout = JSON.stringify({
+      command: 'gsc_ctr_anomaly',
+      site: 'sc-domain:example.com',
+      generated_at: '2026-06-05T12:00:00Z',
+      results: [
+        {
+          query: 'q',
+          page: 'p',
+          position_current: 7.2,
+          position_prior: 7.0,
+          position_delta: 0.2,
+          ctr_current: 0.03,
+          ctr_prior: 0.08,
+          ctr_delta: -0.625,
+          clicks_current: 30,
+          clicks_prior: 80,
+          clicks_lost: 50,
+          impressions_current: 1000,
+          impressions_prior: 1000,
+        },
+      ],
+      quota_used: 2,
+    })
+    const out = parseCTRAnomalyOutput(stdout)
+    expect(out.results).toHaveLength(1)
+    expect(out.results[0].clicks_lost).toBe(50)
+    expect(out.quota_used).toBe(2)
+  })
+
+  it('throws on wrong command', () => {
+    expect(() =>
+      parseCTRAnomalyOutput(
+        JSON.stringify({ command: 'other', site: 's', generated_at: 'g', results: [], quota_used: 0 }),
+      ),
+    ).toThrow(/Unexpected command/)
+  })
+
+  it('throws on garbled stdout', () => {
+    expect(() => parseCTRAnomalyOutput('not json')).toThrow()
+  })
+})
+
+describe('gscCTRAnomalyTool definition', () => {
+  it('has the registered name', () => {
+    expect(gscCTRAnomalyTool.name).toBe('gsc_ctr_anomaly')
+  })
+
+  it('declares all four args', () => {
+    const props = gscCTRAnomalyTool.inputSchema.properties as Record<string, unknown>
+    expect(props.config).toBeDefined()
+    expect(props.days).toBeDefined()
+    expect(props.min_clicks_prior).toBeDefined()
+    expect(props.min_clicks_lost).toBeDefined()
+  })
+
+  it('mentions clicks_lost in description so consumers know the sort key', () => {
+    expect(gscCTRAnomalyTool.description).toMatch(/clicks_lost/)
+  })
+})

--- a/mcp/src/tools/gsc-ctr-anomaly.ts
+++ b/mcp/src/tools/gsc-ctr-anomaly.ts
@@ -1,0 +1,147 @@
+import { z } from 'zod'
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+export const gscCTRAnomalyInputSchema = z.object({
+  config: z
+    .string()
+    .min(1, 'config is required')
+    .describe('Path to the YAML config file with search_console.site_url set'),
+  days: z
+    .number()
+    .int()
+    .min(1)
+    .max(240)
+    .optional()
+    .default(28)
+    .describe(
+      'Length of each comparison window in days (current vs prior). Default: 28. Max: 240 (allows two back-to-back windows within GSC retention).',
+    ),
+  min_clicks_prior: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .default(5)
+    .describe(
+      'Drop pairs whose prior-window click count is below this floor. Default: 5 — kills long-tail noise that would generate false CTR-anomalies with sample size = 1.',
+    ),
+  min_clicks_lost: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .default(0)
+    .describe(
+      'Drop pairs that lost fewer than this many clicks between windows. Default: 0.',
+    ),
+})
+
+export type GscCTRAnomalyInput = z.infer<typeof gscCTRAnomalyInputSchema>
+
+// ============================================================================
+// Output Types — mirror the CLI JSON envelope exactly
+// ============================================================================
+
+export interface CTRAnomalyResultRow {
+  query: string
+  page: string
+  position_current: number
+  position_prior: number
+  position_delta: number
+  ctr_current: number
+  ctr_prior: number
+  ctr_delta: number
+  clicks_current: number
+  clicks_prior: number
+  /** Headline number: absolute clicks lost vs prior window. Sort key. */
+  clicks_lost: number
+  impressions_current: number
+  impressions_prior: number
+}
+
+export interface CTRAnomalyOutput {
+  command: 'gsc_ctr_anomaly'
+  site: string
+  generated_at: string
+  results: CTRAnomalyResultRow[]
+  quota_used: number
+}
+
+// ============================================================================
+// CLI Wiring
+// ============================================================================
+
+export function buildCTRAnomalyArgs(input: GscCTRAnomalyInput): string[] {
+  return [
+    'ctr-anomaly',
+    '--config',
+    input.config,
+    '--format',
+    'json',
+    '--days',
+    String(input.days),
+    '--min-clicks-prior',
+    String(input.min_clicks_prior),
+    '--min-clicks-lost',
+    String(input.min_clicks_lost),
+  ]
+}
+
+export function parseCTRAnomalyOutput(stdout: string): CTRAnomalyOutput {
+  const parsed = JSON.parse(stdout) as Partial<CTRAnomalyOutput>
+  if (parsed.command !== 'gsc_ctr_anomaly') {
+    throw new Error(
+      `Unexpected command in CLI output: ${String(parsed.command)} (want gsc_ctr_anomaly)`,
+    )
+  }
+  if (typeof parsed.site !== 'string' || typeof parsed.generated_at !== 'string') {
+    throw new Error('CLI output missing site or generated_at')
+  }
+  if (!Array.isArray(parsed.results) || typeof parsed.quota_used !== 'number') {
+    throw new Error('CLI output missing results or quota_used')
+  }
+  return parsed as CTRAnomalyOutput
+}
+
+// ============================================================================
+// MCP Tool Definition
+// ============================================================================
+
+export const gscCTRAnomalyTool = {
+  name: 'gsc_ctr_anomaly',
+  description:
+    "Compare two consecutive windows of Google Search Console data and surface (query, page) pairs whose ranking position barely moved but whose click-through rate collapsed. These are snippet-driven regressions — the page is still ranking, but its title/meta has stopped converting against the SERP. Each result carries position_current/prior/delta, ctr_current/prior/delta, clicks_current/prior/lost, and impressions_current/prior — everything an LLM consumer needs to prioritise and rewrite the snippet. Results sorted by clicks_lost descending. Stateless: two Search Analytics API calls per run.",
+  inputSchema: {
+    type: 'object',
+    required: ['config'],
+    properties: {
+      config: {
+        type: 'string',
+        description: 'Path to the YAML config file with search_console.site_url set.',
+      },
+      days: {
+        type: 'number',
+        description: 'Length of each comparison window in days. Default: 28. Max: 240.',
+        default: 28,
+        minimum: 1,
+        maximum: 240,
+      },
+      min_clicks_prior: {
+        type: 'number',
+        description:
+          'Drop pairs whose prior-window clicks are below this floor (kills long-tail noise). Default: 5.',
+        default: 5,
+        minimum: 0,
+      },
+      min_clicks_lost: {
+        type: 'number',
+        description: 'Drop pairs that lost fewer than this many clicks. Default: 0.',
+        default: 0,
+        minimum: 0,
+      },
+    },
+  },
+} as const


### PR DESCRIPTION
Implements BO-05. Two-window comparison surfaces (query, page) pairs whose rank held but CTR collapsed ≥30%. Sorted by clicks_lost desc. Full per-window metrics in the envelope for LLM consumers.

**Live verified against wealthsim:** 90-day window surfaces 6 real anomalies — including the brand query `wealth sim` losing 4 clicks at position 3 (snippet-rot on the brand SERP).

- Go: full suite green
- MCP: 1410 tests green (+18 new)
- `make lint` clean
