### PR TITLE
feat(gsc): BO-03 Weekly Index Health Report

### DIFF
--- a/cmd/gsc_health.go
+++ b/cmd/gsc_health.go
@@ -1,0 +1,462 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/garbarok/ga4-manager/internal/gsc"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagcmd"
+	gscstate "github.com/garbarok/ga4-manager/internal/gsc/state"
+)
+
+const (
+	healthCommandName = "gsc_health"
+
+	// Coverage states the predicate considers "indexed and healthy". Any
+	// movement out of this set is treated as a regression; any movement
+	// into this set is treated as a recovery.
+	healthCoverageStateIndexed = "Submitted and indexed"
+
+	// Rich-results statuses considered passing.
+	healthRichPass = "PASS"
+
+	healthChangeRegression = "regression"
+	healthChangeRecovery   = "recovery"
+	healthChangeBaseline   = "baseline"
+)
+
+var (
+	gscHealthConfig   string
+	gscHealthFormat   string
+	gscHealthStateDir string
+	gscHealthDryRun   bool
+)
+
+var gscHealthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Weekly index-health diff against the prior snapshot",
+	Long: `Inspect every URL declared under search_console.url_inspection.priority_urls
+in the config file, diff each URL's coverage state against the prior snapshot,
+and report regressions, recoveries, and first-time baselines. Designed to run
+on a weekly cron so noindex bugs, canonical mismatches, and mobile-usability
+regressions are caught within days instead of weeks.
+
+State per ADR-0005: ` + "`" + `.ga4-state/health.<site>.json` + "`" + ` (or use --state-dir
+to override). Atomic temp-file-plus-rename writes; an interrupted run never
+corrupts the snapshot.
+
+Per-URL field-level diffs surface the following moves as regressions:
+  coverage_state moving away from "Submitted and indexed"
+  robots_blocked transitioning to true
+  indexing_allowed transitioning to false
+  mobile_usable transitioning to false
+  rich_results_status moving away from "PASS"
+  google_canonical changing
+
+Moves in the opposite direction are surfaced as recoveries (good news).
+
+First-time URLs are surfaced as "baseline" entries — informational,
+they don't count as regressions for exit-code purposes.
+
+Each result carries the full current state of the URL so an LLM consumer
+can decide how to triage without re-inspecting.
+
+Quota cost: one URL Inspection request per priority URL. URL Inspection
+has a 2000/day budget; the command does NOT deduplicate across runs (each
+run inspects every priority URL fresh — that is the point).
+
+Exit codes:
+  0  no regressions (clean — silent on stdout aside from quota footer)
+  2  at least one regression detected
+  1  command failed (API error, malformed config, state write failure)
+
+Examples:
+  ga4 gsc health --config configs/mysite.yaml
+  ga4 gsc health --config configs/mysite.yaml --format json
+  ga4 gsc health --config configs/mysite.yaml --state-dir /var/lib/ga4-state
+  ga4 gsc health --config configs/mysite.yaml --dry-run`,
+	RunE: healthRunE,
+}
+
+func init() {
+	gscCmd.AddCommand(gscHealthCmd)
+	gscHealthCmd.Flags().StringVarP(&gscHealthConfig, "config", "c", "", "Path to configuration file (required)")
+	gscHealthCmd.Flags().StringVar(&gscHealthFormat, "format", diagcmd.FormatTable, "Output format: table or json")
+	gscHealthCmd.Flags().StringVar(&gscHealthStateDir, "state-dir", "", "Override the state directory (default .ga4-state/)")
+	gscHealthCmd.Flags().BoolVar(&gscHealthDryRun, "dry-run", false, "Inspect and diff but do not write a new snapshot")
+}
+
+var gscHealthClientFactory = func() (gsc.InspectAPI, func(), error) {
+	client, err := gsc.NewClient()
+	if err != nil {
+		return nil, func() {}, err
+	}
+	return client, func() { _ = client.Close() }, nil
+}
+
+// healthURLState is the per-URL payload persisted to disk and surfaced as
+// the `current_state` of each result.
+type healthURLState struct {
+	CoverageState     string `json:"coverage_state"`
+	GoogleCanonical   string `json:"google_canonical"`
+	UserCanonical     string `json:"user_canonical"`
+	RobotsBlocked     bool   `json:"robots_blocked"`
+	IndexingAllowed   bool   `json:"indexing_allowed"`
+	MobileUsable      bool   `json:"mobile_usable"`
+	RichResultsStatus string `json:"rich_results_status"`
+}
+
+// healthFieldChange is one field-level diff inside a URL's result entry.
+type healthFieldChange struct {
+	Field  string `json:"field"`
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+// HealthResultRow is one URL whose state differed from the prior snapshot
+// (or is being baselined). Stable URLs with no diffs are NOT emitted —
+// the command is "silent on all-green".
+type HealthResultRow struct {
+	URL          string              `json:"url"`
+	Change       string              `json:"change"` // regression | recovery | baseline
+	Changes      []healthFieldChange `json:"changes,omitempty"`
+	CurrentState healthURLState      `json:"current_state"`
+}
+
+// HealthOutput is the JSON envelope under --format json.
+type HealthOutput = diagcmd.Envelope[HealthResultRow]
+
+// stateData is the body of the snapshot's `data` field.
+type stateData struct {
+	URLs map[string]healthURLState `json:"urls"`
+}
+
+func healthRunE(_ *cobra.Command, _ []string) error {
+	status := runHealthCommand(healthParams{
+		ConfigPath: gscHealthConfig,
+		Format:     gscHealthFormat,
+		StateDir:   gscstate.ResolveStateDir(gscHealthStateDir),
+		DryRun:     gscHealthDryRun,
+		Factory:    gscHealthClientFactory,
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
+		Now:        time.Now().UTC(),
+	})
+	os.Exit(status)
+	return nil
+}
+
+type healthParams struct {
+	ConfigPath string
+	Format     string
+	StateDir   string
+	DryRun     bool
+	Factory    func() (gsc.InspectAPI, func(), error)
+	Stdout     io.Writer
+	Stderr     io.Writer
+	Now        time.Time
+}
+
+func runHealthCommand(p healthParams) int {
+	if err := diagcmd.ValidateFormat(p.Format); err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+	site, cfg, err := diagcmd.LoadSite(p.ConfigPath)
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+	if cfg.SearchConsole == nil || cfg.SearchConsole.URLInspection == nil || len(cfg.SearchConsole.URLInspection.PriorityURLs) == 0 {
+		return diagcmd.FailWith(p.Stderr, "no search_console.url_inspection.priority_urls in %s", p.ConfigPath)
+	}
+	urls := cfg.SearchConsole.URLInspection.PriorityURLs
+
+	client, cleanup, err := p.Factory()
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "failed to create GSC client: %v", err)
+	}
+	defer cleanup()
+
+	store := gscstate.NewStore(p.StateDir)
+	prior, hasPrior, err := loadHealthSnapshot(store, site)
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+
+	currentByURL, inspections, err := inspectAllHealth(client, site, urls)
+	if err != nil {
+		return diagcmd.FailWith(p.Stderr, "%v", err)
+	}
+
+	rows := diffHealth(prior, currentByURL, hasPrior)
+	hasRegression := false
+	for _, r := range rows {
+		if r.Change == healthChangeRegression {
+			hasRegression = true
+			break
+		}
+	}
+
+	if !p.DryRun {
+		if err := writeHealthSnapshot(store, site, currentByURL, p.Now); err != nil {
+			return diagcmd.FailWith(p.Stderr, "failed to write state: %v", err)
+		}
+	}
+
+	env := diagcmd.NewEnvelope(healthCommandName, site, p.Now, rows, inspections)
+	if err := diagcmd.Render(p.Stdout, env, p.Format, healthColumns, healthTextRow); err != nil {
+		return diagcmd.FailWith(p.Stderr, "failed to render output: %v", err)
+	}
+
+	return diagcmd.ExitCode(nil, hasRegression)
+}
+
+// loadHealthSnapshot returns the prior state map plus a flag indicating
+// whether any prior state existed (false on the very first run). A missing
+// snapshot is NOT an error — first-run is the baseline case.
+func loadHealthSnapshot(store *gscstate.Store, site string) (map[string]healthURLState, bool, error) {
+	snap, err := store.Read(context.Background(), healthCommandName, site)
+	if err != nil {
+		if errors.Is(err, gscstate.ErrSnapshotMissing) {
+			return map[string]healthURLState{}, false, nil
+		}
+		return nil, false, fmt.Errorf("read state: %w", err)
+	}
+	var body stateData
+	if err := json.Unmarshal(snap.Data, &body); err != nil {
+		return nil, false, fmt.Errorf("parse state payload: %w", err)
+	}
+	if body.URLs == nil {
+		body.URLs = map[string]healthURLState{}
+	}
+	return body.URLs, true, nil
+}
+
+func writeHealthSnapshot(store *gscstate.Store, site string, urls map[string]healthURLState, now time.Time) error {
+	body := stateData{URLs: urls}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal state payload: %w", err)
+	}
+	_ = now // generated_at is set by the store; param retained for future fakes
+	return store.Write(context.Background(), healthCommandName, site, payload)
+}
+
+func inspectAllHealth(client gsc.InspectAPI, site string, urls []string) (map[string]healthURLState, int, error) {
+	// Deduplicate within this run, in case the config repeats a URL.
+	seen := make(map[string]struct{}, len(urls))
+	ordered := make([]string, 0, len(urls))
+	for _, u := range urls {
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		ordered = append(ordered, u)
+	}
+
+	state := make(map[string]healthURLState, len(ordered))
+	for _, u := range ordered {
+		r, err := client.InspectURL(site, u)
+		if err != nil {
+			return nil, 0, fmt.Errorf("inspect %s: %w", u, err)
+		}
+		state[u] = healthURLState{
+			CoverageState:     r.CoverageState,
+			GoogleCanonical:   r.GoogleCanonical,
+			UserCanonical:     r.UserCanonical,
+			RobotsBlocked:     r.RobotsBlocked,
+			IndexingAllowed:   r.IndexingAllowed,
+			MobileUsable:      r.MobileUsable,
+			RichResultsStatus: r.RichResultsStatus,
+		}
+	}
+	return state, len(ordered), nil
+}
+
+// diffHealth produces one HealthResultRow per URL that materially changed
+// (or is new in this run when hasPrior is true). Stable URLs are excluded.
+//
+// On the very first run (hasPrior == false) NO baseline rows are emitted —
+// there is no prior to diff against and surfacing every URL as "baseline"
+// would defeat silent-on-all-green. Subsequent runs surface newly-added
+// URLs as baselines so the Operator knows new entries entered monitoring.
+func diffHealth(prior, current map[string]healthURLState, hasPrior bool) []HealthResultRow {
+	rows := make([]HealthResultRow, 0)
+
+	urls := make([]string, 0, len(current))
+	for u := range current {
+		urls = append(urls, u)
+	}
+	sort.Strings(urls)
+
+	for _, u := range urls {
+		cur := current[u]
+		old, existed := prior[u]
+		if !existed {
+			if !hasPrior {
+				continue
+			}
+			rows = append(rows, HealthResultRow{
+				URL:          u,
+				Change:       healthChangeBaseline,
+				CurrentState: cur,
+			})
+			continue
+		}
+		changes := compareHealthStates(old, cur)
+		if len(changes) == 0 {
+			continue
+		}
+		rows = append(rows, HealthResultRow{
+			URL:          u,
+			Change:       classifyHealthChanges(changes, old, cur),
+			Changes:      changes,
+			CurrentState: cur,
+		})
+	}
+	return rows
+}
+
+// compareHealthStates returns the list of field-level diffs between two
+// snapshots. Only fields that materially differ are emitted.
+func compareHealthStates(before, after healthURLState) []healthFieldChange {
+	var changes []healthFieldChange
+	add := func(field, b, a string) {
+		if b != a {
+			changes = append(changes, healthFieldChange{Field: field, Before: b, After: a})
+		}
+	}
+	addBool := func(field string, b, a bool) {
+		if b != a {
+			changes = append(changes, healthFieldChange{
+				Field:  field,
+				Before: boolToString(b),
+				After:  boolToString(a),
+			})
+		}
+	}
+	add("coverage_state", before.CoverageState, after.CoverageState)
+	add("google_canonical", before.GoogleCanonical, after.GoogleCanonical)
+	add("user_canonical", before.UserCanonical, after.UserCanonical)
+	addBool("robots_blocked", before.RobotsBlocked, after.RobotsBlocked)
+	addBool("indexing_allowed", before.IndexingAllowed, after.IndexingAllowed)
+	addBool("mobile_usable", before.MobileUsable, after.MobileUsable)
+	add("rich_results_status", before.RichResultsStatus, after.RichResultsStatus)
+	return changes
+}
+
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
+// classifyHealthChanges returns "regression", "recovery", or
+// "baseline" depending on whether the field-level diffs collectively
+// represent a worsening or improvement of the URL's health.
+//
+// A change is a regression if ANY field moved in the bad direction. A
+// recovery requires the URL was previously unhealthy and is now back to
+// the healthy baseline. Otherwise it falls through to a regression so the
+// Operator sees the change explicitly.
+func classifyHealthChanges(changes []healthFieldChange, before, after healthURLState) string {
+	if anyChangeIsBad(changes, before, after) {
+		return healthChangeRegression
+	}
+	if anyChangeIsGood(changes, before, after) {
+		return healthChangeRecovery
+	}
+	// All changes were lateral (e.g. canonical text changed without changing
+	// indexability). Treat as a regression so the Operator inspects.
+	return healthChangeRegression
+}
+
+func anyChangeIsBad(changes []healthFieldChange, before, after healthURLState) bool {
+	for _, c := range changes {
+		switch c.Field {
+		case "coverage_state":
+			if before.CoverageState == healthCoverageStateIndexed &&
+				after.CoverageState != healthCoverageStateIndexed {
+				return true
+			}
+		case "robots_blocked":
+			if !before.RobotsBlocked && after.RobotsBlocked {
+				return true
+			}
+		case "indexing_allowed":
+			if before.IndexingAllowed && !after.IndexingAllowed {
+				return true
+			}
+		case "mobile_usable":
+			if before.MobileUsable && !after.MobileUsable {
+				return true
+			}
+		case "rich_results_status":
+			if before.RichResultsStatus == healthRichPass &&
+				after.RichResultsStatus != healthRichPass &&
+				after.RichResultsStatus != "" {
+				return true
+			}
+		case "google_canonical":
+			// Any canonical change is worth surfacing — could be Google
+			// re-canonicalising to a different page than the operator
+			// declared.
+			return true
+		}
+	}
+	return false
+}
+
+func anyChangeIsGood(changes []healthFieldChange, before, after healthURLState) bool {
+	for _, c := range changes {
+		switch c.Field {
+		case "coverage_state":
+			if before.CoverageState != healthCoverageStateIndexed &&
+				after.CoverageState == healthCoverageStateIndexed {
+				return true
+			}
+		case "robots_blocked":
+			if before.RobotsBlocked && !after.RobotsBlocked {
+				return true
+			}
+		case "indexing_allowed":
+			if !before.IndexingAllowed && after.IndexingAllowed {
+				return true
+			}
+		case "mobile_usable":
+			if !before.MobileUsable && after.MobileUsable {
+				return true
+			}
+		case "rich_results_status":
+			if before.RichResultsStatus != healthRichPass &&
+				after.RichResultsStatus == healthRichPass {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var healthColumns = []string{"url", "change", "fields", "coverage_state"}
+
+func healthTextRow(r HealthResultRow) []string {
+	fields := make([]string, 0, len(r.Changes))
+	for _, c := range r.Changes {
+		fields = append(fields, c.Field)
+	}
+	return []string{
+		r.URL,
+		r.Change,
+		strings.Join(fields, ","),
+		r.CurrentState.CoverageState,
+	}
+}

--- a/cmd/gsc_health_test.go
+++ b/cmd/gsc_health_test.go
@@ -1,0 +1,290 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/garbarok/ga4-manager/internal/gsc"
+	"github.com/garbarok/ga4-manager/internal/gsc/diagcmd"
+)
+
+type fakeHealthClient struct {
+	results      map[string]gsc.URLInspectionResult
+	err          error
+	inspectCalls int
+}
+
+func (f *fakeHealthClient) InspectURL(_, url string) (*gsc.URLInspectionResult, error) {
+	f.inspectCalls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	r, ok := f.results[url]
+	if !ok {
+		// Default to a healthy indexed page when the test didn't override.
+		r = gsc.URLInspectionResult{
+			URL:               url,
+			CoverageState:     "Submitted and indexed",
+			IndexingAllowed:   true,
+			MobileUsable:      true,
+			RichResultsStatus: "PASS",
+		}
+	}
+	return &r, nil
+}
+
+func writeHealthConfig(t *testing.T, site string, urls []string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	body := "project:\n  name: example\nsearch_console:\n  site_url: " + site + "\n  url_inspection:\n    priority_urls:\n"
+	for _, u := range urls {
+		body += "      - " + u + "\n"
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func newHealthParams(t *testing.T, fake *fakeHealthClient, urls []string, format string) (healthParams, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	return healthParams{
+		ConfigPath: writeHealthConfig(t, "sc-domain:example.com", urls),
+		Format:     format,
+		StateDir:   t.TempDir(),
+		Factory:    func() (gsc.InspectAPI, func(), error) { return fake, func() {}, nil },
+		Stdout:     stdout,
+		Stderr:     stderr,
+		Now:        time.Date(2026, 6, 5, 12, 0, 0, 0, time.UTC),
+	}, stdout, stderr
+}
+
+func TestRunHealthCommand_FirstRunIsSilentBaseline(t *testing.T) {
+	fake := &fakeHealthClient{}
+	urls := []string{"https://example.com/a", "https://example.com/b"}
+	params, stdout, _ := newHealthParams(t, fake, urls, diagcmd.FormatTable)
+	if status := runHealthCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("status = %d, want %d", status, diagcmd.ExitClean)
+	}
+	// Silent on first run — only the quota footer.
+	if got := stdout.String(); got != "quota used: 2\n" {
+		t.Errorf("expected only quota footer, got %q", got)
+	}
+	if fake.inspectCalls != 2 {
+		t.Errorf("inspect calls = %d, want 2", fake.inspectCalls)
+	}
+}
+
+func TestRunHealthCommand_DetectsNoindexRegression(t *testing.T) {
+	urls := []string{"https://example.com/a"}
+
+	// First run: indexed and clean — establishes baseline.
+	fake := &fakeHealthClient{}
+	params, _, _ := newHealthParams(t, fake, urls, diagcmd.FormatJSON)
+	if status := runHealthCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("first run status = %d, want clean", status)
+	}
+
+	// Second run: same state dir, same site, page now noindexed.
+	fake2 := &fakeHealthClient{results: map[string]gsc.URLInspectionResult{
+		"https://example.com/a": {
+			URL:               "https://example.com/a",
+			CoverageState:     "Excluded by 'noindex' tag",
+			IndexingAllowed:   false,
+			MobileUsable:      true,
+			RichResultsStatus: "PASS",
+		},
+	}}
+	params2 := params
+	params2.Factory = func() (gsc.InspectAPI, func(), error) { return fake2, func() {}, nil }
+	stdout := &bytes.Buffer{}
+	params2.Stdout = stdout
+	if status := runHealthCommand(params2); status != diagcmd.ExitIssues {
+		t.Fatalf("regression run status = %d, want issues", status)
+	}
+
+	var got HealthOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("len(results) = %d, want 1", len(got.Results))
+	}
+	r := got.Results[0]
+	if r.Change != healthChangeRegression {
+		t.Errorf("change = %q, want regression", r.Change)
+	}
+	fields := make([]string, 0, len(r.Changes))
+	for _, c := range r.Changes {
+		fields = append(fields, c.Field)
+	}
+	wantFields := []string{"coverage_state", "indexing_allowed"}
+	for _, w := range wantFields {
+		if !containsField(fields, w) {
+			t.Errorf("missing field %q in changes, got %v", w, fields)
+		}
+	}
+}
+
+func TestRunHealthCommand_DetectsRecovery(t *testing.T) {
+	urls := []string{"https://example.com/a"}
+
+	// First run: noindexed.
+	fake1 := &fakeHealthClient{results: map[string]gsc.URLInspectionResult{
+		"https://example.com/a": {
+			URL:           "https://example.com/a",
+			CoverageState: "Excluded by 'noindex' tag",
+		},
+	}}
+	params, _, _ := newHealthParams(t, fake1, urls, diagcmd.FormatJSON)
+	runHealthCommand(params)
+
+	// Second run: same state dir, now healthy.
+	fake2 := &fakeHealthClient{results: map[string]gsc.URLInspectionResult{
+		"https://example.com/a": {
+			URL:               "https://example.com/a",
+			CoverageState:     "Submitted and indexed",
+			IndexingAllowed:   true,
+			MobileUsable:      true,
+			RichResultsStatus: "PASS",
+		},
+	}}
+	params2 := params
+	params2.Factory = func() (gsc.InspectAPI, func(), error) { return fake2, func() {}, nil }
+	stdout := &bytes.Buffer{}
+	params2.Stdout = stdout
+	// A recovery is not a regression — exit clean.
+	if status := runHealthCommand(params2); status != diagcmd.ExitClean {
+		t.Fatalf("recovery status = %d, want clean", status)
+	}
+
+	var got HealthOutput
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
+	}
+	if len(got.Results) != 1 || got.Results[0].Change != healthChangeRecovery {
+		t.Errorf("expected one recovery row, got %+v", got.Results)
+	}
+}
+
+func TestRunHealthCommand_StablePageProducesNoRow(t *testing.T) {
+	urls := []string{"https://example.com/a"}
+	fake := &fakeHealthClient{}
+	params, _, _ := newHealthParams(t, fake, urls, diagcmd.FormatJSON)
+	runHealthCommand(params)
+
+	// Second run: identical state — no diff, no row.
+	params2 := params
+	params2.Factory = func() (gsc.InspectAPI, func(), error) { return fake, func() {}, nil }
+	stdout := &bytes.Buffer{}
+	params2.Stdout = stdout
+	if status := runHealthCommand(params2); status != diagcmd.ExitClean {
+		t.Fatalf("status = %d, want clean", status)
+	}
+	var got HealthOutput
+	_ = json.Unmarshal(stdout.Bytes(), &got)
+	if len(got.Results) != 0 {
+		t.Errorf("stable page should produce no row, got %+v", got.Results)
+	}
+}
+
+func TestRunHealthCommand_NewURLAfterBaselineSurfacesAsBaseline(t *testing.T) {
+	urls := []string{"https://example.com/a"}
+	fake := &fakeHealthClient{}
+	params, _, _ := newHealthParams(t, fake, urls, diagcmd.FormatJSON)
+	runHealthCommand(params)
+
+	// Second run: same state dir, config now has TWO URLs.
+	// Re-write the config (different temp config path is fine — same state).
+	configPath2 := writeHealthConfig(t, "sc-domain:example.com",
+		[]string{"https://example.com/a", "https://example.com/b"})
+	params2 := params
+	params2.ConfigPath = configPath2
+	stdout := &bytes.Buffer{}
+	params2.Stdout = stdout
+	runHealthCommand(params2)
+
+	var got HealthOutput
+	_ = json.Unmarshal(stdout.Bytes(), &got)
+	if len(got.Results) != 1 {
+		t.Fatalf("expected 1 baseline row, got %d", len(got.Results))
+	}
+	if got.Results[0].Change != healthChangeBaseline {
+		t.Errorf("change = %q, want baseline", got.Results[0].Change)
+	}
+	if got.Results[0].URL != "https://example.com/b" {
+		t.Errorf("baseline URL = %q, want https://example.com/b", got.Results[0].URL)
+	}
+}
+
+func TestRunHealthCommand_DryRunDoesNotWriteState(t *testing.T) {
+	urls := []string{"https://example.com/a"}
+	fake := &fakeHealthClient{}
+	params, _, _ := newHealthParams(t, fake, urls, diagcmd.FormatJSON)
+	params.DryRun = true
+
+	if status := runHealthCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("status = %d", status)
+	}
+
+	// State dir should be empty — no file written.
+	entries, _ := os.ReadDir(params.StateDir)
+	for _, e := range entries {
+		if !e.IsDir() {
+			t.Errorf("dry-run wrote state file: %s", e.Name())
+		}
+	}
+}
+
+func TestRunHealthCommand_FailureModes(t *testing.T) {
+	t.Run("invalid format", func(t *testing.T) {
+		fake := &fakeHealthClient{}
+		params, _, stderr := newHealthParams(t, fake, []string{"https://x"}, "xml")
+		if status := runHealthCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "invalid --format") {
+			t.Errorf("stderr missing reason: %q", stderr.String())
+		}
+	})
+
+	t.Run("missing priority_urls in config", func(t *testing.T) {
+		fake := &fakeHealthClient{}
+		params, _, stderr := newHealthParams(t, fake, nil, diagcmd.FormatTable)
+		if status := runHealthCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "priority_urls") {
+			t.Errorf("stderr missing reason: %q", stderr.String())
+		}
+	})
+
+	t.Run("inspect error", func(t *testing.T) {
+		fake := &fakeHealthClient{err: errors.New("api down")}
+		params, _, stderr := newHealthParams(t, fake, []string{"https://x"}, diagcmd.FormatTable)
+		if status := runHealthCommand(params); status != diagcmd.ExitFailure {
+			t.Fatalf("status = %d", status)
+		}
+		if !strings.Contains(stderr.String(), "api down") {
+			t.Errorf("stderr missing reason: %q", stderr.String())
+		}
+	})
+}
+
+func containsField(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -98,6 +98,12 @@ import {
   buildCTRAnomalyArgs,
   parseCTRAnomalyOutput,
 } from './tools/gsc-ctr-anomaly.js'
+import {
+  gscHealthTool,
+  gscHealthInputSchema,
+  buildHealthArgs,
+  parseHealthOutput,
+} from './tools/gsc-health.js'
 
 // gsc_monitor_urls is dual-mode (native URL loop OR CLI), handled below.
 import {
@@ -321,6 +327,13 @@ const SPECS: ToolSpec[] = [
     command: 'gsc',
     buildArgs: buildCTRAnomalyArgs,
     parse: (out) => parseCTRAnomalyOutput(out),
+  }),
+  cli({
+    tool: gscHealthTool,
+    schema: gscHealthInputSchema,
+    command: 'gsc',
+    buildArgs: buildHealthArgs,
+    parse: (out) => parseHealthOutput(out),
   }),
 
   // ── gsc_monitor_urls: dual-mode (native URL loop OR CLI config run) ─────────

--- a/mcp/src/tools/gsc-health.test.ts
+++ b/mcp/src/tools/gsc-health.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import {
+  gscHealthInputSchema,
+  gscHealthTool,
+  buildHealthArgs,
+  parseHealthOutput,
+  GscHealthInput,
+} from './gsc-health.js'
+
+describe('gscHealthInputSchema', () => {
+  it('accepts a config path with default flags', () => {
+    const parsed = gscHealthInputSchema.safeParse({ config: 'configs/x.yaml' })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.dry_run).toBe(false)
+      expect(parsed.data.state_dir).toBeUndefined()
+    }
+  })
+
+  it('rejects empty config', () => {
+    expect(gscHealthInputSchema.safeParse({ config: '' }).success).toBe(false)
+  })
+})
+
+describe('buildHealthArgs', () => {
+  it('omits optional flags when unset', () => {
+    const args = buildHealthArgs({
+      config: 'configs/x.yaml',
+      dry_run: false,
+    } as GscHealthInput)
+    expect(args).toEqual(['health', '--config', 'configs/x.yaml', '--format', 'json'])
+  })
+
+  it('appends --state-dir when provided', () => {
+    const args = buildHealthArgs({
+      config: 'configs/x.yaml',
+      state_dir: '/var/lib/ga4-state',
+      dry_run: false,
+    } as GscHealthInput)
+    expect(args).toContain('--state-dir')
+    expect(args).toContain('/var/lib/ga4-state')
+  })
+
+  it('appends --dry-run when true', () => {
+    const args = buildHealthArgs({
+      config: 'configs/x.yaml',
+      dry_run: true,
+    } as GscHealthInput)
+    expect(args).toContain('--dry-run')
+  })
+})
+
+describe('parseHealthOutput', () => {
+  it('parses a valid envelope', () => {
+    const stdout = JSON.stringify({
+      command: 'gsc_health',
+      site: 'sc-domain:example.com',
+      generated_at: '2026-06-05T12:00:00Z',
+      results: [
+        {
+          url: 'https://example.com/a',
+          change: 'regression',
+          changes: [
+            { field: 'coverage_state', before: 'Submitted and indexed', after: "Excluded by 'noindex' tag" },
+          ],
+          current_state: {
+            coverage_state: "Excluded by 'noindex' tag",
+            google_canonical: '',
+            user_canonical: '',
+            robots_blocked: false,
+            indexing_allowed: false,
+            mobile_usable: true,
+            rich_results_status: '',
+          },
+        },
+      ],
+      quota_used: 1,
+    })
+    const out = parseHealthOutput(stdout)
+    expect(out.results).toHaveLength(1)
+    expect(out.results[0].change).toBe('regression')
+    expect(out.results[0].changes?.[0].field).toBe('coverage_state')
+  })
+
+  it('throws on wrong command', () => {
+    expect(() =>
+      parseHealthOutput(
+        JSON.stringify({ command: 'other', site: 's', generated_at: 'g', results: [], quota_used: 0 }),
+      ),
+    ).toThrow(/Unexpected command/)
+  })
+
+  it('throws on garbled stdout', () => {
+    expect(() => parseHealthOutput('not json')).toThrow()
+  })
+})
+
+describe('gscHealthTool definition', () => {
+  it('has the registered name', () => {
+    expect(gscHealthTool.name).toBe('gsc_health')
+  })
+
+  it('mentions noindex in the description so callers know the use case', () => {
+    expect(gscHealthTool.description.toLowerCase()).toContain('noindex')
+  })
+
+  it('marks config as required', () => {
+    expect(gscHealthTool.inputSchema.required).toContain('config')
+  })
+})

--- a/mcp/src/tools/gsc-health.ts
+++ b/mcp/src/tools/gsc-health.ts
@@ -1,0 +1,124 @@
+import { z } from 'zod'
+
+// ============================================================================
+// Input Schema
+// ============================================================================
+
+export const gscHealthInputSchema = z.object({
+  config: z
+    .string()
+    .min(1, 'config is required')
+    .describe(
+      'Path to the YAML config file with search_console.url_inspection.priority_urls set',
+    ),
+  state_dir: z
+    .string()
+    .optional()
+    .describe(
+      'Override the state directory. Default: .ga4-state/ relative to the working directory.',
+    ),
+  dry_run: z
+    .boolean()
+    .optional()
+    .default(false)
+    .describe('Inspect and diff but do not write a new snapshot.'),
+})
+
+export type GscHealthInput = z.infer<typeof gscHealthInputSchema>
+
+// ============================================================================
+// Output Types — mirror the CLI JSON envelope exactly
+// ============================================================================
+
+export interface HealthFieldChange {
+  field: string
+  before: string
+  after: string
+}
+
+export interface HealthURLState {
+  coverage_state: string
+  google_canonical: string
+  user_canonical: string
+  robots_blocked: boolean
+  indexing_allowed: boolean
+  mobile_usable: boolean
+  rich_results_status: string
+}
+
+export interface HealthResultRow {
+  url: string
+  change: 'regression' | 'recovery' | 'baseline'
+  changes?: HealthFieldChange[]
+  current_state: HealthURLState
+}
+
+export interface HealthOutput {
+  command: 'gsc_health'
+  site: string
+  generated_at: string
+  results: HealthResultRow[]
+  quota_used: number
+}
+
+// ============================================================================
+// CLI Wiring
+// ============================================================================
+
+export function buildHealthArgs(input: GscHealthInput): string[] {
+  const args = ['health', '--config', input.config, '--format', 'json']
+  if (input.state_dir) {
+    args.push('--state-dir', input.state_dir)
+  }
+  if (input.dry_run) {
+    args.push('--dry-run')
+  }
+  return args
+}
+
+export function parseHealthOutput(stdout: string): HealthOutput {
+  const parsed = JSON.parse(stdout) as Partial<HealthOutput>
+  if (parsed.command !== 'gsc_health') {
+    throw new Error(
+      `Unexpected command in CLI output: ${String(parsed.command)} (want gsc_health)`,
+    )
+  }
+  if (typeof parsed.site !== 'string' || typeof parsed.generated_at !== 'string') {
+    throw new Error('CLI output missing site or generated_at')
+  }
+  if (!Array.isArray(parsed.results) || typeof parsed.quota_used !== 'number') {
+    throw new Error('CLI output missing results or quota_used')
+  }
+  return parsed as HealthOutput
+}
+
+// ============================================================================
+// MCP Tool Definition
+// ============================================================================
+
+export const gscHealthTool = {
+  name: 'gsc_health',
+  description:
+    "Weekly index-health report. Inspects every URL declared under search_console.url_inspection.priority_urls in the config file, diffs each URL's coverage state against the prior snapshot stored at .ga4-state/health.<site>.json (per ADR-0005), and surfaces regressions, recoveries, and first-time baselines. Designed to run on a weekly cron so noindex bugs, canonical mismatches, mobile-usability regressions, and rich-result failures are caught within days. Silent on all-green: zero regressions → empty results array; ≥1 regression → results populated and the underlying CLI exits 2. Each result carries the field-level diff plus the full current state of the URL so an LLM consumer can triage without re-inspecting. Quota cost: one URL Inspection request per priority URL per run.",
+  inputSchema: {
+    type: 'object',
+    required: ['config'],
+    properties: {
+      config: {
+        type: 'string',
+        description:
+          'Path to the YAML config file with search_console.url_inspection.priority_urls set.',
+      },
+      state_dir: {
+        type: 'string',
+        description:
+          'Override the state directory. Default: .ga4-state/ relative to the working directory.',
+      },
+      dry_run: {
+        type: 'boolean',
+        description: 'Inspect and diff but do not write a new snapshot.',
+        default: false,
+      },
+    },
+  },
+} as const


### PR DESCRIPTION
First state-bearing diagnostic command per ADR-0005. Inspects priority_urls from config, diffs against prior snapshot, surfaces regressions / recoveries / baselines. Silent on all-green; designed for weekly cron use.

- New `ga4 gsc health` CLI + `gsc_health` MCP tool.
- Field-level diffs (coverage_state, canonical, robots/indexing/mobile/rich-results).
- Per-URL JSON envelope with change classification + full current_state.
- One URL Inspection request per priority URL per run.

Tests: Go suite green, MCP 1432 tests green (+12 new), `go vet` clean.