### PR TITLE
feat(v2.3.1): polish for small-site diagnostic usability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Priority filtering (`--priority high/medium/low`)
 - Incremental updates for partial updates
 
+## [2.3.1] - 2026-06-05
+
+### Polish — small-site usability for the diagnostic family
+
+#### Changed
+
+- **`gsc opportunities` default `--min-potential-clicks` 0 → 1.** Suppresses 0-click rounding-error findings on small sites. Pass `--min-potential-clicks 0` to restore the previous "surface everything" behaviour. Same default change mirrored in the matching MCP arg.
+- **`gsc analytics run` default `--days` 30 → 28.** Aligns with the diagnostic-command default and with GSC's standard reporting window. Pass `--days 30` explicitly to keep the old value.
+
+#### Added
+
+- **`gsc ctr-anomaly` sparse-data warning.** When the joined sample falls below the threshold (currently 5 pairs after the `--min-clicks-prior` filter) and zero anomalies came back, the command emits a stderr warning explaining that `0 anomalies` reflects insufficient data, with a remediation hint to widen `--days` or lower `--min-clicks-prior`. JSON output on stdout is unchanged; the warning is stderr-only so structured consumers never see it.
+
 ## [2.3.0] - 2026-06-05
 
 ### GSC Diagnostics framework: four production-grade SEO commands + shared substrate

--- a/cmd/gsc_analytics.go
+++ b/cmd/gsc_analytics.go
@@ -101,7 +101,7 @@ func init() {
 	gscAnalyticsRunCmd.Flags().StringVarP(&gscAnalyticsConfig, "config", "c", "", "Path to configuration file")
 
 	// Days flag (default: 30 days)
-	gscAnalyticsRunCmd.Flags().IntVarP(&gscAnalyticsDays, "days", "d", 30, "Number of days to query (1-180)")
+	gscAnalyticsRunCmd.Flags().IntVarP(&gscAnalyticsDays, "days", "d", 28, "Number of days to query (1-180); 28 aligns with the diagnostic-command default")
 
 	// Dimensions flag (default: query,page)
 	gscAnalyticsRunCmd.Flags().StringVar(&gscAnalyticsDimensions, "dimensions", "query,page", "Dimensions to include (comma-separated, max 3)")

--- a/cmd/gsc_ctr_anomaly.go
+++ b/cmd/gsc_ctr_anomaly.go
@@ -138,6 +138,12 @@ type ctrAnomalyParams struct {
 	Now            time.Time
 }
 
+// ctrAnomalySparsePairsThreshold is the minimum number of (query, page)
+// pairs that survive --min-clicks-prior below which the result set cannot
+// be trusted. With fewer pairs than this, a "zero anomalies" result tells
+// the Operator nothing — there's just not enough data to detect them.
+const ctrAnomalySparsePairsThreshold = 5
+
 func runCTRAnomalyCommand(p ctrAnomalyParams) int {
 	if err := diagcmd.ValidateFormat(p.Format); err != nil {
 		return diagcmd.FailWith(p.Stderr, "%v", err)
@@ -156,13 +162,23 @@ func runCTRAnomalyCommand(p ctrAnomalyParams) int {
 	}
 	defer cleanup()
 
-	env, err := buildCTRAnomalyEnvelope(client, site, p.Days, p.MinClicksPrior, p.MinClicksLost, p.Now)
+	env, pairsCount, err := buildCTRAnomalyEnvelope(client, site, p.Days, p.MinClicksPrior, p.MinClicksLost, p.Now)
 	if err != nil {
 		return diagcmd.FailWith(p.Stderr, "%v", err)
 	}
 
 	if err := diagcmd.Render(p.Stdout, env, p.Format, ctrAnomalyColumns, ctrAnomalyTextRow); err != nil {
 		return diagcmd.FailWith(p.Stderr, "failed to render output: %v", err)
+	}
+
+	// Sparse-data UX warning: when no anomalies came back AND the joined
+	// sample is small, the Operator should know "0 anomalies" reflects
+	// data scarcity rather than a clean run. Stderr-only so JSON
+	// consumers never see it.
+	if len(env.Results) == 0 && pairsCount < ctrAnomalySparsePairsThreshold {
+		fmt.Fprintf(p.Stderr,
+			"warning: only %d (query, page) pairs cleared --min-clicks-prior=%d — too few to detect anomalies reliably. Try a longer window (e.g. --days 90) or lower --min-clicks-prior.\n",
+			pairsCount, p.MinClicksPrior)
 	}
 
 	return diagcmd.ExitCode(nil, len(env.Results) > 0)
@@ -190,7 +206,7 @@ func ctrAnomalyWindows(now time.Time, days int) (string, string, string, string)
 	return currentStart.Format(fmt), currentEnd.Format(fmt), priorStart.Format(fmt), priorEnd.Format(fmt)
 }
 
-func buildCTRAnomalyEnvelope(client gsc.SearchAPI, site string, days int, minClicksPrior, minClicksLost int64, now time.Time) (CTRAnomalyOutput, error) {
+func buildCTRAnomalyEnvelope(client gsc.SearchAPI, site string, days int, minClicksPrior, minClicksLost int64, now time.Time) (CTRAnomalyOutput, int, error) {
 	curStart, curEnd, priorStart, priorEnd := ctrAnomalyWindows(now, days)
 
 	currentReport, err := client.QuerySearchAnalytics(&gsc.SearchAnalyticsQuery{
@@ -202,7 +218,7 @@ func buildCTRAnomalyEnvelope(client gsc.SearchAPI, site string, days int, minCli
 		DataState:  "final",
 	})
 	if err != nil {
-		return CTRAnomalyOutput{}, fmt.Errorf("search analytics current window failed: %w", err)
+		return CTRAnomalyOutput{}, 0, fmt.Errorf("search analytics current window failed: %w", err)
 	}
 
 	priorReport, err := client.QuerySearchAnalytics(&gsc.SearchAnalyticsQuery{
@@ -214,7 +230,7 @@ func buildCTRAnomalyEnvelope(client gsc.SearchAPI, site string, days int, minCli
 		DataState:  "final",
 	})
 	if err != nil {
-		return CTRAnomalyOutput{}, fmt.Errorf("search analytics prior window failed: %w", err)
+		return CTRAnomalyOutput{}, 0, fmt.Errorf("search analytics prior window failed: %w", err)
 	}
 
 	pairs := joinSearchAnalyticsRows(currentReport.Rows, priorReport.Rows, minClicksPrior)
@@ -242,7 +258,7 @@ func buildCTRAnomalyEnvelope(client gsc.SearchAPI, site string, days int, minCli
 		})
 	}
 
-	return diagcmd.NewEnvelope(ctrAnomalyCommandName, site, now, rows, priorReport.QuotaUsed), nil
+	return diagcmd.NewEnvelope(ctrAnomalyCommandName, site, now, rows, priorReport.QuotaUsed), len(pairs), nil
 }
 
 // joinSearchAnalyticsRows pairs current-window and prior-window rows by

--- a/cmd/gsc_ctr_anomaly_test.go
+++ b/cmd/gsc_ctr_anomaly_test.go
@@ -221,6 +221,48 @@ func TestRunCTRAnomalyCommand_Windows(t *testing.T) {
 	}
 }
 
+func TestRunCTRAnomalyCommand_SparseDataEmitsWarning(t *testing.T) {
+	// Only 2 paired rows after the min-clicks-prior filter — below the
+	// sparse threshold. No CTR collapse, so 0 results. Stderr should
+	// carry the "too few pairs to detect anomalies reliably" warning.
+	current := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("q1", "https://example.com/a", 5, 100, 0.05, 7.0),
+		ctrAnomalyRow("q2", "https://example.com/b", 6, 100, 0.06, 7.0),
+	}
+	prior := []gsc.SearchAnalyticsRow{
+		ctrAnomalyRow("q1", "https://example.com/a", 5, 100, 0.05, 7.0),
+		ctrAnomalyRow("q2", "https://example.com/b", 6, 100, 0.06, 7.0),
+	}
+	fake := &fakeCTRAnomalyClient{currentRows: current, priorRows: prior}
+	params, _, stderr := newCTRAnomalyParams(t, fake, diagcmd.FormatJSON)
+	if status := runCTRAnomalyCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("status = %d, want clean", status)
+	}
+	if !strings.Contains(stderr.String(), "too few to detect anomalies") {
+		t.Errorf("expected sparse-data warning on stderr, got %q", stderr.String())
+	}
+}
+
+func TestRunCTRAnomalyCommand_NoWarningWhenSamplesAdequate(t *testing.T) {
+	// Enough pairs that the warning shouldn't fire even though the
+	// result set is empty.
+	current := make([]gsc.SearchAnalyticsRow, 0, 10)
+	prior := make([]gsc.SearchAnalyticsRow, 0, 10)
+	for i := 0; i < 10; i++ {
+		q := "q" + string(rune('0'+i))
+		current = append(current, ctrAnomalyRow(q, "https://example.com/"+q, 8, 100, 0.08, 7.0))
+		prior = append(prior, ctrAnomalyRow(q, "https://example.com/"+q, 8, 100, 0.08, 7.0))
+	}
+	fake := &fakeCTRAnomalyClient{currentRows: current, priorRows: prior}
+	params, _, stderr := newCTRAnomalyParams(t, fake, diagcmd.FormatJSON)
+	if status := runCTRAnomalyCommand(params); status != diagcmd.ExitClean {
+		t.Fatalf("status = %d, want clean", status)
+	}
+	if strings.Contains(stderr.String(), "too few") {
+		t.Errorf("sparse warning should NOT fire on adequate samples, got %q", stderr.String())
+	}
+}
+
 func TestRunCTRAnomalyCommand_FailureModes(t *testing.T) {
 	t.Run("invalid format", func(t *testing.T) {
 		fake := &fakeCTRAnomalyClient{}

--- a/cmd/gsc_opportunities.go
+++ b/cmd/gsc_opportunities.go
@@ -78,7 +78,7 @@ func init() {
 	gscOpportunitiesCmd.Flags().StringVar(&gscOpportunitiesFormat, "format", diagcmd.FormatTable, "Output format: table or json")
 	gscOpportunitiesCmd.Flags().IntVar(&gscOpportunitiesDays, "days", opportunitiesDaysDefault, "Lookback window in days (1–485)")
 	gscOpportunitiesCmd.Flags().Int64Var(&gscOpportunitiesMinImpressions, "min-impressions", 5, "Minimum impressions for a query to be considered (drops noise; default 5 — small sites need a low floor)")
-	gscOpportunitiesCmd.Flags().Int64Var(&gscOpportunitiesMinPotentialClick, "min-potential-clicks", 0, "Drop opportunities below this projected click gain")
+	gscOpportunitiesCmd.Flags().Int64Var(&gscOpportunitiesMinPotentialClick, "min-potential-clicks", 1, "Drop opportunities below this projected click gain (default 1 — suppresses 0-click rounding-error findings)")
 }
 
 // gscOpportunitiesClientFactory returns a live GSC client. Tests substitute.

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ga4-manager-mcp",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ga4-manager-mcp",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "bottleneck": "^2.19.5",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga4-manager-mcp",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "MCP server for GA4 Manager - Analytics and Search Console tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp/src/tools/gsc-opportunities.test.ts
+++ b/mcp/src/tools/gsc-opportunities.test.ts
@@ -14,7 +14,7 @@ describe('gscOpportunitiesInputSchema', () => {
     if (parsed.success) {
       expect(parsed.data.days).toBe(28)
       expect(parsed.data.min_impressions).toBe(20)
-      expect(parsed.data.min_potential_clicks).toBe(0)
+      expect(parsed.data.min_potential_clicks).toBe(1)
     }
   })
 

--- a/mcp/src/tools/gsc-opportunities.ts
+++ b/mcp/src/tools/gsc-opportunities.ts
@@ -31,9 +31,9 @@ export const gscOpportunitiesInputSchema = z.object({
     .int()
     .min(0)
     .optional()
-    .default(0)
+    .default(1)
     .describe(
-      'Filter out opportunities below this projected monthly click gain. Default: 0 (no filter).',
+      'Filter out opportunities below this projected monthly click gain. Default: 1 — suppresses 0-click rounding-error findings on small sites; set to 0 to surface everything.',
     ),
 })
 
@@ -138,8 +138,8 @@ export const gscOpportunitiesTool = {
       min_potential_clicks: {
         type: 'number',
         description:
-          'Drop opportunities below this projected monthly click gain. Default: 0.',
-        default: 0,
+          'Drop opportunities below this projected monthly click gain. Default: 1 (suppresses 0-click rounding-error findings on small sites).',
+        default: 1,
         minimum: 0,
       },
     },


### PR DESCRIPTION
Three follow-ups from post-2.3.0 live-testing feedback.

1. `opportunities` default `--min-potential-clicks` 0 → 1 (suppresses 0-click rounding-error findings on small sites; pass 0 to restore).
2. `analytics run` default `--days` 30 → 28 (aligns with diagnostic-command default).
3. `ctr-anomaly` emits a stderr warning when fewer than 5 (query, page) pairs survive `--min-clicks-prior` and zero anomalies returned — tells the Operator the empty result reflects data scarcity, with remediation hint.

Tests: full Go suite green (+2 new tests), MCP 1432 green.