### PR TITLE
Harden MCP server for directory review + robust binary resolution

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the GA4 Manager MCP Server will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.0.0] - 2026-06-24
 
 ### Changed
 

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to the GA4 Manager MCP Server will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING: `ga4_link` is split into `ga4_link_list`, `ga4_link_create`, and `ga4_link_remove`.** A single tool may not mix safe (read) and unsafe (write/delete) operations under the Claude connector directory review rules. The old `list` / `unlink` flags are gone: list links with `ga4_link_list`, create with `ga4_link_create` (`service` now required), and unlink with `ga4_link_remove` (`service` is `bigquery` | `channels`). All three call the same `ga4 link` CLI command — no Go CLI change.
+- **All tools now declare MCP `annotations`** (`title` plus `readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`). These drive auto-permission behavior and are required for directory submission.
+- **`seo_page_audit` / `seo_audit_batch` descriptions** now state they fetch user-supplied URLs over HTTP.
+
+### Fixed
+
+- **MCP server resolves the `ga4` binary from `PATH`** when neither `GA4_BINARY_PATH` nor the repo-root `ga4` is present. A globally installed `ga4` now works without a repo-root symlink. Resolution order: `GA4_BINARY_PATH` → repo-root `../../ga4` → `ga4` on `PATH`.
+- **`serverInfo.version`** is now read from `package.json` instead of a hard-coded `1.0.0`.
+- **Test suite no longer double-runs** the compiled `dist/**/*.test.js` copies (vitest now excludes `dist/`).
+- **`gsc_sitemaps_list` parser tests** updated to the real CLI table format. The fixtures used a pipe-delimited table the CLI never emits (it renders space-padded `tabwriter` output); the parser was correct, the fixtures were stale.
+
 ## [2.4.0] - 2026-06-15
 
 ### Added

--- a/mcp/PERMISSIONS.md
+++ b/mcp/PERMISSIONS.md
@@ -126,7 +126,7 @@ Repeat for every Search Console property you want to query.
 
 ## Google Analytics 4 (GA4)
 
-**Affects tools:** `ga4_report`, `ga4_setup`, `ga4_cleanup`, `ga4_validate`, `ga4_link`, `ga4_consent_health`
+**Affects tools:** `ga4_report`, `ga4_setup`, `ga4_cleanup`, `ga4_validate`, `ga4_link_list`, `ga4_link_create`, `ga4_link_remove`, `ga4_consent_health`
 
 ### Steps
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -133,11 +133,13 @@ claude mcp list
 
 ### Tool Categories
 
-**GA4 Analytics (5 tools)** - Configuration and management
+**GA4 Analytics (7 tools)** - Configuration and management
 - `ga4_setup` - Create conversions, dimensions, metrics
 - `ga4_report` - View current configuration
 - `ga4_cleanup` - Remove unused resources
-- `ga4_link` - External service integration
+- `ga4_link_list` - List existing external-service links
+- `ga4_link_create` - Create a Search Console/BigQuery/Channels link
+- `ga4_link_remove` - Remove (unlink) a BigQuery/Channels link
 - `ga4_validate` - Configuration validation
 
 **Search Console (8 tools)** - SEO and indexing
@@ -159,10 +161,10 @@ claude mcp list
 ### Tool Operation Types
 
 **Read-Only (Safe):**
-- `ga4_report`, `ga4_validate`, `gsc_sitemaps_list`, `gsc_sitemaps_get`, `gsc_inspect_url`, `gsc_analytics_run`, `gsc_monitor_urls`, `gsc_index_coverage`, `gsc_traffic_compare`, `ga4_consent_health`, `seo_page_audit`
+- `ga4_report`, `ga4_validate`, `ga4_link_list`, `gsc_sitemaps_list`, `gsc_sitemaps_get`, `gsc_inspect_url`, `gsc_analytics_run`, `gsc_monitor_urls`, `gsc_index_coverage`, `gsc_traffic_compare`, `ga4_consent_health`, `seo_page_audit`
 
 **Modifying (Use with caution):**
-- `ga4_setup`, `ga4_cleanup`, `ga4_link`, `gsc_sitemaps_submit`, `gsc_sitemaps_delete`
+- `ga4_setup`, `ga4_cleanup`, `ga4_link_create`, `ga4_link_remove`, `gsc_sitemaps_submit`, `gsc_sitemaps_delete`
 
 **Always use dry-run first for modifying operations!**
 
@@ -358,30 +360,45 @@ Archives unused conversions, dimensions, and metrics to free up quota.
 
 ---
 
-#### `ga4_link` - External Service Integration
+#### External Service Integration (`ga4_link_list` / `ga4_link_create` / `ga4_link_remove`)
 
-Manage links to Search Console, BigQuery, and Channel Groups.
+Linking is split into three tools so that read, write, and delete operations
+are distinct (this is required for the Claude connector directory — a single
+tool may not mix safe and unsafe operations). All three dispatch to the same
+`ga4 link` CLI command.
 
-**Input Schema:**
+##### `ga4_link_list` - List Links (read-only)
+
+Lists existing BigQuery export links and custom Channel Groups. (Search Console
+links can't be listed via the GA4 Admin API and are reported as
+`manual_check_required`.)
 
 ```typescript
 {
   project_name: string;     // Required: Project name
-  service?: string;         // "search-console" | "bigquery" | "channels"
-  list?: boolean;           // List existing links
-  unlink?: string;          // "bigquery" | "channels" (remove link)
-  url?: string;             // Site URL (for search-console)
-  gcp_project?: string;     // GCP project (for bigquery)
-  dataset?: string;         // BigQuery dataset (for bigquery)
 }
 ```
 
-**Example Request (List):**
+**Example Request:**
 
 ```typescript
 {
-  "project_name": "example-site",
-  "list": true
+  "project_name": "example-site"
+}
+```
+
+##### `ga4_link_create` - Create a Link (modifying)
+
+Creates a BigQuery export link, sets up default Channel Groups, or returns a
+Search Console setup guide.
+
+```typescript
+{
+  project_name: string;     // Required: Project name
+  service: string;          // Required: "search-console" | "bigquery" | "channels"
+  url?: string;             // Site URL (required for search-console)
+  gcp_project?: string;     // GCP project (required for bigquery)
+  dataset?: string;         // BigQuery dataset (required for bigquery)
 }
 ```
 
@@ -392,6 +409,27 @@ Manage links to Search Console, BigQuery, and Channel Groups.
   "project_name": "example-site",
   "service": "search-console",
   "url": "https://example.com"
+}
+```
+
+##### `ga4_link_remove` - Remove a Link (destructive)
+
+Unlinks an existing BigQuery export or Channel Group. (Search Console links
+cannot be removed via the Admin API.)
+
+```typescript
+{
+  project_name: string;     // Required: Project name
+  service: string;          // Required: "bigquery" | "channels"
+}
+```
+
+**Example Request:**
+
+```typescript
+{
+  "project_name": "example-site",
+  "service": "bigquery"
 }
 ```
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga4-manager-mcp",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "MCP server for GA4 Manager - Analytics and Search Console tools",
   "type": "module",
   "main": "dist/index.js",

--- a/mcp/src/cli/executor.ts
+++ b/mcp/src/cli/executor.ts
@@ -29,6 +29,7 @@ export class CLIExecutor {
         `ga4 CLI binary not found or not executable at ${this.binaryPath} (${reason}).\n` +
           `Build it first: 'make build' or 'go build -o ga4 .' from the repo root.\n` +
           `Override the path with the GA4_BINARY_PATH environment variable.`,
+        { cause: err },
       );
     }
   }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -9,7 +9,8 @@ import { z } from 'zod'
 import { CLIExecutor } from './cli/executor.js'
 import { mapCLIError } from './utils/errors.js'
 import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
+import { dirname, join, delimiter } from 'path'
+import { accessSync, constants, readFileSync } from 'fs'
 
 // GA4 tools (CLI-backed)
 import {
@@ -31,10 +32,18 @@ import {
   parseCleanupOutput,
 } from './tools/ga4-cleanup.js'
 import {
-  ga4LinkTool,
-  ga4LinkInputSchema,
-  buildLinkArgs,
-  parseLinkOutput,
+  ga4LinkListTool,
+  ga4LinkCreateTool,
+  ga4LinkRemoveTool,
+  ga4LinkListInputSchema,
+  ga4LinkCreateInputSchema,
+  ga4LinkRemoveInputSchema,
+  buildLinkListArgs,
+  buildLinkCreateArgs,
+  buildLinkRemoveArgs,
+  parseLinkListOutput,
+  parseLinkCreateOutput,
+  parseLinkRemoveOutput,
 } from './tools/ga4-link.js'
 import {
   ga4ValidateTool,
@@ -151,9 +160,63 @@ import {
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
-// Binary path from environment or default (relative to dist/)
-const binaryPath = process.env.GA4_BINARY_PATH || join(__dirname, '../../ga4')
+/**
+ * Resolve the ga4 CLI binary, in priority order:
+ *   1. GA4_BINARY_PATH — explicit override (used verbatim, even if missing,
+ *      so an intentional misconfiguration still surfaces a clear error).
+ *   2. The repo-root build next to mcp/ (../../ga4) — the dev default.
+ *   3. A `ga4` on the user's PATH (e.g. a globally installed binary).
+ *
+ * Without (3), installing the CLI globally but not symlinking it into the
+ * repo root crashed the server on startup. Falling back to PATH removes
+ * the need for that manual symlink. If nothing is found, we return the
+ * repo-root default so CLIExecutor emits the helpful "build it first" hint.
+ */
+function resolveBinaryPath(): string {
+  if (process.env.GA4_BINARY_PATH) return process.env.GA4_BINARY_PATH
+
+  const repoRootBinary = join(__dirname, '../../ga4')
+  if (isExecutable(repoRootBinary)) return repoRootBinary
+
+  const onPath = findOnPath('ga4')
+  if (onPath) return onPath
+
+  return repoRootBinary
+}
+
+function isExecutable(path: string): boolean {
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function findOnPath(name: string): string | null {
+  const pathEnv = process.env.PATH
+  if (!pathEnv) return null
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue
+    const candidate = join(dir, name)
+    if (isExecutable(candidate)) return candidate
+  }
+  return null
+}
+
+const binaryPath = resolveBinaryPath()
 const executor = new CLIExecutor(binaryPath)
+
+// Single source of truth for the server version: package.json (dist/ -> ../package.json).
+function readServerVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'))
+    return typeof pkg.version === 'string' ? pkg.version : '0.0.0'
+  } catch {
+    return '0.0.0'
+  }
+}
+const serverVersion = readServerVersion()
 
 // Framework convention (see CONTEXT.md, docs/BACKLOG.md "Implementation notes"):
 //   exit 0 — clean run, no findings
@@ -170,11 +233,21 @@ const isSuccessExit = (code: number): boolean => SUCCESS_EXIT_CODES.has(code)
 // Tool registry
 // ============================================================================
 
+/** Standard MCP tool annotations (title + behavior hints). */
+interface ToolAnnotations {
+  title: string
+  readOnlyHint?: boolean
+  destructiveHint?: boolean
+  idempotentHint?: boolean
+  openWorldHint?: boolean
+}
+
 /** The shape every tool module exports as its MCP definition. */
 interface ToolDef {
   name: string
   description: string
   inputSchema: Record<string, unknown>
+  annotations?: ToolAnnotations
 }
 
 /**
@@ -248,11 +321,25 @@ const SPECS: ToolSpec[] = [
     parse: (out, input) => parseCleanupOutput(out, input.dry_run || false),
   }),
   cli({
-    tool: ga4LinkTool,
-    schema: ga4LinkInputSchema,
+    tool: ga4LinkListTool,
+    schema: ga4LinkListInputSchema,
     command: 'link',
-    buildArgs: buildLinkArgs,
-    parse: (out, input) => parseLinkOutput(out, input),
+    buildArgs: buildLinkListArgs,
+    parse: (out) => parseLinkListOutput(out),
+  }),
+  cli({
+    tool: ga4LinkCreateTool,
+    schema: ga4LinkCreateInputSchema,
+    command: 'link',
+    buildArgs: buildLinkCreateArgs,
+    parse: (out, input) => parseLinkCreateOutput(out, input.service),
+  }),
+  cli({
+    tool: ga4LinkRemoveTool,
+    schema: ga4LinkRemoveInputSchema,
+    command: 'link',
+    buildArgs: buildLinkRemoveArgs,
+    parse: (out, input) => parseLinkRemoveOutput(out, input.service),
   }),
   cli({
     tool: ga4ValidateTool,
@@ -420,7 +507,7 @@ function jsonContent(payload: unknown, isError = false) {
 // ============================================================================
 
 const server = new Server(
-  { name: 'ga4-manager', version: '1.0.0' },
+  { name: 'ga4-manager', version: serverVersion },
   { capabilities: { tools: {} } },
 )
 

--- a/mcp/src/tools/ga4-cleanup.ts
+++ b/mcp/src/tools/ga4-cleanup.ts
@@ -457,4 +457,9 @@ export const ga4CleanupTool = {
     // Note: Zod schema handles mutual exclusivity validation
     // MCP doesn't support oneOf at top level
   },
+  annotations: {
+    title: 'Clean up GA4 resources',
+    readOnlyHint: false,
+    destructiveHint: true,
+  },
 };

--- a/mcp/src/tools/ga4-consent-health.ts
+++ b/mcp/src/tools/ga4-consent-health.ts
@@ -237,4 +237,8 @@ export const ga4ConsentHealthTool = {
       },
     },
   },
+  annotations: {
+    title: 'GA4 consent-mode health',
+    readOnlyHint: true,
+  },
 }

--- a/mcp/src/tools/ga4-link.test.ts
+++ b/mcp/src/tools/ga4-link.test.ts
@@ -1,151 +1,142 @@
 import { describe, it, expect } from 'vitest';
 import {
-  ga4LinkInputSchema,
-  buildLinkArgs,
-  parseLinkOutput,
-  GA4LinkInput,
+  ga4LinkListInputSchema,
+  ga4LinkCreateInputSchema,
+  ga4LinkRemoveInputSchema,
+  buildLinkListArgs,
+  buildLinkCreateArgs,
+  buildLinkRemoveArgs,
+  parseLinkListOutput,
+  parseLinkCreateOutput,
+  parseLinkRemoveOutput,
+  GA4LinkCreateInput,
 } from './ga4-link.js';
 
-describe('ga4_link tool', () => {
+describe('ga4_link tools (split)', () => {
   describe('input schema validation', () => {
-    it('accepts project_name with service', () => {
+    it('list: accepts project_name', () => {
+      expect(ga4LinkListInputSchema.safeParse({ project_name: 'basic-ecommerce' }).success).toBe(true);
+    });
+
+    it('list: rejects missing project_name', () => {
+      expect(ga4LinkListInputSchema.safeParse({}).success).toBe(false);
+    });
+
+    it('create: accepts project_name with service', () => {
       const input = { project_name: 'basic-ecommerce', service: 'channels' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
+      expect(ga4LinkCreateInputSchema.safeParse(input).success).toBe(true);
     });
 
-    it('accepts project_name with list flag', () => {
-      const input = { project_name: 'basic-ecommerce', list: true };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
+    it('create: rejects missing service', () => {
+      expect(ga4LinkCreateInputSchema.safeParse({ project_name: 'basic' }).success).toBe(false);
     });
 
-    it('accepts project_name with unlink', () => {
-      const input = { project_name: 'basic-ecommerce', unlink: 'bigquery' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
-    });
-
-    it('rejects missing project_name', () => {
-      const input = { service: 'channels' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
-    });
-
-    it('rejects project_name without action', () => {
-      const input = { project_name: 'basic-ecommerce' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
-    });
-
-    it('requires url for search-console service', () => {
+    it('create: requires url for search-console service', () => {
       const input = { project_name: 'basic', service: 'search-console' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
+      expect(ga4LinkCreateInputSchema.safeParse(input).success).toBe(false);
     });
 
-    it('accepts search-console with url', () => {
-      const input = {
-        project_name: 'basic',
-        service: 'search-console',
-        url: 'https://example.com'
-      };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
+    it('create: accepts search-console with url', () => {
+      const input = { project_name: 'basic', service: 'search-console', url: 'https://example.com' };
+      expect(ga4LinkCreateInputSchema.safeParse(input).success).toBe(true);
     });
 
-    it('requires gcp_project and dataset for bigquery service', () => {
-      const input = { project_name: 'basic', service: 'bigquery' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
-
-      const inputWithProject = {
-        project_name: 'basic',
-        service: 'bigquery',
-        gcp_project: 'my-project'
-      };
-      const result2 = ga4LinkInputSchema.safeParse(inputWithProject);
-      expect(result2.success).toBe(false);
+    it('create: requires gcp_project and dataset for bigquery service', () => {
+      expect(ga4LinkCreateInputSchema.safeParse({ project_name: 'basic', service: 'bigquery' }).success).toBe(false);
+      expect(
+        ga4LinkCreateInputSchema.safeParse({ project_name: 'basic', service: 'bigquery', gcp_project: 'my-project' })
+          .success,
+      ).toBe(false);
     });
 
-    it('accepts bigquery with gcp_project and dataset', () => {
+    it('create: accepts bigquery with gcp_project and dataset', () => {
       const input = {
         project_name: 'basic',
         service: 'bigquery',
         gcp_project: 'my-project',
-        dataset: 'analytics'
+        dataset: 'analytics',
       };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
+      expect(ga4LinkCreateInputSchema.safeParse(input).success).toBe(true);
     });
 
-    it('rejects invalid service value', () => {
-      const input = { project_name: 'basic', service: 'invalid-service' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
+    it('create: rejects invalid service value', () => {
+      expect(ga4LinkCreateInputSchema.safeParse({ project_name: 'basic', service: 'invalid' }).success).toBe(false);
     });
 
-    it('rejects invalid unlink value', () => {
-      const input = { project_name: 'basic', unlink: 'search-console' };
-      const result = ga4LinkInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
+    it('remove: accepts bigquery and channels', () => {
+      expect(ga4LinkRemoveInputSchema.safeParse({ project_name: 'basic', service: 'bigquery' }).success).toBe(true);
+      expect(ga4LinkRemoveInputSchema.safeParse({ project_name: 'basic', service: 'channels' }).success).toBe(true);
+    });
+
+    it('remove: rejects search-console (cannot unlink via API)', () => {
+      expect(ga4LinkRemoveInputSchema.safeParse({ project_name: 'basic', service: 'search-console' }).success).toBe(
+        false,
+      );
     });
   });
 
-  describe('buildLinkArgs', () => {
-    it('builds args for list operation', () => {
-      const input: GA4LinkInput = { project_name: 'my-project', list: true };
-      const args = buildLinkArgs(input);
-      expect(args).toEqual(['--project', 'my-project', '--list']);
+  describe('buildArgs', () => {
+    it('list', () => {
+      expect(buildLinkListArgs({ project_name: 'my-project' })).toEqual(['--project', 'my-project', '--list']);
     });
 
-    it('builds args for unlink operation', () => {
-      const input: GA4LinkInput = { project_name: 'my-project', unlink: 'bigquery' };
-      const args = buildLinkArgs(input);
-      expect(args).toEqual(['--project', 'my-project', '--unlink', 'bigquery']);
-    });
-
-    it('builds args for channels service', () => {
-      const input: GA4LinkInput = { project_name: 'my-project', service: 'channels' };
-      const args = buildLinkArgs(input);
-      expect(args).toEqual(['--project', 'my-project', '--service', 'channels']);
-    });
-
-    it('builds args for search-console with url', () => {
-      const input: GA4LinkInput = {
-        project_name: 'my-project',
-        service: 'search-console',
-        url: 'https://example.com'
-      };
-      const args = buildLinkArgs(input);
-      expect(args).toEqual([
-        '--project', 'my-project',
-        '--service', 'search-console',
-        '--url', 'https://example.com'
+    it('remove', () => {
+      expect(buildLinkRemoveArgs({ project_name: 'my-project', service: 'bigquery' })).toEqual([
+        '--project',
+        'my-project',
+        '--unlink',
+        'bigquery',
       ]);
     });
 
-    it('builds args for bigquery with gcp_project and dataset', () => {
-      const input: GA4LinkInput = {
+    it('create: channels service', () => {
+      expect(buildLinkCreateArgs({ project_name: 'my-project', service: 'channels' })).toEqual([
+        '--project',
+        'my-project',
+        '--service',
+        'channels',
+      ]);
+    });
+
+    it('create: search-console with url', () => {
+      const input: GA4LinkCreateInput = {
+        project_name: 'my-project',
+        service: 'search-console',
+        url: 'https://example.com',
+      };
+      expect(buildLinkCreateArgs(input)).toEqual([
+        '--project',
+        'my-project',
+        '--service',
+        'search-console',
+        '--url',
+        'https://example.com',
+      ]);
+    });
+
+    it('create: bigquery with gcp_project and dataset', () => {
+      const input: GA4LinkCreateInput = {
         project_name: 'my-project',
         service: 'bigquery',
         gcp_project: 'my-gcp-project',
-        dataset: 'analytics_dataset'
+        dataset: 'analytics_dataset',
       };
-      const args = buildLinkArgs(input);
-      expect(args).toEqual([
-        '--project', 'my-project',
-        '--service', 'bigquery',
-        '--gcp-project', 'my-gcp-project',
-        '--dataset', 'analytics_dataset'
+      expect(buildLinkCreateArgs(input)).toEqual([
+        '--project',
+        'my-project',
+        '--service',
+        'bigquery',
+        '--gcp-project',
+        'my-gcp-project',
+        '--dataset',
+        'analytics_dataset',
       ]);
     });
   });
 
-  describe('parseLinkOutput', () => {
-    describe('list operation', () => {
-      it('parses list output with BigQuery and Channel Groups', () => {
-        const output = `
+  describe('parseLinkListOutput', () => {
+    it('parses list output with BigQuery and Channel Groups', () => {
+      const output = `
 🔗 GA4 Manager - Link External Services
 ═══════════════════════════════════════════════
 📦 Project: MyProject (Property: 123456789)
@@ -165,26 +156,25 @@ Channel Groups:
   ✓ Paid Social Ads
 `;
 
-        const input: GA4LinkInput = { project_name: 'test', list: true };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkListOutput(output);
 
-        expect(result.success).toBe(true);
-        expect(result.operation).toBe('link');
-        expect(result.action).toBe('list');
-        expect(result.project?.name).toBe('MyProject');
-        expect(result.project?.property_id).toBe('123456789');
+      expect(result.success).toBe(true);
+      expect(result.operation).toBe('link');
+      expect(result.action).toBe('list');
+      expect(result.project?.name).toBe('MyProject');
+      expect(result.project?.property_id).toBe('123456789');
 
-        const listResults = result.results as any;
-        expect(listResults.search_console.status).toBe('manual_check_required');
-        expect(listResults.bigquery).toHaveLength(1);
-        expect(listResults.bigquery[0].project).toBe('my-gcp-project');
-        expect(listResults.bigquery[0].daily_export).toBe(true);
-        expect(listResults.bigquery[0].streaming_export).toBe(false);
-        expect(listResults.channel_groups).toHaveLength(2);
-      });
+      const listResults = result.results as any;
+      expect(listResults.search_console.status).toBe('manual_check_required');
+      expect(listResults.bigquery).toHaveLength(1);
+      expect(listResults.bigquery[0].project).toBe('my-gcp-project');
+      expect(listResults.bigquery[0].daily_export).toBe(true);
+      expect(listResults.bigquery[0].streaming_export).toBe(false);
+      expect(listResults.channel_groups).toHaveLength(2);
+    });
 
-      it('parses list output with no links', () => {
-        const output = `
+    it('parses list output with no links', () => {
+      const output = `
 🔗 GA4 Manager - Link External Services
 ═══════════════════════════════════════════════
 📦 Project: EmptyProject (Property: 987654321)
@@ -202,179 +192,129 @@ Channel Groups:
   ○ No custom channel groups found.
 `;
 
-        const input: GA4LinkInput = { project_name: 'test', list: true };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkListOutput(output);
 
-        expect(result.success).toBe(true);
-        const listResults = result.results as any;
-        expect(listResults.bigquery).toHaveLength(0);
-        expect(listResults.channel_groups).toHaveLength(0);
-      });
+      expect(result.success).toBe(true);
+      const listResults = result.results as any;
+      expect(listResults.bigquery).toHaveLength(0);
+      expect(listResults.channel_groups).toHaveLength(0);
     });
+  });
 
-    describe('link operation', () => {
-      it('parses successful bigquery link creation', () => {
-        const output = `
-🔗 GA4 Manager - Link External Services
-═══════════════════════════════════════════════
+  describe('parseLinkCreateOutput', () => {
+    it('parses successful bigquery link creation', () => {
+      const output = `
 📦 Project: MyProject (Property: 123456789)
-───────────────────────────────────────────────
-
 📊 Linking BigQuery...
 ✓ Successfully created BigQuery link: properties/123456789/bigQueryLinks/xyz123
 `;
 
-        const input: GA4LinkInput = {
-          project_name: 'test',
-          service: 'bigquery',
-          gcp_project: 'my-project',
-          dataset: 'analytics'
-        };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkCreateOutput(output, 'bigquery');
 
-        expect(result.success).toBe(true);
-        expect(result.action).toBe('link');
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('link');
 
-        const linkResult = result.results as any;
-        expect(linkResult.success).toBe(true);
-        expect(linkResult.service).toBe('bigquery');
-        expect(linkResult.message).toContain('created successfully');
-      });
+      const linkResult = result.results as any;
+      expect(linkResult.success).toBe(true);
+      expect(linkResult.service).toBe('bigquery');
+      expect(linkResult.message).toContain('created successfully');
+    });
 
-      it('parses bigquery link already exists', () => {
-        const output = `
-🔗 GA4 Manager - Link External Services
-═══════════════════════════════════════════════
+    it('parses bigquery link already exists', () => {
+      const output = `
 📦 Project: MyProject (Property: 123456789)
-───────────────────────────────────────────────
-
 📊 Linking BigQuery...
 ✓ A BigQuery link already exists for this property. No action taken.
 `;
 
-        const input: GA4LinkInput = {
-          project_name: 'test',
-          service: 'bigquery',
-          gcp_project: 'my-project',
-          dataset: 'analytics'
-        };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkCreateOutput(output, 'bigquery');
 
-        expect(result.success).toBe(true);
-        const linkResult = result.results as any;
-        expect(linkResult.success).toBe(true);
-        expect(linkResult.message).toContain('already exists');
-      });
+      expect(result.success).toBe(true);
+      const linkResult = result.results as any;
+      expect(linkResult.success).toBe(true);
+      expect(linkResult.message).toContain('already exists');
+    });
 
-      it('parses search console guide output', () => {
-        const output = `
-🔗 GA4 Manager - Link External Services
-═══════════════════════════════════════════════
+    it('parses search console guide output', () => {
+      const output = `
 📦 Project: MyProject (Property: 123456789)
-───────────────────────────────────────────────
-
 🔗 Search Console Link Setup Guide
-...guide content...
 ℹ The GA4 Admin API does not support programmatic Search Console linking. Please follow the manual steps above.
 `;
 
-        const input: GA4LinkInput = {
-          project_name: 'test',
-          service: 'search-console',
-          url: 'https://example.com'
-        };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkCreateOutput(output, 'search-console');
 
-        expect(result.success).toBe(true);
-        const linkResult = result.results as any;
-        expect(linkResult.success).toBe(true);
-        expect(linkResult.action).toBe('guide');
-        expect(linkResult.service).toBe('search-console');
-      });
-
-      it('parses channels setup completion', () => {
-        const output = `
-🔗 GA4 Manager - Link External Services
-═══════════════════════════════════════════════
-📦 Project: MyProject (Property: 123456789)
-───────────────────────────────────────────────
-
-📡 Setting up default Channel Groups...
-✓ Channel group setup process completed.
-Please check the output above for the status of each channel group.
-`;
-
-        const input: GA4LinkInput = { project_name: 'test', service: 'channels' };
-        const result = parseLinkOutput(output, input);
-
-        expect(result.success).toBe(true);
-        const linkResult = result.results as any;
-        expect(linkResult.success).toBe(true);
-        expect(linkResult.service).toBe('channels');
-        expect(linkResult.message).toContain('completed');
-      });
+      expect(result.success).toBe(true);
+      const linkResult = result.results as any;
+      expect(linkResult.success).toBe(true);
+      expect(linkResult.action).toBe('guide');
+      expect(linkResult.service).toBe('search-console');
     });
 
-    describe('unlink operation', () => {
-      it('parses successful bigquery unlink', () => {
-        const output = `
-🔗 GA4 Manager - Link External Services
-═══════════════════════════════════════════════
+    it('parses channels setup completion', () => {
+      const output = `
 📦 Project: MyProject (Property: 123456789)
-───────────────────────────────────────────────
+📡 Setting up default Channel Groups...
+✓ Channel group setup process completed.
+`;
 
+      const result = parseLinkCreateOutput(output, 'channels');
+
+      expect(result.success).toBe(true);
+      const linkResult = result.results as any;
+      expect(linkResult.success).toBe(true);
+      expect(linkResult.service).toBe('channels');
+      expect(linkResult.message).toContain('completed');
+    });
+  });
+
+  describe('parseLinkRemoveOutput', () => {
+    it('parses successful bigquery unlink', () => {
+      const output = `
+📦 Project: MyProject (Property: 123456789)
 🔓 Unlinking service: bigquery
 Deleting link: properties/123456789/bigQueryLinks/xyz123
 ✓ Successfully deleted properties/123456789/bigQueryLinks/xyz123
 `;
 
-        const input: GA4LinkInput = { project_name: 'test', unlink: 'bigquery' };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkRemoveOutput(output, 'bigquery');
 
-        expect(result.success).toBe(true);
-        expect(result.action).toBe('unlink');
+      expect(result.success).toBe(true);
+      expect(result.action).toBe('unlink');
 
-        const unlinkResult = result.results as any;
-        expect(unlinkResult.success).toBe(true);
-        expect(unlinkResult.service).toBe('bigquery');
-        expect(unlinkResult.action).toBe('unlink');
-      });
+      const unlinkResult = result.results as any;
+      expect(unlinkResult.success).toBe(true);
+      expect(unlinkResult.service).toBe('bigquery');
+      expect(unlinkResult.action).toBe('unlink');
+    });
 
-      it('parses no links to unlink', () => {
-        const output = `
-🔗 GA4 Manager - Link External Services
-═══════════════════════════════════════════════
+    it('parses no links to unlink', () => {
+      const output = `
 📦 Project: MyProject (Property: 123456789)
-───────────────────────────────────────────────
-
 🔓 Unlinking service: channels
 No custom channel groups found to unlink.
 `;
 
-        const input: GA4LinkInput = { project_name: 'test', unlink: 'channels' };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkRemoveOutput(output, 'channels');
 
-        expect(result.success).toBe(true);
-        const unlinkResult = result.results as any;
-        expect(unlinkResult.success).toBe(true);
-        expect(unlinkResult.message).toContain('No');
-      });
+      expect(result.success).toBe(true);
+      const unlinkResult = result.results as any;
+      expect(unlinkResult.success).toBe(true);
+      expect(unlinkResult.message).toContain('No');
     });
+  });
 
-    describe('error handling', () => {
-      it('handles error output', () => {
-        const output = `
+  describe('error handling', () => {
+    it('handles error output', () => {
+      const output = `
 🔗 GA4 Manager - Link External Services
-═══════════════════════════════════════════════
 Error: failed to create GA4 client: missing credentials
 `;
 
-        const input: GA4LinkInput = { project_name: 'test', service: 'channels' };
-        const result = parseLinkOutput(output, input);
+      const result = parseLinkCreateOutput(output, 'channels');
 
-        expect(result.success).toBe(false);
-        expect(result.error).toContain('missing credentials');
-      });
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('missing credentials');
     });
   });
 });

--- a/mcp/src/tools/ga4-link.ts
+++ b/mcp/src/tools/ga4-link.ts
@@ -1,63 +1,58 @@
 import { z } from 'zod';
 
 /**
- * Input schema for ga4_link tool
+ * ga4_link is split into three operation-specific tools so that a single
+ * tool never mixes safe (read) and unsafe (write/delete) operations:
  *
- * Links external services to GA4 properties:
- * - search-console: Generates setup guide for Search Console linking
- * - bigquery: Creates/manages BigQuery export links
- * - channels: Sets up default channel groupings
+ * - ga4_link_list   — read existing links (safe)
+ * - ga4_link_create — create a BigQuery/Channels link or SC guide (write)
+ * - ga4_link_remove — unlink an existing BigQuery/Channels link (destructive)
  *
- * Operations:
- * - Link a service (requires project_name + service)
- * - List existing links (requires project_name + list)
- * - Unlink a service (requires project_name + unlink)
+ * All three dispatch to the same `ga4 link` CLI subcommand with different
+ * flags, so the Go CLI is unchanged.
  */
-export const ga4LinkInputSchema = z.object({
-  /** Config file name (without .yaml) - required for all operations */
-  project_name: z.string(),
-  /** Service to link */
-  service: z.enum(['search-console', 'bigquery', 'channels']).optional(),
-  /** Site URL for Search Console linking */
-  url: z.string().optional(),
-  /** GCP Project ID for BigQuery linking */
-  gcp_project: z.string().optional(),
-  /** BigQuery dataset ID */
-  dataset: z.string().optional(),
-  /** List existing links */
-  list: z.boolean().optional(),
-  /** Service to unlink */
-  unlink: z.enum(['bigquery', 'channels']).optional(),
-}).refine(
-  (data) => data.service || data.list || data.unlink,
-  {
-    error: 'At least one of service, list, or unlink must be provided',
-  }
-).refine(
-  (data) => {
-    // If service is search-console, url is required
-    if (data.service === 'search-console' && !data.url) {
-      return false;
-    }
-    return true;
-  },
-  {
-    error: 'url is required when service is search-console',
-  }
-).refine(
-  (data) => {
-    // If service is bigquery, gcp_project and dataset are required
-    if (data.service === 'bigquery' && (!data.gcp_project || !data.dataset)) {
-      return false;
-    }
-    return true;
-  },
-  {
-    error: 'gcp_project and dataset are required when service is bigquery',
-  }
-);
 
-export type GA4LinkInput = z.infer<typeof ga4LinkInputSchema>;
+// ── Input schemas ────────────────────────────────────────────────────────────
+
+/** List existing links for all services. */
+export const ga4LinkListInputSchema = z.object({
+  /** Config file name (without .yaml) */
+  project_name: z.string(),
+});
+export type GA4LinkListInput = z.infer<typeof ga4LinkListInputSchema>;
+
+/** Create/manage a link for one service. */
+export const ga4LinkCreateInputSchema = z
+  .object({
+    /** Config file name (without .yaml) */
+    project_name: z.string(),
+    /** Service to link */
+    service: z.enum(['search-console', 'bigquery', 'channels']),
+    /** Site URL for Search Console linking */
+    url: z.string().optional(),
+    /** GCP Project ID for BigQuery linking */
+    gcp_project: z.string().optional(),
+    /** BigQuery dataset ID */
+    dataset: z.string().optional(),
+  })
+  .refine((data) => data.service !== 'search-console' || !!data.url, {
+    error: 'url is required when service is search-console',
+  })
+  .refine((data) => data.service !== 'bigquery' || (!!data.gcp_project && !!data.dataset), {
+    error: 'gcp_project and dataset are required when service is bigquery',
+  });
+export type GA4LinkCreateInput = z.infer<typeof ga4LinkCreateInputSchema>;
+
+/** Unlink an existing link. Search Console links cannot be removed via the API. */
+export const ga4LinkRemoveInputSchema = z.object({
+  /** Config file name (without .yaml) */
+  project_name: z.string(),
+  /** Service to unlink */
+  service: z.enum(['bigquery', 'channels']),
+});
+export type GA4LinkRemoveInput = z.infer<typeof ga4LinkRemoveInputSchema>;
+
+// ── Output types ─────────────────────────────────────────────────────────────
 
 /**
  * BigQuery link information
@@ -126,77 +121,68 @@ export interface LinkOutput {
   error?: string;
 }
 
-/**
- * Build CLI arguments from input
- *
- * @param input - Validated input
- * @returns Array of CLI arguments
- */
-export function buildLinkArgs(input: GA4LinkInput): string[] {
-  const args: string[] = ['--project', input.project_name];
+// ── Build CLI arguments ──────────────────────────────────────────────────────
 
-  if (input.list) {
-    args.push('--list');
-  } else if (input.unlink) {
-    args.push('--unlink', input.unlink);
-  } else if (input.service) {
-    args.push('--service', input.service);
+export function buildLinkListArgs(input: GA4LinkListInput): string[] {
+  return ['--project', input.project_name, '--list'];
+}
 
-    if (input.service === 'search-console' && input.url) {
-      args.push('--url', input.url);
+export function buildLinkCreateArgs(input: GA4LinkCreateInput): string[] {
+  const args: string[] = ['--project', input.project_name, '--service', input.service];
+
+  if (input.service === 'search-console' && input.url) {
+    args.push('--url', input.url);
+  }
+
+  if (input.service === 'bigquery') {
+    if (input.gcp_project) {
+      args.push('--gcp-project', input.gcp_project);
     }
-
-    if (input.service === 'bigquery') {
-      if (input.gcp_project) {
-        args.push('--gcp-project', input.gcp_project);
-      }
-      if (input.dataset) {
-        args.push('--dataset', input.dataset);
-      }
+    if (input.dataset) {
+      args.push('--dataset', input.dataset);
     }
   }
 
   return args;
 }
 
-/**
- * Parse CLI output into structured LinkOutput
- *
- * Handles three types of operations:
- * - List: Parses existing links for all services
- * - Link: Parses link creation result
- * - Unlink: Parses unlink operation result
- *
- * @param output - Raw CLI output
- * @param input - Original input for context
- * @returns Structured link output
- */
-export function parseLinkOutput(output: string, input: GA4LinkInput): LinkOutput {
-  const result: LinkOutput = {
-    success: true,
-    operation: 'link',
-    action: input.list ? 'list' : input.unlink ? 'unlink' : 'link',
-  };
+export function buildLinkRemoveArgs(input: GA4LinkRemoveInput): string[] {
+  return ['--project', input.project_name, '--unlink', input.service];
+}
 
-  // Check for errors
+// ── Parse CLI output ─────────────────────────────────────────────────────────
+
+/** Shared prelude: detect a top-level error, else extract project info. */
+function startResult(output: string, action: LinkOutput['action']): LinkOutput {
+  const result: LinkOutput = { success: true, operation: 'link', action };
   const errorMatch = output.match(/Error:\s*(.+)/);
   if (errorMatch) {
     result.success = false;
     result.error = errorMatch[1].trim();
     return result;
   }
-
-  // Extract project info
   result.project = extractProjectInfo(output);
+  return result;
+}
 
-  if (input.list) {
-    result.results = parseListOutput(output);
-  } else if (input.unlink) {
-    result.results = parseUnlinkOutput(output, input.unlink);
-  } else if (input.service) {
-    result.results = parseLinkServiceOutput(output, input.service);
-  }
+export function parseLinkListOutput(output: string): LinkOutput {
+  const result = startResult(output, 'list');
+  if (!result.success) return result;
+  result.results = parseListOutput(output);
+  return result;
+}
 
+export function parseLinkCreateOutput(output: string, service: GA4LinkCreateInput['service']): LinkOutput {
+  const result = startResult(output, 'link');
+  if (!result.success) return result;
+  result.results = parseLinkServiceOutput(output, service);
+  return result;
+}
+
+export function parseLinkRemoveOutput(output: string, service: GA4LinkRemoveInput['service']): LinkOutput {
+  const result = startResult(output, 'unlink');
+  if (!result.success) return result;
+  result.results = parseUnlinkOutput(output, service);
   return result;
 }
 
@@ -408,12 +394,35 @@ function extractSection(output: string, startMarker: string, endMarker: string |
     : output.slice(startIdx, endIdx);
 }
 
-/**
- * MCP Tool definition for ga4_link
- */
-export const ga4LinkTool = {
-  name: 'ga4_link',
-  description: 'Link external services to GA4 property (Search Console, BigQuery, Channel Groups)',
+// ── MCP tool definitions ─────────────────────────────────────────────────────
+
+export const ga4LinkListTool = {
+  name: 'ga4_link_list',
+  description:
+    'List existing external-service links for a GA4 property: BigQuery export links and custom Channel Groups. ' +
+    '(Search Console links cannot be listed via the GA4 Admin API and are reported as requiring a manual check.)',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      project_name: {
+        type: 'string',
+        description: 'Config file name (without .yaml) - required',
+      },
+    },
+    required: ['project_name'] as const,
+  },
+  annotations: {
+    title: 'List GA4 service links',
+    readOnlyHint: true,
+  },
+};
+
+export const ga4LinkCreateTool = {
+  name: 'ga4_link_create',
+  description:
+    'Create an external-service link for a GA4 property. service=bigquery creates a BigQuery export link ' +
+    '(requires gcp_project + dataset); service=channels sets up default Channel Groups; ' +
+    'service=search-console returns a manual setup guide (the Admin API cannot link Search Console programmatically).',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -438,16 +447,42 @@ export const ga4LinkTool = {
         type: 'string',
         description: 'BigQuery dataset ID (required for bigquery)',
       },
-      list: {
-        type: 'boolean',
-        description: 'List existing links for all services',
+    },
+    required: ['project_name', 'service'] as const,
+  },
+  annotations: {
+    title: 'Create GA4 service link',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
+};
+
+export const ga4LinkRemoveTool = {
+  name: 'ga4_link_remove',
+  description:
+    'Remove (unlink) an existing external-service link from a GA4 property. ' +
+    'service=bigquery deletes the BigQuery export link; service=channels removes custom Channel Groups. ' +
+    'Search Console links cannot be removed via the Admin API.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      project_name: {
+        type: 'string',
+        description: 'Config file name (without .yaml) - required',
       },
-      unlink: {
+      service: {
         type: 'string',
         enum: ['bigquery', 'channels'],
         description: 'Service to unlink (removes existing link)',
       },
     },
-    required: ['project_name'] as const,
+    required: ['project_name', 'service'] as const,
+  },
+  annotations: {
+    title: 'Remove GA4 service link',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
   },
 };

--- a/mcp/src/tools/ga4-report.ts
+++ b/mcp/src/tools/ga4-report.ts
@@ -516,4 +516,8 @@ export const ga4ReportTool = {
     // Note: Zod schema handles mutual exclusivity validation
     // MCP doesn't support oneOf at top level
   },
+  annotations: {
+    title: 'Run GA4 report',
+    readOnlyHint: true,
+  },
 };

--- a/mcp/src/tools/ga4-setup.ts
+++ b/mcp/src/tools/ga4-setup.ts
@@ -331,4 +331,9 @@ export const ga4SetupTool = {
     // Note: Zod schema handles mutual exclusivity validation
     // MCP doesn't support oneOf at top level
   },
+  annotations: {
+    title: 'Set up GA4/GSC from config',
+    readOnlyHint: false,
+    destructiveHint: true,
+  },
 };

--- a/mcp/src/tools/ga4-validate.ts
+++ b/mcp/src/tools/ga4-validate.ts
@@ -419,4 +419,8 @@ export const ga4ValidateTool = {
     // Note: Zod schema handles mutual exclusivity validation
     // MCP doesn't support oneOf at top level
   },
+  annotations: {
+    title: 'Validate GA4 configuration',
+    readOnlyHint: true,
+  },
 };

--- a/mcp/src/tools/gsc-analytics.ts
+++ b/mcp/src/tools/gsc-analytics.ts
@@ -559,6 +559,10 @@ export const gscAnalyticsRunTool = {
     // Note: Zod schema handles mutual exclusivity validation
     // MCP doesn't support oneOf at top level
   },
+  annotations: {
+    title: 'Run Search Console analytics',
+    readOnlyHint: true,
+  },
 };
 
 // ============================================================================

--- a/mcp/src/tools/gsc-cannibalization.ts
+++ b/mcp/src/tools/gsc-cannibalization.ts
@@ -170,4 +170,8 @@ export const gscCannibalizationTool = {
       },
     },
   },
+  annotations: {
+    title: 'Detect keyword cannibalization',
+    readOnlyHint: true,
+  },
 } as const

--- a/mcp/src/tools/gsc-coverage.ts
+++ b/mcp/src/tools/gsc-coverage.ts
@@ -431,6 +431,10 @@ export const gscIndexCoverageTool = {
       },
     },
   },
+  annotations: {
+    title: 'Search Console index coverage',
+    readOnlyHint: true,
+  },
 };
 
 // ============================================================================

--- a/mcp/src/tools/gsc-ctr-anomaly.ts
+++ b/mcp/src/tools/gsc-ctr-anomaly.ts
@@ -144,4 +144,5 @@ export const gscCTRAnomalyTool = {
       },
     },
   },
+  annotations: { title: 'Detect CTR anomalies', readOnlyHint: true },
 } as const

--- a/mcp/src/tools/gsc-health.ts
+++ b/mcp/src/tools/gsc-health.ts
@@ -121,4 +121,5 @@ export const gscHealthTool = {
       },
     },
   },
+  annotations: { title: 'Search Console health check', readOnlyHint: true },
 } as const

--- a/mcp/src/tools/gsc-inspect.ts
+++ b/mcp/src/tools/gsc-inspect.ts
@@ -455,6 +455,11 @@ export const gscInspectUrlTool = {
     },
     required: ['site', 'url'],
   },
+  annotations: {
+    title: 'Inspect URL in Search Console',
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
 };
 
 // ============================================================================

--- a/mcp/src/tools/gsc-monitor.ts
+++ b/mcp/src/tools/gsc-monitor.ts
@@ -642,6 +642,7 @@ export const gscMonitorUrlsTool = {
       },
     },
   },
+  annotations: { title: 'Monitor URLs in Search Console', readOnlyHint: true, openWorldHint: true },
 };
 
 // ============================================================================

--- a/mcp/src/tools/gsc-opportunities.ts
+++ b/mcp/src/tools/gsc-opportunities.ts
@@ -144,4 +144,8 @@ export const gscOpportunitiesTool = {
       },
     },
   },
+  annotations: {
+    title: 'Find SEO opportunities',
+    readOnlyHint: true,
+  },
 } as const

--- a/mcp/src/tools/gsc-sitemaps.test.ts
+++ b/mcp/src/tools/gsc-sitemaps.test.ts
@@ -67,15 +67,15 @@ describe('gsc_sitemaps_list tool', () => {
 
   describe('parseSitemapsListOutput', () => {
     it('parses successful output with multiple sitemaps', () => {
+      // The CLI renders this table with tabwriter (2-space-padded columns),
+      // not pipe-delimited markdown. Columns: URL, URLs, Errors, Warnings,
+      // Last Submitted, Status.
       const output = `
 Listing sitemaps for sc-domain:example.com
-+--------------------------------------+------+--------+----------+------------------+--------+
-|             SITEMAP URL              | URLS | ERRORS | WARNINGS |  LAST SUBMITTED  | STATUS |
-+--------------------------------------+------+--------+----------+------------------+--------+
-| https://example.com/sitemap.xml      |  150 |      0 |        0 | 2024-01-15 10:30 | OK     |
-| https://example.com/sitemap-blog.xml |   45 |      0 |        2 | 2024-01-14 08:00 | Warnings: 2 |
-| https://example.com/sitemap-news.xml |   30 |      1 |        0 | 2024-01-13 12:15 | Errors: 1   |
-+--------------------------------------+------+--------+----------+------------------+--------+
+Sitemap URL                            URLs  Errors  Warnings  Last Submitted    Status
+https://example.com/sitemap.xml        150   0       0         2024-01-15 10:30  OK
+https://example.com/sitemap-blog.xml   45    0       2         2024-01-14 08:00  Warnings: 2
+https://example.com/sitemap-news.xml   30    1       0         2024-01-13 12:15  Errors: 1
 
 Found 3 sitemap(s)
 `;
@@ -111,11 +111,8 @@ No sitemaps found for this site
     it('parses output with sitemap index', () => {
       const output = `
 Listing sitemaps for sc-domain:example.com
-+----------------------------------------+------+--------+----------+------------------+--------+
-|              SITEMAP URL               | URLS | ERRORS | WARNINGS |  LAST SUBMITTED  | STATUS |
-+----------------------------------------+------+--------+----------+------------------+--------+
-| https://example.com/sitemap.xml (Index) |  500 |      0 |        0 | 2024-01-15 10:30 | OK     |
-+----------------------------------------+------+--------+----------+------------------+--------+
+Sitemap URL                               URLs  Errors  Warnings  Last Submitted    Status
+https://example.com/sitemap.xml (Index)   500   0       0         2024-01-15 10:30  OK
 
 Found 1 sitemap(s)
 `;
@@ -130,11 +127,8 @@ Found 1 sitemap(s)
     it('parses output with pending status', () => {
       const output = `
 Listing sitemaps for sc-domain:example.com
-+----------------------------------------+------+--------+----------+------------------+---------+
-|              SITEMAP URL               | URLS | ERRORS | WARNINGS |  LAST SUBMITTED  | STATUS  |
-+----------------------------------------+------+--------+----------+------------------+---------+
-| https://example.com/sitemap.xml        |    0 |      0 |        0 | 2024-01-15 10:30 | Pending |
-+----------------------------------------+------+--------+----------+------------------+---------+
+Sitemap URL                       URLs  Errors  Warnings  Last Submitted    Status
+https://example.com/sitemap.xml   0     0       0         2024-01-15 10:30  Pending
 
 Found 1 sitemap(s)
 `;

--- a/mcp/src/tools/gsc-sitemaps.ts
+++ b/mcp/src/tools/gsc-sitemaps.ts
@@ -132,6 +132,10 @@ export const gscSitemapsListTool = {
     },
     required: ['site'],
   },
+  annotations: {
+    title: 'List sitemaps',
+    readOnlyHint: true,
+  },
 };
 
 // ============================================================================
@@ -224,6 +228,12 @@ export const gscSitemapsSubmitTool = {
     },
     required: ['site', 'url'],
   },
+  annotations: {
+    title: 'Submit a sitemap',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  },
 };
 
 // ============================================================================
@@ -315,6 +325,12 @@ export const gscSitemapsDeleteTool = {
       },
     },
     required: ['site', 'url'],
+  },
+  annotations: {
+    title: 'Delete a sitemap',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: true,
   },
 };
 
@@ -487,6 +503,10 @@ export const gscSitemapsGetTool = {
       },
     },
     required: ['site', 'url'],
+  },
+  annotations: {
+    title: 'Get sitemap details',
+    readOnlyHint: true,
   },
 };
 

--- a/mcp/src/tools/gsc-traffic-compare.ts
+++ b/mcp/src/tools/gsc-traffic-compare.ts
@@ -392,4 +392,5 @@ export const gscTrafficCompareTool = {
       },
     },
   },
+  annotations: { title: 'Compare Search Console traffic', readOnlyHint: true },
 }

--- a/mcp/src/tools/seo-audit-batch.ts
+++ b/mcp/src/tools/seo-audit-batch.ts
@@ -255,7 +255,7 @@ export const seoAuditBatchTool = {
   description:
     'Audit many pages at once for SEO problems (missing title/description, bad canonical, noindex, redirect issues, HTTP errors). ' +
     'Provide an explicit urls[] list and/or a sitemap URL (sitemap-index files are followed and expanded). ' +
-    'Runs the single-page auditor over each URL with bounded concurrency and returns per-URL results plus a summary. ' +
+    'Runs the single-page auditor over each URL with bounded concurrency, fetching each supplied URL over HTTP, and returns per-URL results plus a summary. ' +
     'Optionally fetches Core Web Vitals via PageSpeed Insights (needs a PSI key; set PSI_API_KEY or pass psi_api_key).',
   inputSchema: {
     type: 'object',
@@ -305,4 +305,5 @@ export const seoAuditBatchTool = {
       },
     },
   },
+  annotations: { title: 'Batch SEO page audit', readOnlyHint: true, openWorldHint: true },
 }

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -378,7 +378,7 @@ export const seoPageAuditTool = {
   name: 'seo_page_audit',
   description:
     'Use when auditing a single page for SEO problems: missing title or description, bad canonical, noindex directives, missing OG image, heading structure issues, redirect chain problems. ' +
-    'Fetches the URL with manual redirect tracing (max 5 hops), parses on-page signals (title, meta description, canonical, robots, Open Graph, Schema.org types, h1/h2 counts, hreflang). ' +
+    'Fetches the given URL over HTTP with manual redirect tracing (max 5 hops), parses on-page signals (title, meta description, canonical, robots, Open Graph, Schema.org types, h1/h2 counts, hreflang). ' +
     'Returns a structured issues list with severity (error/warning/info) and the full redirect chain. ' +
     'Optionally checks Core Web Vitals via PageSpeed Insights API.',
   inputSchema: {
@@ -426,4 +426,5 @@ export const seoPageAuditTool = {
       },
     },
   },
+  annotations: { title: 'Audit a page for SEO', readOnlyHint: true, openWorldHint: true },
 }

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // Only run tests from source. Without this, the compiled copies under
+    // dist/ (produced by `npm run build`) are discovered and run too,
+    // doubling the suite and double-counting failures.
+    exclude: ['node_modules/**', 'dist/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
Hardens the `mcp/` server against the Claude connector **directory review criteria** and fixes the startup crash seen in the MCP logs. **No Go CLI changes** — everything is under `mcp/`.

### Startup / binary resolution
- Resolve the `ga4` binary from **PATH** when neither `GA4_BINARY_PATH` nor the repo-root `./ga4` exists, so a globally installed CLI works without a symlink (order: `GA4_BINARY_PATH` → repo-root `../../ga4` → `ga4` on PATH).
- `serverInfo.version` now reads from `package.json` (was hard-coded `1.0.0`).
- Attach error `cause` when the binary is unusable.

### Directory-review hardening
- **Annotations on all tools** — `title` + `readOnlyHint`/`destructiveHint`/`idempotentHint`/`openWorldHint` (drive auto-permissions; required for submission).
- **BREAKING:** split `ga4_link` → `ga4_link_list` (read) / `ga4_link_create` (write) / `ga4_link_remove` (destructive) so no single tool mixes safe and unsafe operations. All three dispatch to the same `ga4 link` CLI command.
- Name the HTTP-fetch behavior in `seo_page_audit` / `seo_audit_batch` descriptions.

### Tests & tooling
- Rewrote `ga4_link` tests for the split tools (+25 cases).
- Fixed stale `gsc_sitemaps_list` fixtures to the real `tabwriter` format (parser was correct; fixtures used a pipe table the CLI never emits).
- Excluded `dist/` from vitest so compiled test copies don't double-run.
- Updated README / PERMISSIONS / CHANGELOG for the `ga4_link` split.

## Verification
- `npm run build` ✓ · `npm run lint` ✓
- **746 tests pass, 0 failures**
- Live `tools/list`: 23 tools, all annotated, old `ga4_link` gone, 3 split tools present.

## Note
`mcp/package.json` is still `2.4.0` with a `[Unreleased]` CHANGELOG section containing a BREAKING change — you may want to bump the MCP version before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)