### PR TITLE
feat(mcp): MCPB packaging + fix dropped rows in GSC report tools (v3.1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ node_modules/
 mcp/dist/
 .vite/
 
+# MCPB bundle staging & packed artifacts (mcp/)
+mcp/build/
+mcp/dist-mcpb/
+
 # IDE
 .vscode/
 .idea/

--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the GA4 Manager MCP Server will be documented in this fil
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0] - 2026-06-24
+
+### Added
+
+- **MCPB bundle packaging.** `npm run pack:mcpb` builds a self-contained `.mcpb` (compiled server + production `node_modules` staged via `pnpm deploy`, plus a prebuilt per-platform `ga4` binary) that installs in Claude Desktop without Node or Go. Credentials are supplied per-install through `manifest.json` `user_config` — no secrets are baked into the bundle. Pass a target to cross-compile, e.g. `npm run pack:mcpb linux/amd64`.
+
+### Fixed
+
+- **`gsc_analytics_run` and `gsc_index_coverage` now return their per-row arrays.** Both omitted `--format json` when calling the CLI (whose default format is `table`), so the table parser ran and silently dropped `rows[]` / `pages_sample[]`, leaving only aggregates regardless of the requested format. They now always request JSON, and JSON detection tolerates the CLI's status-line preamble.
+- **`seo_page_audit` treats an empty `PSI_API_KEY` as unset.** The MCPB manifest always sets the env var, so an unconfigured key arrived as `""`; it no longer disables Core Web Vitals.
+- **Test suite excludes `build/` and `dist-mcpb/`** so the staged bundle's vendored `*.test.ts` files (e.g. zod's) are not picked up.
+
+### Changed
+
+- **Removed the no-op `format` parameter** from `gsc_analytics_run` and `gsc_index_coverage`. These MCP tools always return structured JSON; the parameter never changed the result. Unknown keys are ignored, so callers still passing `format` are unaffected.
+
 ## [3.0.0] - 2026-06-24
 
 ### Changed

--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://raw.githubusercontent.com/anthropics/mcpb/main/schemas/mcpb-manifest-v0.4.schema.json",
+  "manifest_version": "0.4",
+  "name": "ga4-manager-mcp",
+  "display_name": "GA4 Manager",
+  "version": "3.0.0",
+  "description": "Manage GA4 properties and audit Search Console / SEO from Claude.",
+  "long_description": "Exposes the GA4 Manager toolkit as MCP tools: GA4 property setup, reporting, cleanup and data-stream linking (via a bundled `ga4` CLI), Search Console analytics, coverage, cannibalization, CTR-anomaly and URL inspection, plus native SEO page/batch audits and consent-health checks. Runs locally so it can read your Google service-account credentials and talk to the Admin/Search Console APIs on your behalf.",
+  "author": {
+    "name": "Oscar Gallego",
+    "email": "ai@oscargallegoruiz.com"
+  },
+  "homepage": "https://github.com/garbarok/ga4-manager",
+  "documentation": "https://github.com/garbarok/ga4-manager/tree/main/mcp",
+  "icon": "icon.png",
+  "server": {
+    "type": "node",
+    "entry_point": "server/dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/dist/index.js"],
+      "env": {
+        "GA4_BINARY_PATH": "${__dirname}/bin/ga4",
+        "GOOGLE_APPLICATION_CREDENTIALS": "${user_config.credentials}",
+        "GOOGLE_CLOUD_PROJECT": "${user_config.project}",
+        "PSI_API_KEY": "${user_config.psi_api_key}"
+      }
+    }
+  },
+  "user_config": {
+    "credentials": {
+      "type": "file",
+      "title": "Google credentials JSON",
+      "description": "Service-account key file, or an Application Default Credentials file (~/.config/gcloud/application_default_credentials.json).",
+      "required": true
+    },
+    "project": {
+      "type": "string",
+      "title": "Google Cloud project ID",
+      "description": "The GCP project that owns the GA4 / Search Console access.",
+      "required": true
+    },
+    "psi_api_key": {
+      "type": "string",
+      "title": "PageSpeed Insights API key (optional)",
+      "description": "Enables Core Web Vitals in SEO audits. Leave blank to skip CWV.",
+      "sensitive": true,
+      "required": false
+    }
+  },
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=18.0.0"
+    }
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ga4-manager-mcp",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "MCP server for GA4 Manager - Analytics and Search Console tools",
   "type": "module",
   "main": "dist/index.js",
@@ -10,7 +10,8 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:watch": "vitest watch",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "pack:mcpb": "bash scripts/build-mcpb.sh"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp/scripts/build-mcpb.sh
+++ b/mcp/scripts/build-mcpb.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Build a packaged MCPB bundle for the GA4 Manager MCP server.
+#
+# The bundle ships its own runtime: the compiled Node server, its production
+# node_modules, and a prebuilt `ga4` Go binary for ONE target platform. The
+# manifest points GA4_BINARY_PATH at the bundled binary, so the user installs a
+# single .mcpb file and needs neither Node nor Go.
+#
+# Usage:
+#   scripts/build-mcpb.sh                # build for the host platform
+#   scripts/build-mcpb.sh linux/amd64    # cross-compile for another platform
+#   scripts/build-mcpb.sh darwin/arm64
+#
+# Output: dist-mcpb/ga4-manager-mcp-<goos>-<goarch>.mcpb
+set -euo pipefail
+
+# ---- paths -----------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MCP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$MCP_DIR/.." && pwd)"
+STAGE="$MCP_DIR/build/mcpb"
+DEPLOY="$MCP_DIR/build/deploy"
+OUT_DIR="$MCP_DIR/dist-mcpb"
+
+# ---- resolve target platform ----------------------------------------------
+TARGET="${1:-$(go env GOOS)/$(go env GOARCH)}"
+GOOS="${TARGET%%/*}"
+GOARCH="${TARGET##*/}"
+
+# Map Go's GOOS to the MCPB platform vocabulary (darwin/linux/win32).
+case "$GOOS" in
+  darwin) MCPB_PLATFORM="darwin" ;;
+  linux)  MCPB_PLATFORM="linux" ;;
+  windows) MCPB_PLATFORM="win32" ;;
+  *) echo "Unsupported GOOS: $GOOS" >&2; exit 1 ;;
+esac
+
+GA4_BIN="ga4"
+[ "$GOOS" = "windows" ] && GA4_BIN="ga4.exe"
+
+echo ">> Building MCPB for $GOOS/$GOARCH (mcpb platform: $MCPB_PLATFORM)" >&2
+
+# ---- 1. compile the Node server -------------------------------------------
+echo ">> tsc build" >&2
+( cd "$MCP_DIR" && pnpm run build >/dev/null )
+
+# ---- 2. stage the server + production deps ---------------------------------
+# `pnpm deploy` resolves the production dependency closure from the workspace
+# lockfile and materialises it as real files (hoisted linker → no store
+# symlinks), so the bundle is self-contained and portable. It copies the whole
+# package dir, though, so we deploy to a temp dir and cherry-pick just the
+# runtime bits (compiled JS + package.json + node_modules) into the bundle.
+echo ">> staging server/ via pnpm deploy (prod, hoisted)" >&2
+rm -rf "$STAGE" "$DEPLOY"
+mkdir -p "$STAGE/server" "$STAGE/bin"
+( cd "$MCP_DIR" && pnpm --filter ga4-manager-mcp deploy --prod --legacy \
+    --config.node-linker=hoisted "$DEPLOY" >/dev/null 2>&1 )
+mv "$DEPLOY/node_modules" "$STAGE/server/node_modules"
+cp "$DEPLOY/package.json" "$STAGE/server/package.json"
+cp -R "$MCP_DIR/dist" "$STAGE/server/dist"
+rm -rf "$STAGE/server/node_modules/.bin"   # dev CLI shims; the server needs none
+rm -rf "$DEPLOY"
+
+# ---- 3. cross-compile the ga4 Go binary -----------------------------------
+echo ">> go build ga4 -> bin/$GA4_BIN" >&2
+( cd "$REPO_ROOT" && GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 \
+    go build -trimpath -ldflags="-s -w" -o "$STAGE/bin/$GA4_BIN" . )
+chmod +x "$STAGE/bin/$GA4_BIN" 2>/dev/null || true
+
+# ---- 4. stage the manifest (sync version, pin platform, handle icon) -------
+echo ">> assembling manifest.json" >&2
+cp "$MCP_DIR/manifest.json" "$STAGE/manifest.json"
+if [ -f "$MCP_DIR/icon.png" ]; then
+  cp "$MCP_DIR/icon.png" "$STAGE/icon.png"
+  HAS_ICON=1
+else
+  HAS_ICON=0
+fi
+MCP_DIR="$MCP_DIR" STAGE="$STAGE" MCPB_PLATFORM="$MCPB_PLATFORM" GA4_BIN="$GA4_BIN" \
+HAS_ICON="$HAS_ICON" node <<'NODE'
+const fs = require('fs');
+const path = require('path');
+const { MCP_DIR, STAGE, MCPB_PLATFORM, GA4_BIN, HAS_ICON } = process.env;
+const pkg = JSON.parse(fs.readFileSync(path.join(MCP_DIR, 'package.json'), 'utf8'));
+const manifestPath = path.join(STAGE, 'manifest.json');
+const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+m.version = pkg.version;                       // single source of truth: package.json
+m.compatibility.platforms = [MCPB_PLATFORM];   // this bundle ships one platform's binary
+m.server.mcp_config.env.GA4_BINARY_PATH = `\${__dirname}/bin/${GA4_BIN}`;
+if (HAS_ICON !== '1') delete m.icon;           // no icon file -> drop the reference
+fs.writeFileSync(manifestPath, JSON.stringify(m, null, 2) + '\n');
+console.error(`   version ${m.version}, platforms ${JSON.stringify(m.compatibility.platforms)}`);
+NODE
+
+# ---- 5. validate + pack ----------------------------------------------------
+echo ">> validating bundle" >&2
+npx --yes @anthropic-ai/mcpb validate "$STAGE/manifest.json" >&2
+
+mkdir -p "$OUT_DIR"
+OUTFILE="$OUT_DIR/ga4-manager-mcp-$GOOS-$GOARCH.mcpb"
+echo ">> packing -> $OUTFILE" >&2
+npx --yes @anthropic-ai/mcpb pack "$STAGE" "$OUTFILE" >&2
+
+echo "$OUTFILE"

--- a/mcp/src/tools/gsc-analytics.test.ts
+++ b/mcp/src/tools/gsc-analytics.test.ts
@@ -6,7 +6,6 @@ import {
   parseAnalyticsRunOutput,
   validateDimensions,
   VALID_DIMENSIONS,
-  VALID_FORMATS,
   GscAnalyticsRunInput,
 } from './gsc-analytics.js';
 
@@ -34,7 +33,6 @@ describe('gsc_analytics_run input schema', () => {
         days: 7,
         dimensions: 'query,page,country',
         limit: 500,
-        format: 'csv' as const,
         dry_run: true,
       };
       const result = gscAnalyticsRunInputSchema.safeParse(input);
@@ -53,7 +51,6 @@ describe('gsc_analytics_run input schema', () => {
       const input = {
         config: 'configs/mysite.yaml',
         days: 14,
-        format: 'markdown' as const,
       };
       const result = gscAnalyticsRunInputSchema.safeParse(input);
       expect(result.success).toBe(true);
@@ -68,7 +65,7 @@ describe('gsc_analytics_run input schema', () => {
     });
 
     it('rejects input with only optional parameters', () => {
-      const input = { days: 30, format: 'json' };
+      const input = { days: 30 };
       const result = gscAnalyticsRunInputSchema.safeParse(input);
       expect(result.success).toBe(false);
     });
@@ -131,20 +128,6 @@ describe('gsc_analytics_run input schema', () => {
       expect(result.success).toBe(false);
     });
   });
-
-  describe('format parameter validation', () => {
-    it.each(VALID_FORMATS)('accepts valid format: %s', (format) => {
-      const input = { site: 'sc-domain:example.com', format };
-      const result = gscAnalyticsRunInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
-    });
-
-    it('rejects invalid format', () => {
-      const input = { site: 'sc-domain:example.com', format: 'xml' };
-      const result = gscAnalyticsRunInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
-    });
-  });
 });
 
 // ============================================================================
@@ -202,12 +185,12 @@ describe('validateDimensions', () => {
 describe('buildAnalyticsRunArgs', () => {
   it('builds args with site only', () => {
     const args = buildAnalyticsRunArgs({ site: 'sc-domain:example.com' } as GscAnalyticsRunInput);
-    expect(args).toEqual(['analytics', 'run', '--site', 'sc-domain:example.com']);
+    expect(args).toEqual(['analytics', 'run', '--site', 'sc-domain:example.com', '--format', 'json']);
   });
 
   it('builds args with config only', () => {
     const args = buildAnalyticsRunArgs({ config: 'configs/mysite.yaml' } as GscAnalyticsRunInput);
-    expect(args).toEqual(['analytics', 'run', '--config', 'configs/mysite.yaml']);
+    expect(args).toEqual(['analytics', 'run', '--config', 'configs/mysite.yaml', '--format', 'json']);
   });
 
   it('builds args with custom days', () => {
@@ -243,15 +226,13 @@ describe('buildAnalyticsRunArgs', () => {
     expect(args).not.toContain('--limit');
   });
 
-  it('builds args with custom format', () => {
-    const args = buildAnalyticsRunArgs({ site: 'sc-domain:example.com', format: 'csv' } as GscAnalyticsRunInput);
+  // The CLI is ALWAYS asked for JSON: it is the only output the MCP can parse
+  // into per-page rows (the CLI default, `table`, drops them). There is no
+  // user-facing output-format knob.
+  it('always requests JSON from the CLI', () => {
+    const args = buildAnalyticsRunArgs({ site: 'sc-domain:example.com' } as GscAnalyticsRunInput);
     expect(args).toContain('--format');
-    expect(args).toContain('csv');
-  });
-
-  it('omits default format (json)', () => {
-    const args = buildAnalyticsRunArgs({ site: 'sc-domain:example.com', format: 'json' } as GscAnalyticsRunInput);
-    expect(args).not.toContain('--format');
+    expect(args[args.indexOf('--format') + 1]).toBe('json');
   });
 
   it('builds args with dry-run flag', () => {
@@ -270,7 +251,6 @@ describe('buildAnalyticsRunArgs', () => {
       days: 14,
       dimensions: 'query,country',
       limit: 200,
-      format: 'markdown',
       dry_run: true,
     };
     const args = buildAnalyticsRunArgs(input);
@@ -683,7 +663,6 @@ describe('gscAnalyticsRunTool definition', () => {
     expect(props.days).toBeDefined();
     expect(props.dimensions).toBeDefined();
     expect(props.limit).toBeDefined();
-    expect(props.format).toBeDefined();
     expect(props.dry_run).toBeDefined();
   });
 });

--- a/mcp/src/tools/gsc-analytics.ts
+++ b/mcp/src/tools/gsc-analytics.ts
@@ -20,12 +20,6 @@ export const VALID_DIMENSIONS = [
 
 export type ValidDimension = typeof VALID_DIMENSIONS[number];
 
-/**
- * Valid output formats
- */
-export const VALID_FORMATS = ['json', 'csv', 'table', 'markdown'] as const;
-export type ValidFormat = typeof VALID_FORMATS[number];
-
 // ============================================================================
 // GSC Analytics Run Tool
 // ============================================================================
@@ -47,8 +41,6 @@ export const gscAnalyticsRunInputSchema = z.object({
   dimensions: z.string().optional().default('query,page'),
   /** Maximum rows to return (1-25000, default: 100) */
   limit: z.number().int().min(1).max(25000).optional().default(100),
-  /** Output format: json, csv, table, markdown (default: json) */
-  format: z.enum(VALID_FORMATS).optional().default('json'),
   /** Preview query without making API call */
   dry_run: z.boolean().optional(),
 }).refine(
@@ -191,9 +183,13 @@ export function buildAnalyticsRunArgs(input: GscAnalyticsRunInput): string[] {
     args.push('--limit', input.limit.toString());
   }
 
-  if (input.format !== undefined && input.format !== 'json') {
-    args.push('--format', input.format);
-  }
+  // Always request JSON from the CLI. parseJsonOutput is the ONLY parser that
+  // preserves per-page rows; the CLI's own default is `table`
+  // (cmd/gsc_analytics.go), whose output carries no rows once parsed by
+  // parseTableOutput. This MCP tool always returns structured JSON, so there is
+  // no output-format knob — omitting this flag previously dropped every
+  // per-page breakdown.
+  args.push('--format', 'json');
 
   if (input.dry_run) {
     args.push('--dry-run');
@@ -262,8 +258,12 @@ export function parseAnalyticsRunOutput(output: string): AnalyticsRunOutput {
     return parseDryRunOutput(output);
   }
 
-  // Parse JSON output (primary format for MCP)
-  if (output.trim().startsWith('{')) {
+  // Parse JSON output (primary format for MCP). The CLI prepends human-readable
+  // status lines (📊/📅/📈) and slog INFO lines before the JSON payload, so the
+  // output does NOT start with '{'. Detect a JSON object anywhere — routing on
+  // startsWith('{') misfires to parseTableOutput, which can't read JSON and
+  // silently drops rows/aggregates (returns only site/period).
+  if (/\{[\s\S]*\}/.test(output)) {
     return parseJsonOutput(output);
   }
 
@@ -544,12 +544,6 @@ export const gscAnalyticsRunTool = {
         default: 100,
         minimum: 1,
         maximum: 25000,
-      },
-      format: {
-        type: 'string',
-        enum: ['json', 'csv', 'table', 'markdown'],
-        description: 'Output format. Use json for structured data processing. Default: json.',
-        default: 'json',
       },
       dry_run: {
         type: 'boolean',

--- a/mcp/src/tools/gsc-coverage.test.ts
+++ b/mcp/src/tools/gsc-coverage.test.ts
@@ -5,7 +5,6 @@ import {
   buildIndexCoverageArgs,
   parseIndexCoverageOutput,
   VALID_STATES,
-  VALID_FORMATS,
   GscIndexCoverageInput,
 } from './gsc-coverage.js';
 
@@ -33,7 +32,6 @@ describe('gsc_index_coverage input schema', () => {
         days: 7,
         state: 'indexed' as const,
         top_issues: 5,
-        format: 'csv' as const,
         dry_run: true,
       };
       const result = gscIndexCoverageInputSchema.safeParse(input);
@@ -52,7 +50,6 @@ describe('gsc_index_coverage input schema', () => {
       const input = {
         config: 'configs/mysite.yaml',
         days: 14,
-        format: 'markdown' as const,
       };
       const result = gscIndexCoverageInputSchema.safeParse(input);
       expect(result.success).toBe(true);
@@ -67,7 +64,7 @@ describe('gsc_index_coverage input schema', () => {
     });
 
     it('rejects input with only optional parameters', () => {
-      const input = { days: 30, format: 'json' };
+      const input = { days: 30 };
       const result = gscIndexCoverageInputSchema.safeParse(input);
       expect(result.success).toBe(false);
     });
@@ -144,20 +141,6 @@ describe('gsc_index_coverage input schema', () => {
       expect(result.success).toBe(false);
     });
   });
-
-  describe('format parameter validation', () => {
-    it.each(VALID_FORMATS)('accepts valid format: %s', (format) => {
-      const input = { site: 'sc-domain:example.com', format };
-      const result = gscIndexCoverageInputSchema.safeParse(input);
-      expect(result.success).toBe(true);
-    });
-
-    it('rejects invalid format', () => {
-      const input = { site: 'sc-domain:example.com', format: 'xml' };
-      const result = gscIndexCoverageInputSchema.safeParse(input);
-      expect(result.success).toBe(false);
-    });
-  });
 });
 
 // ============================================================================
@@ -167,12 +150,12 @@ describe('gsc_index_coverage input schema', () => {
 describe('buildIndexCoverageArgs', () => {
   it('builds args with site only', () => {
     const args = buildIndexCoverageArgs({ site: 'sc-domain:example.com' } as GscIndexCoverageInput);
-    expect(args).toEqual(['coverage', '--site', 'sc-domain:example.com']);
+    expect(args).toEqual(['coverage', '--site', 'sc-domain:example.com', '--format', 'json']);
   });
 
   it('builds args with config only', () => {
     const args = buildIndexCoverageArgs({ config: 'configs/mysite.yaml' } as GscIndexCoverageInput);
-    expect(args).toEqual(['coverage', '--config', 'configs/mysite.yaml']);
+    expect(args).toEqual(['coverage', '--config', 'configs/mysite.yaml', '--format', 'json']);
   });
 
   it('builds args with custom days', () => {
@@ -208,15 +191,13 @@ describe('buildIndexCoverageArgs', () => {
     expect(args).not.toContain('--top-issues');
   });
 
-  it('builds args with custom format', () => {
-    const args = buildIndexCoverageArgs({ site: 'sc-domain:example.com', format: 'csv' } as GscIndexCoverageInput);
+  // The CLI is ALWAYS asked for JSON: only the JSON path carries the per-page
+  // pages_sample array (the CLI default, `table`, drops it). There is no
+  // user-facing output-format knob.
+  it('always requests JSON from the CLI', () => {
+    const args = buildIndexCoverageArgs({ site: 'sc-domain:example.com' } as GscIndexCoverageInput);
     expect(args).toContain('--format');
-    expect(args).toContain('csv');
-  });
-
-  it('omits default format (json)', () => {
-    const args = buildIndexCoverageArgs({ site: 'sc-domain:example.com', format: 'json' } as GscIndexCoverageInput);
-    expect(args).not.toContain('--format');
+    expect(args[args.indexOf('--format') + 1]).toBe('json');
   });
 
   it('builds args with dry-run flag', () => {
@@ -235,7 +216,6 @@ describe('buildIndexCoverageArgs', () => {
       days: 14,
       state: 'low_impressions',
       top_issues: 5,
-      format: 'markdown',
       dry_run: true,
     };
     const args = buildIndexCoverageArgs(input);
@@ -553,7 +533,6 @@ describe('gscIndexCoverageTool definition', () => {
     expect(props.days).toBeDefined();
     expect(props.state).toBeDefined();
     expect(props.top_issues).toBeDefined();
-    expect(props.format).toBeDefined();
     expect(props.dry_run).toBeDefined();
   });
 });

--- a/mcp/src/tools/gsc-coverage.ts
+++ b/mcp/src/tools/gsc-coverage.ts
@@ -17,12 +17,6 @@ export const VALID_STATES = [
 
 export type ValidState = typeof VALID_STATES[number];
 
-/**
- * Valid output formats
- */
-export const VALID_FORMATS = ['json', 'csv', 'table', 'markdown'] as const;
-export type ValidFormat = typeof VALID_FORMATS[number];
-
 // ============================================================================
 // GSC Index Coverage Tool
 // ============================================================================
@@ -44,8 +38,6 @@ export const gscIndexCoverageInputSchema = z.object({
   state: z.enum(VALID_STATES).optional().default('all'),
   /** Number of top issues to display (default: 10) */
   top_issues: z.number().int().min(1).max(50).optional().default(10),
-  /** Output format: json, csv, table, markdown (default: json) */
-  format: z.enum(VALID_FORMATS).optional().default('json'),
   /** Preview query without making API call */
   dry_run: z.boolean().optional(),
 }).refine(
@@ -130,9 +122,11 @@ export function buildIndexCoverageArgs(input: GscIndexCoverageInput): string[] {
     args.push('--top-issues', input.top_issues.toString());
   }
 
-  if (input.format !== undefined && input.format !== 'json') {
-    args.push('--format', input.format);
-  }
+  // Always request JSON from the CLI. Only the JSON path (parseJsonOutput)
+  // carries the per-page `pages_sample` array; the CLI's own default is
+  // `table`, whose parser drops it. This MCP tool always returns structured
+  // JSON, so there is no output-format knob.
+  args.push('--format', 'json');
 
   if (input.dry_run) {
     args.push('--dry-run');
@@ -194,8 +188,12 @@ export function parseIndexCoverageOutput(output: string): IndexCoverageOutput {
     return parseDryRunOutput(output);
   }
 
-  // Parse JSON output (primary format for MCP)
-  if (output.trim().startsWith('{')) {
+  // Parse JSON output (primary format for MCP). The CLI prepends human-readable
+  // status lines (📊/📅/📈) and slog INFO lines before the JSON payload, so the
+  // output does NOT start with '{'. Detect a JSON object anywhere — routing on
+  // startsWith('{') misfires to parseTableOutput, which can't read JSON and
+  // silently drops the per-page data (returns only summary fields).
+  if (/\{[\s\S]*\}/.test(output)) {
     return parseJsonOutput(output);
   }
 
@@ -418,12 +416,6 @@ export const gscIndexCoverageTool = {
         default: 10,
         minimum: 1,
         maximum: 50,
-      },
-      format: {
-        type: 'string',
-        enum: ['json', 'csv', 'table', 'markdown'],
-        description: 'Output format. Use json for structured data processing. Default: json.',
-        default: 'json',
       },
       dry_run: {
         type: 'boolean',

--- a/mcp/src/tools/seo-page-audit.ts
+++ b/mcp/src/tools/seo-page-audit.ts
@@ -245,7 +245,9 @@ export async function runSeoPageAudit(input: SeoPageAuditInput): Promise<SeoPage
 
   // Fall back to the PSI_API_KEY env var when no key is passed per-call, so CWV
   // works without threading the key through every invocation (see CONFIGURATION.md).
-  const effectivePsiKey = psi_api_key ?? process.env.PSI_API_KEY ?? undefined
+  // `|| undefined` (not `??`): the MCPB manifest always sets PSI_API_KEY in the
+  // server env, so an unconfigured key arrives as "" rather than unset.
+  const effectivePsiKey = psi_api_key ?? (process.env.PSI_API_KEY || undefined)
 
   // Robots check before fetching
   if (respect_robots) {

--- a/mcp/vitest.config.ts
+++ b/mcp/vitest.config.ts
@@ -6,8 +6,10 @@ export default defineConfig({
     environment: 'node',
     // Only run tests from source. Without this, the compiled copies under
     // dist/ (produced by `npm run build`) are discovered and run too,
-    // doubling the suite and double-counting failures.
-    exclude: ['node_modules/**', 'dist/**'],
+    // doubling the suite and double-counting failures. build/ and dist-mcpb/
+    // hold the staged MCPB bundle, whose vendored node_modules carry their own
+    // *.test.ts (e.g. zod's) that must never be picked up here.
+    exclude: ['node_modules/**', 'dist/**', 'build/**', 'dist-mcpb/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary

Two things, both in `mcp/`:

1. **MCPB packaging** — ship the MCP server as a single installable `.mcpb` for Claude Desktop.
2. **Fix the GSC "report" tools that returned only aggregates** — `gsc_analytics_run` and `gsc_index_coverage` were dropping their per-row arrays.

## MCPB packaging
- `npm run pack:mcpb` builds a self-contained bundle: compiled server + production `node_modules` (staged via `pnpm deploy`, hoisted/real files) + a prebuilt **per-platform `ga4` binary**, with `GA4_BINARY_PATH` pointed at the bundled binary. Installs without Node or Go.
- Credentials are supplied **per-install** via `manifest.json` `user_config` (credentials file picker, project id, optional sensitive PSI key) — **no secrets are baked into the bundle** (verified: the packed archive contains none of the local `.env` values).
- Cross-compile other platforms with e.g. `npm run pack:mcpb linux/amd64`.

## Fixes
- **`gsc_analytics_run` / `gsc_index_coverage` now return `rows[]` / `pages_sample[]`.** Root cause: `buildArgs` omitted `--format json`, so the CLI used its default `table` output and the table parser silently dropped the per-row array — leaving only aggregates *regardless of the requested format*. (`gsc_opportunities` worked precisely because it always forces JSON.) Both tools now always request JSON, and JSON detection tolerates the CLI's status-line preamble.
- **`seo_page_audit`** treats an empty `PSI_API_KEY` (always set by the MCPB env) as unset, so Core Web Vitals aren't disabled by `""`.
- **vitest** excludes `build/` and `dist-mcpb/` so the staged bundle's vendored `*.test.ts` (e.g. zod's) aren't picked up.

## Changed
- Removed the **no-op `format` param** from `gsc_analytics_run` and `gsc_index_coverage`; these MCP tools always return structured JSON. Unknown keys are ignored, so existing callers are unaffected.

## Testing
- `npx tsc --noEmit` clean; full suite **740 tests pass**.
- Packed bundle smoke-tested over stdio (`tools/list`, plus a live `seo_page_audit` run end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)